### PR TITLE
lint: add copyright linter

### DIFF
--- a/scripts/copyright.py
+++ b/scripts/copyright.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from typing import List
+
+
+COPYRIGHT_NOTICE: str = """
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+""".strip()
+
+
+def main(files: List[str]) -> None:
+    missing = []
+    for path in files:
+        with open(path, "rt") as f:
+            data = f.read()
+
+        data = data.strip()
+        # don't lint empty files
+        if len(data) == 0:
+            continue
+
+        # skip the interpreter command and formatting
+        while data.startswith("#!") or data.startswith("# -*-"):
+            data = data[data.index("\n") + 1 :]
+
+        if not data.startswith(COPYRIGHT_NOTICE):
+            missing.append(path)
+
+    if len(missing) > 0:
+        print(f"{COPYRIGHT_NOTICE}\n")
+        print("Please add the copyright notice to all listed files:\n")
+        for path in missing:
+            print(path)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -51,7 +51,7 @@ if [ "$CHANGED_FILES" != "" ]
 then
     # Processing files one by one since passing directly $CHANGED_FILES will
     # treat the whole variable as a single file.
-    echo "Running isort and black ..."
+    echo "Running linters ..."
     for file in $CHANGED_FILES
     do
         echo "Checking $file"
@@ -59,6 +59,7 @@ then
             --line-width 88 --lines-after-imports 2 --combine-as --section-default THIRDPARTY -q
         black "$file" -q
         flake8 "$file" || LINT_ERRORS=1
+        scripts/copyright.py "$file" || LINT_ERRORS=1
     done
 else
     echo "No changes made to any Python files. Nothing to do."


### PR DESCRIPTION
<!-- Change Summary -->

This adds a linter to ensure the copyright header is present on all .py files.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Run the linter with files with and without the header:

```
scripts/copyright.py **/*.py
```

Run the general linter script with and without the header:

```
scripts/lint.sh
```