### PR TITLE
setup CI to push torchx:latest on master commits

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,27 @@
+name: Docker Container
+
+on:
+  push:
+    branches:
+      - master
+      - torchxcontainer
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout TorchX
+        uses: actions/checkout@v2
+      - name: Configure Docker
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -eux
+          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 495572122715.dkr.ecr.us-west-2.amazonaws.com
+      - name: Build container
+        run: torchx/runtime/container/build.sh
+      - name: Tag container
+        run: docker tag torchx ${{secrets.TORCHX_CONTAINER_REPO}}:latest
+      - name: Push container
+        run: docker push ${{secrets.TORCHX_CONTAINER_REPO}}:latest

--- a/torchx/runtime/container/build.sh
+++ b/torchx/runtime/container/build.sh
@@ -7,4 +7,4 @@
 
 set -ex
 
-tar -czh --exclude docs . | docker build -t torchx - -f torchx/container/Dockerfile
+tar -czh --exclude docs --exclude .git . | docker build -t torchx - -f torchx/runtime/container/Dockerfile


### PR DESCRIPTION
<!-- Change Summary -->

This sets up a CI pipeline that publishes the torchx ECR docker container each time there's a new commit on master.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

push to torchx/torchxcontainer branch and check that torchx:latest is correctly published

https://github.com/pytorch/torchx/runs/2740114001

https://us-west-2.console.aws.amazon.com/ecr/repositories/private/495572122715/torchx/image/sha256:e5e1f65c2833461001058bdcd57884a422b97cb86038063fdf6111339afeb44e/details/?region=us-west-2