### PR TITLE
examples/lightning_classy_vision: export inference model

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,6 +1,6 @@
 FROM pytorch/pytorch
 
-RUN pip install classy_vision pytorch-lightning fsspec[s3]
+RUN pip install classy_vision pytorch-lightning fsspec[s3] torch-model-archiver
 
 WORKDIR /app
 


### PR DESCRIPTION
<!-- Change Summary -->

This adds code to export a torch-model-archive file which can be used with torchserve for inference.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->


```
scripts/kfpint.py
```