### PR TITLE
added KFP adapter for new torchx.specs.api interface

### DIFF
--- a/torchx/pipelines/kfp/adapter.py
+++ b/torchx/pipelines/kfp/adapter.py
@@ -7,13 +7,15 @@
 
 import copy
 import os
-from typing import Type, Callable, List, Optional, Dict
+from typing import Callable, Dict, List, Optional, Type
 
 import yaml
 from kfp import components, dsl
 from torchx.runtime.component import Component, is_optional
+from torchx.specs import api
 
 from .version import __version__ as __version__  # noqa F401
+
 
 TORCHX_CONTAINER_ENV: str = "TORCHX_CONTAINER"
 TORCHX_CONTAINER: str = os.getenv(
@@ -111,3 +113,41 @@ class TorchXComponent:
     @property
     def output(self) -> dsl.PipelineParam:
         ...
+
+
+def component_spec_from_app(app: api.Application) -> str:
+    assert len(app.roles) == 1, f"KFP adapter only support one role, got {app.roles}"
+
+    role = app.roles[0]
+    assert (
+        role.num_replicas == 1
+    ), f"KFP adapter only supports one replica, got {app.num_replicas}"
+    assert role.container != api.NULL_CONTAINER, "missing container for KFP"
+
+    container = role.container
+    assert container.base_image is None, "KFP adapter does not support base_image"
+    assert (
+        container.resources == api.NULL_RESOURCE
+    ), "KFP adapter requires you to specify resources in the pipeline"
+    assert len(container.port_map) == 0, "KFP adapter does not support port_map"
+
+    command = [role.entrypoint, *role.args]
+
+    spec = {
+        "name": f"{app.name}-{role.name}",
+        "description": f"KFP wrapper for TorchX component {app.name}, role {role.name}",
+        "implementation": {
+            "container": {
+                "image": container.image,
+                "command": command,
+                "env": role.env,
+            }
+        },
+    }
+    return yaml.dump(spec)
+
+
+# pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
+def component_from_app(app: api.Application) -> Callable:
+    spec = component_spec_from_app(app)
+    return components.load_component_from_text(spec)


### PR DESCRIPTION
This creates a KFP adapter for the new specs interface.

```
import torchx.specs.api as torchx
from kfp import compiler, components, dsl

app = torchx.Application(...)
kfp_copy: Callable = component_from_app(app)

def pipeline() -> dsl.PipelineParam:
    a = kfp_copy()
    b = kfp_copy()
    b.after(a)
    return b

compiler.Compiler().compile(pipeline, "pipeline.zip")
```