### PR TITLE
pipelines/kfp: added port_map support to KFP adapter

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -120,7 +120,7 @@ class Container:
      my_container = Container(
         image="pytorch/torch:1",
         resources=Resource(cpu=1, gpu=1, memMB=500),
-        ports={"tcp_store":8080, "tensorboard": 8081}
+        port_map={"tcp_store":8080, "tensorboard": 8081}
      )
 
      # for schedulers that support base_images


### PR DESCRIPTION
<!-- Change Summary -->

This adds port_map support to the kfp adapter. This allows for exposing ports on the container.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
python setup.py test -s torchx.pipelines
pyre
```

used as part of the torchserve PR to expose ports, manually tested via HTTP server

