### PR TITLE
Introduce new Resource Definition API

### DIFF
--- a/torchx/components/base/__init__.py
+++ b/torchx/components/base/__init__.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 from torchx.specs.api import NULL_RESOURCE, Resource, RetryPolicy, Role
 from torchx.util.entrypoints import load
 
-from .roles import create_torch_dist_role  # noqa: F401 F403
+from .roles import create_torch_dist_role
 
 
 def named_resource(name: str) -> Resource:

--- a/torchx/components/base/resource_def.py
+++ b/torchx/components/base/resource_def.py
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+
+from torchx.specs.api import Resource, NULL_RESOURCE
+
+GiB: int = 1024
+
+
+# The alias is used for testing when the resource requirements do not matter
+IGNORED: Resource = NULL_RESOURCE
+
+
+def list_resources() -> Dict[str, Resource]:
+    return {
+        # aws t4g.large
+        "cpu_x_2": Resource(cpu=2, gpu=0, memMB=8 * GiB),
+        # aws t4g.xlarge
+        "cpu_x_4": Resource(cpu=4, gpu=0, memMB=16 * GiB),
+        # aws t4g.2xlarge
+        "cpu_x_8": Resource(cpu=8, gpu=0, memMB=32 * GiB),
+        # aws p3.Xxlarge
+        "gpu_x_1": Resource(cpu=8, gpu=1, memMB=61 * GiB),
+        "gpu_x_2": Resource(cpu=16, gpu=2, memMB=122 * GiB),
+        "gpu_x_4": Resource(cpu=32, gpu=4, memMB=244 * GiB),
+        "gpu_x_8": Resource(cpu=64, gpu=8, memMB=488 * GiB),
+        "IGNORED": IGNORED,
+    }

--- a/torchx/components/base/test/resource_def_test.py
+++ b/torchx/components/base/test/resource_def_test.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+from torchx.components.base.resource_def import list_resources
+
+
+class ResourceDefTest(unittest.TestCase):
+    def test_list_resources(self) -> None:
+        resouces = list_resources()
+        self.assertEqual(8, len(resouces))


### PR DESCRIPTION
Summary:
The diff introduces a string representation of the resource definitions
Users can use these predefined resources in the following way:

    import torch_dist_role

    torch_dist_role(name="trainer", resource="TC", ..)

The diff also adds support for user-defined resources via entrypoints.
Users can define entrypoints in format:

    [torchx.base]
    resource_defs = custom_path:list_resources

The FB specific resources are defined in ``torchx.components.base.fb.resource_def`` . The resource.cpu is defined as a number of cores.

The diff also adds resource resolution for both mast and flow scheduler: adjusting memory to memory tax and scaling cpu(in flow case) to set it as number of hyperthreads.

Differential Revision: D28953775

