### PR TITLE
scripts/lint.sh: run the linters

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,4 +23,6 @@ jobs:
           pip install isort
           pip install black
       - name: Run Lint
-        run: scripts/lint.sh
+        run: |
+          git config --global url."https://${{ secrets.GITHUB_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+          scripts/lint.sh

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+set -e
 
 if [ ! "$(black --version)" ]
 then
@@ -19,10 +21,10 @@ fi
 # cd to the project directory
 cd "$(dirname "$0")/.." || exit 1
 
-GIT_URL_1="git@github.com:pytorch/torchx.git"
+GIT_URL_1="https://github.com/pytorch/torchx.git"
 GIT_URL_2="git@github.com:pytorch/torchx.git"
 
-UPSTREAM_URL="$(git config remote.upstream.url)"
+UPSTREAM_URL="$(git config remote.upstream.url)" || true
 
 if [ -z "$UPSTREAM_URL" ]
 then
@@ -36,9 +38,7 @@ then
     exit 1
 fi
 
-# fetch upstream
 git fetch upstream
-
 
 CHANGED_FILES="$(git diff --diff-filter=ACMRT --name-only upstream/master | grep '\.py$' | tr '\n' ' ')"
 
@@ -50,10 +50,9 @@ then
     for file in $CHANGED_FILES
     do
         echo "Checking $file"
-        set -e isort "$file" --recursive --multi-line 3 --trailing-comma --force-grid-wrap 0 \
+        isort "$file" --recursive --multi-line 3 --trailing-comma --force-grid-wrap 0 \
                 --line-width 88 --lines-after-imports 2 --combine-as --section-default THIRDPARTY
-
-        set -e black "$file"
+        black "$file"
     done
 else
     echo "No changes made to any Python files. Nothing to do."


### PR DESCRIPTION
There was a bug in the lint.sh script such that the linters weren't actually being run.

`set -e <cmd>` just silently ignores the `<cmd>` part. Instead we should use `set -e` at the top of the file and call the linters normally.

It also adds GITHUB_TOKEN support so the linter script can actually checkout upstream to do a diff.

Test plan:

CI and

modify random .py file with import and whitespace changes

```
scripts/lint.sh
```