### PR TITLE
torchx/schedulers: added support for image_type=docker

### DIFF
--- a/torchx/cli/config/echo.torchx
+++ b/torchx/cli/config/echo.torchx
@@ -5,6 +5,10 @@ arguments:
     help: Message to echo
     default: "hello world"
     type: str
+  - name: --image
+    help: Image to run
+    default: /tmp
+    type: str
 """
 
 import torchx.specs as specs
@@ -14,7 +18,7 @@ echo = specs.Role(
     name="echo",
     entrypoint="/bin/echo",
     args=[args.msg],
-    container=specs.Container(image="/tmp"),
+    container=specs.Container(image=args.image),
     num_replicas=1,
 )
 


### PR DESCRIPTION
<!-- Change Summary -->

This adds support for image_type=docker. Image fetchers have been renamed to image providers as docker needs a special CLI command in order to run the docker container.

To select docker:
```
torchx run --scheduler local --scheduler_args image_type=docker echo.torchx --image pytorch/pytorch:latest
```

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pyre
python setup.py test -s torchx.schedulers
python torchx/cli/main.py run --scheduler local --scheduler_args image_type=docker echo.torchx --image pytorch/pytorch:latest
```
