### PR TITLE
fix broken tests

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -107,8 +107,11 @@ def get_file_contents(conf_file: str) -> Optional[str]:
     Example: ``get_file("torchx/cli/config/foo.txt")``
     """
 
-    root = path.dirname(__file__).replace(__name__.replace(".", path.sep), "")
+    module = __name__.replace(".", path.sep)  # torchx/cli/cmd_run
+    module_path, _ = path.splitext(__file__)  # $root/torchx/cli/cmd_run
+    root = module_path.replace(module, "")
     abspath = path.join(root, conf_file)
+
     if path.exists(abspath):
         with open(abspath, "r") as f:
             return f.read()

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
-from torchx.cli.cmd_run import CmdBuiltins, CmdRun, _builtins
+from torchx.cli.cmd_run import CmdBuiltins, CmdRun, _builtins, get_file_contents
 
 
 @contextmanager
@@ -119,6 +119,10 @@ class CmdRunTest(unittest.TestCase):
         )
         self.cmd_run.run(args)
         mock_runner_run.assert_not_called()
+
+    def test_get_file_contents(self) -> None:
+        content = get_file_contents("torchx/cli/config/echo.torchx")
+        self.assertIsNotNone(content)
 
 
 class CmdBuiltinTest(unittest.TestCase):


### PR DESCRIPTION
Summary: `get_file_contents` method in `cmd_run` was not properly implemented (was trying to read from `$root/torchx/cli/torchx/cli/conf` intead of `$root/torchx/cli/conf`)

Differential Revision: D28620895

