### PR TITLE
Torchx: switch from isort to usort

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dependencies
         run: |
           set -eux
-          pip install isort==4.3.21
+          pip install usort==0.6.4
           pip install black
           pip install flake8==3.9.0
       - name: Run Lint

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ moto>=2.0.6
 kfp==1.6.2
 pyre-extensions>=0.0.21
 black>=21.5b1
-isort==4.3.21
+usort==0.6.4
 pytorch-lightning>=0.5.3
 torch>=1.8.1
 torchvision>=0.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.usort]
+first_party_detection = false

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -12,9 +12,9 @@ then
     echo "Please install black."
     exit 1
 fi
-if [ ! "$(isort --version)" ]
+if [ ! "$(usort --version)" ]
 then
-    echo "Please install isort."
+    echo "Please install usort."
     exit 1
 fi
 if [ ! "$(flake8 --version)" ]
@@ -55,8 +55,7 @@ then
     for file in $CHANGED_FILES
     do
         echo "Checking $file"
-        isort "$file" --recursive --multi-line 3 --trailing-comma --force-grid-wrap 0 \
-            --line-width 88 --lines-after-imports 2 --combine-as --section-default THIRDPARTY -q
+        usort format "$file"
         black "$file" -q
         flake8 "$file" || LINT_ERRORS=1
         scripts/copyright.py "$file" || LINT_ERRORS=1
@@ -73,7 +72,7 @@ then
     exit 1
 fi
 
-# Check if any files were modified by running isort + black
+# Check if any files were modified by running usort + black
 # If so, then the files were formatted incorrectly (e.g. did not pass lint)
 CHANGED_FILES="$(git diff --name-only | grep '\.py$' | tr '\n' ' ')"
 if [ "$CHANGED_FILES" != "" ]


### PR DESCRIPTION
Summary: Switch from isort to usort since usort is used by the insernal fb linter

Reviewed By: d4l3k

Differential Revision: D28916198

