### PR TITLE
torchserve: fix tests

### DIFF
--- a/torchx/components/serve/serve.py
+++ b/torchx/components/serve/serve.py
@@ -14,7 +14,7 @@ def torchserve(
     management_api: str,
     image: str = "495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx:latest",
     params: Optional[Dict[str, object]] = None,
-) -> specs.Application:
+) -> specs.AppDef:
     """Deploys the provided model to the given torchserve management API
     endpoint.
 
@@ -26,7 +26,7 @@ def torchserve(
             See https://pytorch.org/serve/management_api.html#register-a-model
 
     Returns:
-        specs.Application: Torchx Application
+        specs.AppDef: Torchx applicaiton definition
     """
 
     args = [
@@ -43,7 +43,7 @@ def torchserve(
                 str(value),
             ]
 
-    return specs.Application(
+    return specs.AppDef(
         name="torchx-serve-torchserve",
         roles=[
             specs.Role(

--- a/torchx/components/serve/test/serve_test.py
+++ b/torchx/components/serve/test/serve_test.py
@@ -13,7 +13,7 @@ from torchx.components.serve.serve import torchserve
 
 class ServeTest(unittest.TestCase):
     def test_torchserve(self) -> None:
-        want = specs.Application(
+        want = specs.AppDef(
             name="torchx-serve-torchserve",
             roles=[
                 specs.Role(


### PR DESCRIPTION
<!-- Change Summary -->

#26 and  #29 conflicted resulting in failing tests.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pyre
python setup.py test
```
