### PR TITLE
Use torch_dist_role in torchx

### DIFF
--- a/torchx/cli/test/cmd_describe_test.py
+++ b/torchx/cli/test/cmd_describe_test.py
@@ -10,19 +10,21 @@ import unittest
 from unittest.mock import patch
 
 from torchx.cli.cmd_describe import CmdDescribe
-from torchx.specs.api import AppDef, Container, ElasticRole, Resource
+from torchx.components.base import torch_dist_role
+from torchx.specs.api import AppDef, Container, Resource
 
 
 class CmdDescribeTest(unittest.TestCase):
     def get_test_app(self) -> AppDef:
         resource = Resource(cpu=2, gpu=0, memMB=256)
-        trainer = (
-            ElasticRole("elastic_trainer", nnodes="2:3")
-            .runs("trainer.par", "--arg1", "foo")
-            .on(Container("trainer_fbpkg").require(resource))
-            .replicas(2)
+        trainer = torch_dist_role(
+            "elastic_trainer",
+            entrypoint="trainer.par",
+            script_args=["--arg1", "foo"],
+            num_replicas=2,
+            container=Container("trainer_fbpkg").require(resource),
+            nnodes="2:3",
         )
-
         return AppDef("my_train_job").of(trainer)
 
     def test_run(self) -> None:

--- a/torchx/components/base/__init__.py
+++ b/torchx/components/base/__init__.py
@@ -44,6 +44,29 @@ def torch_dist_role(
     will be used.
 
     For more information see ``torchx.components.base.roles``
+
+    Usage:
+
+    ::
+
+     # nnodes and nproc_per_node correspond to the ``torch.distributed.launch`` arguments. More
+     # info about available arguments: https://pytorch.org/docs/stable/distributed.html#launch-utility
+     trainer = torch_dist_role("trainer",container, entrypoint="trainer.py",.., nnodes=2, nproc_per_node=4)
+
+    Args:
+        name: Name of the role
+        container: Container
+        entrypoint: Script or binary to launch
+        script_args: Arguments to the script
+        script_envs: Env. variables to the worker
+        num_replicas: Number of replicas
+        max_retries: Number of retries
+        retry_policy: ``torchx.specs.api.RetryPolicy``
+        launch_kwargs: ``torch.distributed.launch`` arguments.
+
+    Returns:
+        Torchx role
+
     """
     dist_role_factory = load(
         "torchx.base",

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -6,7 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # TODO(aivanou): Update documentation
-
 import argparse
 import copy
 import inspect
@@ -236,7 +235,7 @@ class RetryPolicy(str, Enum):
               on the retry policies they support and behavior caveats (if any).
 
     1. REPLICA: Replaces the replica instance. Surviving replicas are untouched.
-                Use with ``ElasticRole`` to have torchelastic coordinate restarts
+                Use with ``torch_dist_role`` to have torch coordinate restarts
                 and membership changes. Otherwise, it is up to the application to
                 deal with failed replica departures and replacement replica admittance.
     2. APPLICATION: Restarts the entire application.


### PR DESCRIPTION
Summary: Move ElasticRole and ElasticRole to tsm, use torch_dist_role in torchx

Differential Revision: D28924583

