### PR TITLE
Torchx: introduce role factory methods

### DIFF
--- a/torchx/components/base/__init__.py
+++ b/torchx/components/base/__init__.py
@@ -10,10 +10,55 @@ other components. Many methods in the base component library are factory methods
 for ``Role``, ``Container``, and ``Resources`` that are hooked up to
 TorchX's configurable extension points.
 """
+from typing import Any, Dict, List, Optional
 
-import torchx.specs as specs
+from torchx.specs.api import NULL_RESOURCE, Container, Resource, RetryPolicy, Role
+from torchx.util.entrypoints import load
+
+from .roles import create_torch_dist_role  # noqa: F401 F403
 
 
-def named_resource(name: str) -> specs.Resource:
+def named_resource(name: str) -> Resource:
     # TODO <PLACEHOLDER> read instance types and resource mappings from entrypoints
-    return specs.NULL_RESOURCE
+    return NULL_RESOURCE
+
+
+def torch_dist_role(
+    name: str,
+    container: Container,
+    entrypoint: str,
+    script_args: Optional[List[str]] = None,
+    script_envs: Optional[Dict[str, str]] = None,
+    num_replicas: int = 1,
+    max_retries: int = 0,
+    retry_policy: RetryPolicy = RetryPolicy.APPLICATION,
+    **launch_kwargs: Any,
+) -> Role:
+    """
+    A ``Role`` for which the user provided ``entrypoint`` is executed with the
+        torchelastic agent (in the container). Note that the torchelastic agent
+        invokes multiple copies of ``entrypoint``.
+
+    The method will try to search factory method that is registerred via entrypoints.
+    If no group or role found, the default ``torchx.components.base.role.create_torch_dist_role``
+    will be used.
+
+    For more information see ``torchx.components.base.roles``
+    """
+    dist_role_factory = load(
+        "torchx.base",
+        "dist_role",
+        default=create_torch_dist_role,
+    )
+
+    return dist_role_factory(
+        name,
+        container,
+        entrypoint,
+        script_args,
+        script_envs,
+        num_replicas,
+        max_retries,
+        retry_policy,
+        **launch_kwargs,
+    )

--- a/torchx/components/base/roles.py
+++ b/torchx/components/base/roles.py
@@ -1,0 +1,100 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from typing import Any, Dict, List, Optional
+
+from torchx.specs.api import Container, RetryPolicy, Role, macros
+
+
+def create_torch_dist_role(
+    name: str,
+    container: Container,
+    entrypoint: str,
+    script_args: Optional[List[str]] = None,
+    script_envs: Optional[Dict[str, str]] = None,
+    num_replicas: int = 1,
+    max_retries: int = 0,
+    retry_policy: RetryPolicy = RetryPolicy.APPLICATION,
+    **launch_kwargs: Any,
+) -> Role:
+    """
+    A ``Role`` for which the user provided ``entrypoint`` is executed with the
+    torchelastic agent (in the container). Note that the torchelastic agent
+    invokes multiple copies of ``entrypoint``.
+
+    For more information about torchelastic see
+    `torchelastic quickstart docs <http://pytorch.org/elastic/0.2.0/quickstart.html>`__.
+
+    .. important:: It is the responsibility of the user to ensure that the
+                   container's image includes torchelastic. Since Torchx has no
+                   control over the build process of the image, it cannot
+                   automatically include torchelastic in the container's image.
+
+    The following example launches 2 ``replicas`` (nodes) of an elastic ``my_train_script.py``
+    that is allowed to scale between 2 to 4 nodes. Each node runs 8 workers which are allowed
+    to fail and restart a maximum of 3 times.
+
+    .. warning:: ``replicas`` MUST BE an integer between (inclusive) ``nnodes``. That is,
+                   ``ElasticRole("trainer", nnodes="2:4").replicas(5)`` is invalid and will
+                   result in undefined behavior.
+
+    ::
+
+     elastic_trainer = torch_dist_role("trainer", "my_train_script.py",
+                            script_args=["--script_arg", "foo", "--another_arg", "bar"],
+                            num_replicas=4, max_retries=1,
+                            nproc_per_node=8, nnodes="2:4", max_restarts=3)
+     # effectively runs:
+     #    python -m torch.distributed.launch
+     #        --nproc_per_node 8
+     #        --nnodes 2:4
+     #        --max_restarts 3
+     #        my_train_script.py --script_arg foo --another_arg bar
+
+    Args:
+        name: Name of the role
+        entrypoint: User binary or python script that will be launched.
+        script_args: User provided arguments
+        script_envs: Env. variables that will be set on worker process that runs entrypoint
+        num_replicas: Number of role replicas to run
+        max_retries: Max number of retries
+        retry_policy: Retry policy that is applied to the role
+        launch_kwargs: kwarg style launch arguments that will be used to launch torchelastic agent.
+
+    Returns:
+        Role object that launches user entrypoint via the torchelastic as proxy
+
+    """
+    script_args = script_args or []
+    script_envs = script_envs or {}
+
+    entrypoint_override = "python"
+    args: List[str] = ["-m", "torch.distributed.launch"]
+
+    launch_kwargs.setdefault("rdzv_backend", "etcd")
+    launch_kwargs.setdefault("rdzv_id", macros.app_id)
+    launch_kwargs.setdefault("role", name)
+
+    for (arg, val) in launch_kwargs.items():
+        if isinstance(val, bool):
+            # treat boolean kwarg as a flag
+            if val:
+                args += [f"--{arg}"]
+        else:
+            args += [f"--{arg}", str(val)]
+    if not os.path.isabs(entrypoint) and not entrypoint.startswith(macros.img_root):
+        # make entrypoint relative to {img_root} ONLY if it is not an absolute path
+        entrypoint = os.path.join(macros.img_root, entrypoint)
+
+    args += [entrypoint, *script_args]
+    return (
+        Role(name)
+        .runs(entrypoint_override, *args, **script_envs)
+        .on(container)
+        .replicas(num_replicas)
+        .with_retry_policy(retry_policy, max_retries)
+    )

--- a/torchx/components/base/test/roles_test.py
+++ b/torchx/components/base/test/roles_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import os
+import unittest
+from dataclasses import asdict
+
+from torchx.components.base.roles import create_torch_dist_role
+from torchx.specs.api import NULL_CONTAINER, Container, Resource, Role, macros
+
+
+class TorchDistRoleBuilderTest(unittest.TestCase):
+    def test_build_create_torch_dist_role(self) -> None:
+        # runs: python -m torch.distributed.launch
+        #                    --nnodes 2:4
+        #                    --max_restarts 3
+        #                    --no_python True
+        #                    --rdzv_backend etcd
+        #                    --rdzv_id ${app_id}
+        #                    /bin/echo hello world
+        container = Container(image="test_image")
+        container.ports(foo=8080)
+        elastic_trainer = create_torch_dist_role(
+            "elastic_trainer",
+            container,
+            entrypoint="/bin/echo",
+            script_args=["hello", "world"],
+            script_envs={"ENV_VAR_1": "FOOBAR"},
+            nnodes="2:4",
+            max_restarts=3,
+            no_python=True,
+        ).replicas(2)
+        self.assertEqual("elastic_trainer", elastic_trainer.name)
+        self.assertEqual("python", elastic_trainer.entrypoint)
+        self.assertEqual(
+            [
+                "-m",
+                "torch.distributed.launch",
+                "--nnodes",
+                "2:4",
+                "--max_restarts",
+                "3",
+                "--no_python",
+                "--rdzv_backend",
+                "etcd",
+                "--rdzv_id",
+                macros.app_id,
+                "--role",
+                "elastic_trainer",
+                "/bin/echo",
+                "hello",
+                "world",
+            ],
+            elastic_trainer.args,
+        )
+        self.assertEqual({"ENV_VAR_1": "FOOBAR"}, elastic_trainer.env)
+        self.assertEqual(container, elastic_trainer.container)
+        self.assertEqual(2, elastic_trainer.num_replicas)
+
+    def test_build_create_torch_dist_role_override_rdzv_params(self) -> None:
+        role = create_torch_dist_role(
+            "test_role",
+            NULL_CONTAINER,
+            "user_script.py",
+            script_args=["--script_arg", "foo"],
+            nnodes="2:4",
+            rdzv_backend="etcd",
+            rdzv_id="foobar",
+        )
+        self.assertEqual(
+            [
+                "-m",
+                "torch.distributed.launch",
+                "--nnodes",
+                "2:4",
+                "--rdzv_backend",
+                "etcd",
+                "--rdzv_id",
+                "foobar",
+                "--role",
+                "test_role",
+                os.path.join(macros.img_root, "user_script.py"),
+                "--script_arg",
+                "foo",
+            ],
+            role.args,
+        )
+
+    def test_build_create_torch_dist_role_flag_args(self) -> None:
+        role = create_torch_dist_role(
+            "test_role", NULL_CONTAINER, "user_script.py", no_python=False
+        )
+        self.assertEqual(
+            [
+                "-m",
+                "torch.distributed.launch",
+                "--rdzv_backend",
+                "etcd",
+                "--rdzv_id",
+                macros.app_id,
+                "--role",
+                "test_role",
+                os.path.join(macros.img_root, "user_script.py"),
+            ],
+            role.args,
+        )
+
+    def test_build_create_torch_dist_role_img_root_already_in_entrypoint(
+        self,
+    ) -> None:
+        role = create_torch_dist_role(
+            "test_role",
+            NULL_CONTAINER,
+            os.path.join(macros.img_root, "user_script.py"),
+            no_python=False,
+        )
+        self.assertEqual(
+            [
+                "-m",
+                "torch.distributed.launch",
+                "--rdzv_backend",
+                "etcd",
+                "--rdzv_id",
+                macros.app_id,
+                "--role",
+                "test_role",
+                os.path.join(macros.img_root, "user_script.py"),
+            ],
+            role.args,
+        )
+
+    def test_json_serialization_factory(self) -> None:
+        """
+        Tests that an ElasticRole can be serialized into json (dict)
+        then recreated as a Role. An ElasticRole is really just a builder
+        utility to make it easy for users to create a Role with the entrypoint
+        being ``torch.distributed.launch``
+        """
+        resources = Resource(cpu=1, gpu=0, memMB=512)
+        container = Container(image="user_image", resources=resources).ports(
+            tensorboard=8080
+        )
+        role = create_torch_dist_role(
+            "test_role",
+            container,
+            "user_script.py",
+            script_args=["--script_arg", "foo"],
+            nnodes="2:4",
+            rdzv_backend="etcd",
+            rdzv_id="foobar",
+        ).replicas(3)
+
+        # this is effectively JSON
+        elastic_json = asdict(role)
+        container_json = elastic_json.pop("container")
+        resource_json = container_json.pop("resources")
+        container_json["resources"] = Resource(**resource_json)
+
+        role = Role(
+            **elastic_json,
+            container=Container(**container_json),
+        )
+        self.assertEqual(container, role.container)
+        self.assertEqual(role.name, role.name)
+        self.assertEqual(role.entrypoint, role.entrypoint)
+        self.assertEqual(
+            role.args,
+            role.args,
+        )
+        self.assertEqual(asdict(role), asdict(role))

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -12,6 +12,7 @@ import copy
 import inspect
 import json
 import os
+import warnings
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from string import Template
@@ -323,43 +324,16 @@ class Role:
 
 class ElasticRole(Role):
     """
-    A ``Role`` for which the user provided ``entrypoint`` is executed with the
-    torchelastic agent (in the container). Note that the torchelastic agent
-    invokes multiple copies of ``entrypoint``.
-
-    For more information about torchelastic see
-    `torchelastic quickstart docs <http://pytorch.org/elastic/0.2.0/quickstart.html>`__.
-
-    .. important:: It is the responsibility of the user to ensure that the
-                   container's image includes torchelastic. Since Torchx has no
-                   control over the build process of the image, it cannot
-                   automatically include torchelastic in the container's image.
-
-    The following example launches 2 ``replicas`` (nodes) of an elastic ``my_train_script.py``
-    that is allowed to scale between 2 to 4 nodes. Each node runs 8 workers which are allowed
-    to fail and restart a maximum of 3 times.
-
-    .. warning:: ``replicas`` MUST BE an integer between (inclusive) ``nnodes``. That is,
-                   ``ElasticRole("trainer", nnodes="2:4").replicas(5)`` is invalid and will
-                   result in undefined behavior.
-
-    ::
-
-     elastic_trainer = ElasticRole("trainer", nproc_per_node=8, nnodes="2:4", max_restarts=3)
-                        .runs("my_train_script.py", "--script_arg", "foo", "--another_arg", "bar")
-                        .on(container)
-                        .replicas(2)
-     # effectively runs:
-     #    python -m torchelastic.distributed.launch
-     #        --nproc_per_node 8
-     #        --nnodes 2:4
-     #        --max_restarts 3
-     #        my_train_script.py --script_arg foo --another_arg bar
-
+    Deprecated, use ``torchx.components.base.torch_dist_role`` method.
     """
 
     def __init__(self, name: str, **launch_kwargs: Any) -> None:
         super().__init__(name=name)
+
+        warnings.warn(
+            "ElasticRole is deprecated, use torchx.components.base.torch_dist_role factory method",
+            category=DeprecationWarning,
+        )
         self.entrypoint = "python"
         self.args: List[str] = []
         self.args += ["-m", "torchelastic.distributed.launch"]


### PR DESCRIPTION
Summary:
The diff introduces elastic_role and elastic_role_fb factory methods that are direct replacements for the ElasticRole and ElasticRoleFB classes.

    elastic_role(..) equivalent to Role(..).runs(..)

    elastic_role_fb(..) equivalent to Role(..).runs(..).on(..)

* The removal of ElasticRole and ElasticRoleFB will be in follow up diffs
* Documentation update will be in follow up diff

Differential Revision: D28888787

