### PR TITLE
Torchx: rename Application to AppDef

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -20,25 +20,25 @@ Below is a UML diagram
 Concepts
 -----------
 
-Applications
+AppDefs
 ~~~~~~~~~~~~~
 
-In TorchX an ``Application`` is simply a struct with the *definition* of
+In TorchX an ``AppDef`` is simply a struct with the *definition* of
 the actual application. In scheduler lingo, this is a ``JobDefinition`` and a
 similar concept in Kubernetes is the ``spec.yaml``. To disambiguate between the
 application binary (logic) and the spec, we typically refer to a TorchX
-``Application`` as an "app spec" or ``specs.Application``. ``specs.Application``
+``AppDef`` as an "app spec" or ``specs.AppDef``. ``specs.AppDef``
 is the common interface understood by ``torchx.runner``
 and ``torchx.pipelines`` allowing you to run your app as a standalone job
 or as a stage in an ML pipeline.
 
-Below is a simple example of an ``specs.Application`` that echos "hello world"
+Below is a simple example of an ``specs.AppDef`` that echos "hello world"
 
 .. code-block:: python
 
  import torchx.specs as specs
 
- specs.Application(
+ specs.AppDef(
     name="echo",
     roles=[
         specs.Role(
@@ -51,7 +51,7 @@ Below is a simple example of an ``specs.Application`` that echos "hello world"
     ]
  )
 
-As you can see, ``specs.Application`` is a pure python dataclass that
+As you can see, ``specs.AppDef`` is a pure python dataclass that
 simply encodes the name of the main binary (entrypoint), arguments to
 pass to it, and a few other runtime parameters such as ``num_replicas`` and
 information about the container in which to run (``entrypoint=/bin/echo``).
@@ -71,11 +71,11 @@ Rather you would use a templetized app spec called ``components``.
 Components
 ~~~~~~~~~~~~
 
-A component in TorchX is simply a templetized ``spec.Application``. You can
-think of them as convenient "factory methods" for ``spec.Application``.
+A component in TorchX is simply a templetized ``spec.AppDef``. You can
+think of them as convenient "factory methods" for ``spec.AppDef``.
 
 .. note:: Unlike applications, components don't map to an actual python dataclass.
-          Rather a factory function that returns an ``spec.Application``
+          Rather a factory function that returns an ``spec.AppDef``
           is called a component.
 
 The granularity at which the app spec is templetized varies. Some components
@@ -91,7 +91,7 @@ of a homogeneous ``gang`` trainer app spec:
  def get_app_spec(jobname: str, nnodes: int, image: str, entrypoint: str, *script_args: str):
     single_gpu = specs.Resources(cpu=4, gpu=1, memMB=1024)
     container = specs.Container(image=image, resources=single_gpu)
-    return specs.Appplication(
+    return specs.AppDef(
             name=jobname,
             roles=[
                 specs.Role(

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -67,7 +67,7 @@ Now copy paste the following into echo_torchx.py
  import torchx.specs as specs
 
 
- def get_app_spec(num_replicas: int, msg: str = "hello world") -> specs.Application:
+ def get_app_spec(num_replicas: int, msg: str = "hello world") -> specs.AppDef:
      """
      Echos a message to stdout (calls /bin/echo)
 
@@ -76,7 +76,7 @@ Now copy paste the following into echo_torchx.py
         msg: message to echo
 
      """
-     return specs.Application(
+     return specs.AppDef(
          name="echo",
          roles=[
              specs.Role(

--- a/docs/source/specs.rst
+++ b/docs/source/specs.rst
@@ -5,10 +5,10 @@ torchx.specs
 .. currentmodule:: torchx.specs
 
 
-Application
+AppDef
 ------------
 
-.. autoclass:: Application
+.. autoclass:: AppDef
    :members:
 
 Role

--- a/examples/lightning_classy_vision/lightning_classy_vision.torchx
+++ b/examples/lightning_classy_vision/lightning_classy_vision.torchx
@@ -45,5 +45,5 @@ trainer_role = (
     .replicas(1)
 )
 
-app = torchx.Application("examples-lightning_classy_vision").of(trainer_role)
+app = torchx.AppDef("examples-lightning_classy_vision").of(trainer_role)
 export(app)

--- a/torchx/cli/__init__.py
+++ b/torchx/cli/__init__.py
@@ -6,7 +6,7 @@
 
 """
 The ``torchx`` CLI is a commandline tool around :py:class:`torchx.runner.Runner`.
-It allows users to launch :py:class:`torchx.specs.Application` directly onto
+It allows users to launch :py:class:`torchx.specs.AppDef` directly onto
 one of the supported schedulers without authoring a pipeline (aka workflow).
 This is convenient for quickly iterating on the application logic without
 incurring both the technical and cognitive overhead of learning, writing, and
@@ -63,7 +63,7 @@ The ``run``  subcommand takes either one of:
      $ cat ~/my_trainer_spec.py
      import torchx.specs as specs
 
-     def get_spec(foo: int, bar: str) -> specs.Application:
+     def get_spec(foo: int, bar: str) -> specs.AppDef:
        <...spec file details omitted for brevity...>
 
      $ torchx run --scheduler <sched_name> ~/my_trainer_spec.py get_spec

--- a/torchx/cli/cmd_describe.py
+++ b/torchx/cli/cmd_describe.py
@@ -32,6 +32,6 @@ class CmdDescribe(SubCommand):
             pprint.pprint(dataclasses.asdict(app), indent=2, width=80)
         else:
             print(
-                f"Application: {app_id} on session: {session_name},"
+                f"AppDef: {app_id} on session: {session_name},"
                 f" does not exist or has been removed from {scheduler}'s data plane"
             )

--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -128,7 +128,7 @@ def get_logs(identifier: str, regex: Optional[str], should_tail: bool = False) -
         raise threads_exceptions[0]
 
 
-def find_role_replicas(app: specs.Application, role_name: str) -> Optional[int]:
+def find_role_replicas(app: specs.AppDef, role_name: str) -> Optional[int]:
     for role in app.roles:
         if role_name == role.name:
             return role.num_replicas

--- a/torchx/cli/cmd_status.py
+++ b/torchx/cli/cmd_status.py
@@ -18,7 +18,7 @@ from torchx.specs import api
 from torchx.specs.api import NONE
 
 
-_APP_STATUS_FORMAT_TEMPLATE = """Application:
+_APP_STATUS_FORMAT_TEMPLATE = """AppDef:
   State: ${state}
   Num Restarts: ${num_restarts}
 Roles:${roles}"""
@@ -163,6 +163,6 @@ class CmdStatus(SubCommand):
             print(format_app_status(app_status, filter_roles))
         else:
             print(
-                f"Application: {app_id} on session: {session_name},"
+                f"AppDef: {app_id} on session: {session_name},"
                 f" does not exist or has been removed from {scheduler}'s data plane"
             )

--- a/torchx/cli/test/cmd_describe_test.py
+++ b/torchx/cli/test/cmd_describe_test.py
@@ -10,11 +10,11 @@ import unittest
 from unittest.mock import patch
 
 from torchx.cli.cmd_describe import CmdDescribe
-from torchx.specs.api import Application, Container, ElasticRole, Resource
+from torchx.specs.api import AppDef, Container, ElasticRole, Resource
 
 
 class CmdDescribeTest(unittest.TestCase):
-    def get_test_app(self) -> Application:
+    def get_test_app(self) -> AppDef:
         resource = Resource(cpu=2, gpu=0, memMB=256)
         trainer = (
             ElasticRole("elastic_trainer", nnodes="2:3")
@@ -23,7 +23,7 @@ class CmdDescribeTest(unittest.TestCase):
             .replicas(2)
         )
 
-        return Application("my_train_job").of(trainer)
+        return AppDef("my_train_job").of(trainer)
 
     def test_run(self) -> None:
         parser = argparse.ArgumentParser()

--- a/torchx/cli/test/cmd_status_test.py
+++ b/torchx/cli/test/cmd_status_test.py
@@ -11,11 +11,7 @@ import time
 import unittest
 from unittest.mock import patch
 
-from torchx.cli.cmd_status import (
-    CmdStatus,
-    format_app_status,
-    format_error_message,
-)
+from torchx.cli.cmd_status import CmdStatus, format_app_status, format_error_message
 from torchx.specs.api import AppState, AppStatus, ReplicaStatus, RoleStatus
 
 
@@ -79,7 +75,7 @@ Traceback (most recent call last):
         app_status = self._get_test_app_status()
         actual_message = format_app_status(app_status)
         print(actual_message)
-        expected_message = """Application:
+        expected_message = """AppDef:
   State: RUNNING
   Num Restarts: 0
 Roles:

--- a/torchx/cli/test/echo.torchx
+++ b/torchx/cli/test/echo.torchx
@@ -19,6 +19,6 @@ echo = specs.Role(
     num_replicas=1,
 )
 
-app = specs.Application(name="echo_job", roles=[echo])
+app = specs.AppDef(name="echo_job", roles=[echo])
 
 export(app)

--- a/torchx/cli/test/examples/test.py
+++ b/torchx/cli/test/examples/test.py
@@ -8,7 +8,7 @@
 import torchx.specs as specs
 
 
-def echo(msg: str = "hello world", image: str = "/tmp") -> specs.Application:
+def echo(msg: str = "hello world", image: str = "/tmp") -> specs.AppDef:
     """Echos a message
 
     Args:
@@ -24,10 +24,10 @@ def echo(msg: str = "hello world", image: str = "/tmp") -> specs.Application:
         num_replicas=1,
     )
 
-    return specs.Application(name="echo", roles=[echo])
+    return specs.AppDef(name="echo", roles=[echo])
 
 
-def touch(file: str) -> specs.Application:
+def touch(file: str) -> specs.AppDef:
     """Echos a message
 
     Args:
@@ -42,10 +42,10 @@ def touch(file: str) -> specs.Application:
         num_replicas=1,
     )
 
-    return specs.Application(name="touch", roles=[touch])
+    return specs.AppDef(name="touch", roles=[touch])
 
 
-def touch_v2(file: str) -> specs.Application:
+def touch_v2(file: str) -> specs.AppDef:
     """Echos a message
 
     Args:
@@ -60,12 +60,12 @@ def touch_v2(file: str) -> specs.Application:
         num_replicas=1,
     )
 
-    return specs.Application(name="touch", roles=[touch])
+    return specs.AppDef(name="touch", roles=[touch])
 
 
 def simple(
     num_trainers: int = 10, trainer_image: str = "pytorch/torchx:latest"
-) -> specs.Application:
+) -> specs.AppDef:
     """A simple configuration example.
 
     Args:
@@ -100,4 +100,4 @@ def simple(
         num_replicas=1,
     )
 
-    return specs.Application(name="my_train_job", roles=[trainer, ps, reader])
+    return specs.AppDef(name="my_train_job", roles=[trainer, ps, reader])

--- a/torchx/cli/test/examples/test_simple.torchx
+++ b/torchx/cli/test/examples/test_simple.torchx
@@ -42,6 +42,6 @@ reader = specs.Role(
     num_replicas=1,
 )
 
-app = specs.Application(name="my_train_job", roles=[trainer, ps, reader])
+app = specs.AppDef(name="my_train_job", roles=[trainer, ps, reader])
 
 export(app)

--- a/torchx/cli/test/examples/touch.torchx
+++ b/torchx/cli/test/examples/touch.torchx
@@ -18,4 +18,4 @@ touch = specs.Role(
     num_replicas=1,
 )
 
-export(specs.Application(name="touch", roles=[touch]))
+export(specs.AppDef(name="touch", roles=[touch]))

--- a/torchx/cli/test/examples/touch_v2.torchx
+++ b/torchx/cli/test/examples/touch_v2.torchx
@@ -17,4 +17,4 @@ touch = specs.Role(
     num_replicas=1,
 )
 
-export(specs.Application(name="touch", roles=[touch]))
+export(specs.AppDef(name="touch", roles=[touch]))

--- a/torchx/components/__init__.py
+++ b/torchx/components/__init__.py
@@ -8,7 +8,7 @@
 This module contains a collection of builtin TorchX components. The directory
 structure is organized by component category. Components are simply
 templetized app specs. Think of them as a factory methods for different types
-of job definitions. The functions that return ``specs.Application`` in this
+of job definitions. The functions that return ``specs.AppDef`` in this
 module are what we refer to as components.
 
 You can browse the library of components in the ``torchx.components`` module
@@ -41,7 +41,7 @@ and should be located accordingly. E.g. the definition of distributed components
 should be located in ``distributed.py`` file.
 
 Create component as function. Each component represents a function that accepts
- arbitrary arguments and returns ``specs.Application``.
+ arbitrary arguments and returns ``specs.AppDef``.
 
 Unit tests. Write unit tests that use ``torchx.specs.file_linter`` to validate
 the component's structure,  similar to ``torchx.components.tests.distributed_test.py``.

--- a/torchx/components/base/binary_component.py
+++ b/torchx/components/base/binary_component.py
@@ -15,7 +15,7 @@ def binary_component(
     entrypoint: str,
     args: Optional[List[str]] = None,
     env: Optional[Dict[str, str]] = None,
-) -> api.Application:
+) -> api.AppDef:
     """
     binary_component creates a single binary and container component from the
     provided arguments.
@@ -32,7 +32,7 @@ def binary_component(
         )
     """
 
-    return api.Application(
+    return api.AppDef(
         name=name,
         roles=[
             api.Role(

--- a/torchx/components/base/test/binary_component_test.py
+++ b/torchx/components/base/test/binary_component_test.py
@@ -12,7 +12,7 @@ from torchx.specs import api
 
 class BinaryComponentTest(unittest.TestCase):
     def test_binary_component(self) -> None:
-        want = api.Application(
+        want = api.AppDef(
             name="datapreproc",
             roles=[
                 api.Role(

--- a/torchx/components/dist/ddp.py
+++ b/torchx/components/dist/ddp.py
@@ -7,8 +7,8 @@
 import torchx.specs as specs
 
 
-def get_app_spec(fixme: str) -> specs.Application:
+def get_app_spec(fixme: str) -> specs.AppDef:
     # TODO actually return ddp app (to get the resources right needs to be
     #  done after properly implementing torchx.components.base.named_resource)
     role = specs.ElasticRole(name="foobar")
-    return specs.Application(name=fixme, roles=[role])
+    return specs.AppDef(name=fixme, roles=[role])

--- a/torchx/components/distributed.py
+++ b/torchx/components/distributed.py
@@ -17,7 +17,7 @@ def ddp(
     role: str = "worker",
     env: Optional[Dict[str, str]] = None,
     *script_args: str,
-) -> specs.Application:
+) -> specs.AppDef:
     """Single role application.
 
     Single role application.
@@ -31,7 +31,7 @@ def ddp(
         script_args: Script arguments.
 
     Returns:
-        specs.Application: Torchx Application
+        specs.AppDef: Torchx AppDef
     """
     app_env: Dict[str, str] = {}
     if env:
@@ -49,4 +49,4 @@ def ddp(
 
     # get app name from cli or extract from fbpkg. Note that fbpkg name can has "."
     # but not allowed in app name.
-    return specs.Application(name).of(ddp_role)
+    return specs.AppDef(name).of(ddp_role)

--- a/torchx/components/tests.py
+++ b/torchx/components/tests.py
@@ -8,7 +8,7 @@
 import torchx.specs as specs
 
 
-def echo(msg: str = "hello world", image: str = "/tmp") -> specs.Application:
+def echo(msg: str = "hello world", image: str = "/tmp") -> specs.AppDef:
     """Echos a message
 
     Args:
@@ -24,10 +24,10 @@ def echo(msg: str = "hello world", image: str = "/tmp") -> specs.Application:
         num_replicas=1,
     )
 
-    return specs.Application(name="echo", roles=[echo])
+    return specs.AppDef(name="echo", roles=[echo])
 
 
-def touch(file: str) -> specs.Application:
+def touch(file: str) -> specs.AppDef:
     """Test component, creates a file in tmp dir
 
     Args:
@@ -42,10 +42,10 @@ def touch(file: str) -> specs.Application:
         num_replicas=1,
     )
 
-    return specs.Application(name="touch", roles=[touch])
+    return specs.AppDef(name="touch", roles=[touch])
 
 
-def touch_v2(file: str) -> specs.Application:
+def touch_v2(file: str) -> specs.AppDef:
     """Test component, creates a file in tmp dir
 
     Args:
@@ -60,12 +60,12 @@ def touch_v2(file: str) -> specs.Application:
         num_replicas=1,
     )
 
-    return specs.Application(name="touch", roles=[touch])
+    return specs.AppDef(name="touch", roles=[touch])
 
 
 def simple(
     num_trainers: int = 10, trainer_image: str = "pytorch/torchx:latest"
-) -> specs.Application:
+) -> specs.AppDef:
     """A simple configuration example.
 
     Args:
@@ -100,4 +100,4 @@ def simple(
         num_replicas=1,
     )
 
-    return specs.Application(name="my_train_job", roles=[trainer, ps, reader])
+    return specs.AppDef(name="my_train_job", roles=[trainer, ps, reader])

--- a/torchx/components/utils/echo.py
+++ b/torchx/components/utils/echo.py
@@ -7,7 +7,7 @@
 import torchx.specs as specs
 
 
-def get_app_spec(msg: str = "hello world") -> specs.Application:
+def get_app_spec(msg: str = "hello world") -> specs.AppDef:
     """
     Echos a message to stdout (calls /bin/echo)
 
@@ -15,7 +15,7 @@ def get_app_spec(msg: str = "hello world") -> specs.Application:
         msg: message to echo
 
     """
-    return specs.Application(
+    return specs.AppDef(
         name="echo",
         roles=[
             specs.Role(

--- a/torchx/pipelines/kfp/adapter.py
+++ b/torchx/pipelines/kfp/adapter.py
@@ -128,7 +128,7 @@ class TorchXComponent:
         ...
 
 
-def component_spec_from_app(app: api.Application) -> Tuple[str, api.Container]:
+def component_spec_from_app(app: api.AppDef) -> Tuple[str, api.Container]:
     assert len(app.roles) == 1, f"KFP adapter only support one role, got {app.roles}"
 
     role = app.roles[0]
@@ -161,11 +161,10 @@ class ContainerFactory(Protocol):
         ...
 
 
-def component_from_app(app: api.Application) -> ContainerFactory:
+def component_from_app(app: api.AppDef) -> ContainerFactory:
     container_spec: api.Container
     spec, container_spec = component_spec_from_app(app)
     resources: api.Resource = container_spec.resources
-
     assert (
         len(resources.capabilities) == 0
     ), f"KFP doesn't support capabilities, got {resources.capabilities}"

--- a/torchx/pipelines/kfp/test/adapter_test.py
+++ b/torchx/pipelines/kfp/test/adapter_test.py
@@ -117,7 +117,7 @@ class KFPSpecsTest(unittest.TestCase):
     tests KFP components using torchx.specs.api
     """
 
-    def _test_app(self) -> api.Application:
+    def _test_app(self) -> api.AppDef:
         container = api.Container(
             image="pytorch/torchx:latest",
             resources=api.Resource(
@@ -139,7 +139,7 @@ class KFPSpecsTest(unittest.TestCase):
             .replicas(1)
         )
 
-        return api.Application("test").of(trainer_role)
+        return api.AppDef("test").of(trainer_role)
 
     def test_component_spec_from_app(self) -> None:
         app = self._test_app()

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -20,9 +20,9 @@ from torchx.schedulers import get_schedulers
 from torchx.schedulers.api import Scheduler
 from torchx.specs.api import (
     NULL_CONTAINER,
+    AppDef,
     AppDryRunInfo,
     AppHandle,
-    Application,
     AppStatus,
     RunConfig,
     SchedulerBackend,
@@ -43,7 +43,7 @@ NONE: str = "<NONE>"
 class Runner:
     """
     Torchx individual component runner. Has the methods for the user to
-    act upon ``Applications``. The ``Runner`` is stateful and
+    act upon ``AppDefs``. The ``Runner`` is stateful and
     represents a logical workspace of the user. It can be backed by a service
     (e.g. Torchx server) for persistence or can be standalone with no persistence
     meaning that the ``Runner`` lasts only during the duration of the hosting
@@ -64,7 +64,7 @@ class Runner:
         self._name: str = name
         self._schedulers = schedulers
         self._wait_interval = wait_interval
-        self._apps: Dict[AppHandle, Application] = {}
+        self._apps: Dict[AppHandle, AppDef] = {}
 
     def run_from_path(
         self,
@@ -147,7 +147,7 @@ class Runner:
 
     def run(
         self,
-        app: Application,
+        app: AppDef,
         scheduler: SchedulerBackend = "default",
         cfg: Optional[RunConfig] = None,
     ) -> AppHandle:
@@ -216,7 +216,7 @@ class Runner:
 
     def dryrun(
         self,
-        app: Application,
+        app: AppDef,
         scheduler: SchedulerBackend = "default",
         cfg: Optional[RunConfig] = None,
         # pyre-fixme[24]: AppDryRunInfo was designed to work with Any request object
@@ -350,7 +350,7 @@ class Runner:
                 else:
                     time.sleep(self._wait_interval)
 
-    def list(self) -> Dict[AppHandle, Application]:
+    def list(self) -> Dict[AppHandle, AppDef]:
         """
         Returns the applications that were run with this session mapped by the app handle.
         The persistence of the session is implementation dependent.
@@ -380,7 +380,7 @@ class Runner:
             if status is not None and not status.is_terminal():
                 scheduler.cancel(app_id)
 
-    def describe(self, app_handle: AppHandle) -> Optional[Application]:
+    def describe(self, app_handle: AppHandle) -> Optional[AppDef]:
         """
         Reconstructs the application (to the best extent) given the app handle.
         Note that the reconstructed application may not be the complete app as
@@ -388,7 +388,7 @@ class Runner:
         is scheduler dependent.
 
         Returns:
-            Application or None if the app does not exist anymore or if the
+            AppDef or None if the app does not exist anymore or if the
             scheduler does not support describing the app handle
         """
         scheduler, scheduler_backend, app_id = self._scheduler_app_id(
@@ -401,7 +401,7 @@ class Runner:
             if not app:
                 desc = scheduler.describe(app_id)
                 if desc:
-                    app = Application(name=app_id).of(*desc.roles)
+                    app = AppDef(name=app_id).of(*desc.roles)
             return app
 
     def log_lines(

--- a/torchx/runner/test/resource/distributed.py
+++ b/torchx/runner/test/resource/distributed.py
@@ -17,7 +17,7 @@ def ddp(
     role: str = "worker",
     env: Optional[Dict[str, str]] = None,
     *script_args: str,
-) -> specs.Application:
+) -> specs.AppDef:
     """Single role application.
 
     Single role application.
@@ -31,7 +31,7 @@ def ddp(
         script_args: Script arguments.
 
     Returns:
-        specs.Application: Torchx Application
+        specs.AppDef: Torchx AppDef
     """
     app_env: Dict[str, str] = {}
     if env:
@@ -49,4 +49,4 @@ def ddp(
 
     # get app name from cli or extract from fbpkg. Note that fbpkg name can has "."
     # but not allowed in app name.
-    return specs.Application(name).of(ddp_role)
+    return specs.AppDef(name).of(ddp_role)

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -8,19 +8,19 @@
 import abc
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Optional, Iterable
+from typing import Iterable, List, Optional
 
 from torchx.specs.api import (
-    Application,
-    RunConfig,
-    AppState,
-    RoleStatus,
-    Role,
-    AppDryRunInfo,
-    runopts,
     NONE,
-    SchedulerBackend,
     NULL_RESOURCE,
+    AppDef,
+    AppDryRunInfo,
+    AppState,
+    Role,
+    RoleStatus,
+    RunConfig,
+    SchedulerBackend,
+    runopts,
 )
 
 
@@ -30,7 +30,7 @@ class DescribeAppResponse:
     Response object returned by ``Scheduler.describe(app)`` API. Contains
     the status and description of the application as known by the scheduler.
     For some schedulers implementations this response object has necessary
-    and sufficient information to recreate an ``Application`` object in the
+    and sufficient information to recreate an ``AppDef`` object in the
     absence of the hosting ``Session``. For these types of schedulers,
     the user can re-``run()`` the attached application. Otherwise the user
     can only call non-creating methods (e.g. ``wait()``, ``status()``, etc).
@@ -65,7 +65,7 @@ class Scheduler(abc.ABC):
         self.backend = backend
         self.session_name = session_name
 
-    def submit(self, app: Application, cfg: RunConfig) -> str:
+    def submit(self, app: AppDef, cfg: RunConfig) -> str:
         """
         Submits the application to be run by the scheduler.
 
@@ -94,7 +94,7 @@ class Scheduler(abc.ABC):
         raise NotImplementedError()
 
     # pyre-fixme[24]: AppDryRunInfo was designed to work with Any request object
-    def submit_dryrun(self, app: Application, cfg: RunConfig) -> AppDryRunInfo:
+    def submit_dryrun(self, app: AppDef, cfg: RunConfig) -> AppDryRunInfo:
         """
         Rather than submitting the request to run the app, returns the
         request object that would have been submitted to the underlying
@@ -112,7 +112,7 @@ class Scheduler(abc.ABC):
         return dryrun_info
 
     # pyre-fixme[24]: AppDryRunInfo was designed to work with Any request object
-    def _submit_dryrun(self, app: Application, cfg: RunConfig) -> AppDryRunInfo:
+    def _submit_dryrun(self, app: AppDef, cfg: RunConfig) -> AppDryRunInfo:
         raise NotImplementedError()
 
     def run_opts(self) -> runopts:
@@ -128,7 +128,7 @@ class Scheduler(abc.ABC):
         Describes the specified application.
 
         Returns:
-            Application description or ``None`` if the app does not exist.
+            AppDef description or ``None`` if the app does not exist.
         """
         raise NotImplementedError()
 
@@ -236,7 +236,7 @@ class Scheduler(abc.ABC):
             f"{self.__class__.__qualname__} does not support application log iteration"
         )
 
-    def _validate(self, app: Application, scheduler: SchedulerBackend) -> None:
+    def _validate(self, app: AppDef, scheduler: SchedulerBackend) -> None:
         """
         Validates whether application is consistent with the scheduler.
 

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -9,14 +9,13 @@
 import unittest
 from datetime import datetime
 from typing import Iterable, Optional, Union
-from unittest.mock import MagicMock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from torchx.schedulers.api import Scheduler, DescribeAppResponse
+from torchx.schedulers.api import DescribeAppResponse, Scheduler
 from torchx.specs.api import (
     NULL_RESOURCE,
+    AppDef,
     AppDryRunInfo,
-    Application,
     InvalidRunConfigException,
     Resource,
     RunConfig,
@@ -34,9 +33,7 @@ class SchedulerTest(unittest.TestCase):
             assert app is not None
             return app.name
 
-        def _submit_dryrun(
-            self, app: Application, cfg: RunConfig
-        ) -> AppDryRunInfo[None]:
+        def _submit_dryrun(self, app: AppDef, cfg: RunConfig) -> AppDryRunInfo[None]:
             return AppDryRunInfo(None, lambda t: "None")
 
         def describe(self, app_id: str) -> Optional[DescribeAppResponse]:

--- a/torchx/specs/file_linter.py
+++ b/torchx/specs/file_linter.py
@@ -190,10 +190,10 @@ class TorchxReturnValidator(TorchxFunctionValidator):
     def validate(self, app_specs_func_def: ast.FunctionDef) -> List[LinterMessage]:
         """
         Validates return annotation of the torchx function. Current allowed annotations:
-            * Application
-            * specs.Application
+            * AppDef
+            * specs.AppDef
         """
-        supported_return_annotation = "Application"
+        supported_return_annotation = "AppDef"
         return_annotation = self._get_return_annotation(app_specs_func_def)
         linter_errors = []
         if not return_annotation:

--- a/torchx/specs/test/file_linter_test.py
+++ b/torchx/specs/test/file_linter_test.py
@@ -14,8 +14,8 @@ from torchx.specs.file_linter import get_fn_docstring, parse_fn_docstring, valid
 
 
 # Note if the function is moved, the tests need to be updated with new lineno
-# pyre-ignore[11]: Ignore unknown type "Application"
-def _test_empty_fn() -> "Application":
+# pyre-ignore[11]: Ignore unknown type "AppDef"
+def _test_empty_fn() -> "AppDef":
     pass
 
 
@@ -35,28 +35,26 @@ def _test_fn_return_int() -> int:
     return 0
 
 
-def _test_docstring_empty(arg: str) -> "Application":
+def _test_docstring_empty(arg: str) -> "AppDef":
     """ """
     pass
 
 
-def _test_docstring_func_desc() -> "Application":
+def _test_docstring_func_desc() -> "AppDef":
     """
     Function description
     """
     pass
 
 
-def _test_docstring_no_args(arg: str) -> "Application":
+def _test_docstring_no_args(arg: str) -> "AppDef":
     """
     Test description
     """
     pass
 
 
-def _test_docstring_correct(
-    arg0: str, arg1: int, arg2: Dict[int, str]
-) -> "Application":
+def _test_docstring_correct(arg0: str, arg1: int, arg2: Dict[int, str]) -> "AppDef":
     """Short Test description
 
     Long funct description
@@ -70,7 +68,7 @@ def _test_docstring_correct(
 
 
 # pyre-ignore[2]: Omit return value for testing purposes
-def _test_args_no_type_defs(arg0, arg1, arg2: Dict[int, str]) -> "Application":
+def _test_args_no_type_defs(arg0, arg1, arg2: Dict[int, str]) -> "AppDef":
     """
     Test description
 
@@ -90,7 +88,7 @@ def _test_args_dict_list_complex_types(
     arg2: Dict[int, List[str]],
     arg3: List[List[str]],
     arg4: Optional[Optional[str]],
-) -> "Application":
+) -> "AppDef":
     """
     Test description
 
@@ -127,7 +125,7 @@ class SpecsFileValidatorTest(unittest.TestCase):
         self.assertEqual(1, len(linter_errors))
         expected_desc = (
             "Function: _test_fn_no_return missing return annotation or "
-            "has unknown annotations. Supported return annotation: Application"
+            "has unknown annotations. Supported return annotation: AppDef"
         )
         self.assertEqual(expected_desc, linter_errors[0].description)
 
@@ -138,7 +136,7 @@ class SpecsFileValidatorTest(unittest.TestCase):
         self.assertEqual(1, len(linter_errors))
         expected_desc = (
             "Function: _test_fn_return_int has incorrect return annotation, "
-            "supported annotation: Application"
+            "supported annotation: AppDef"
         )
         self.assertEqual(expected_desc, linter_errors[0].description)
 


### PR DESCRIPTION
Summary: The diff renames Application to AppDef, only inside torchx, exposing it as Application in tsm dir for BC

Reviewed By: kiukchung

Differential Revision: D28853523

