### PR TITLE
Remove ElasticRole and ElasticRoleFB

### DIFF
--- a/docs/source/specs.rst
+++ b/docs/source/specs.rst
@@ -16,9 +16,6 @@ Role
 .. autoclass:: Role
    :members:
 
-.. autoclass:: ElasticRole
-   :members:
-
 .. autoclass:: RetryPolicy
    :members:
 

--- a/torchx/components/base/roles.py
+++ b/torchx/components/base/roles.py
@@ -43,7 +43,7 @@ def create_torch_dist_role(
     to fail and restart a maximum of 3 times.
 
     .. warning:: ``replicas`` MUST BE an integer between (inclusive) ``nnodes``. That is,
-                   ``ElasticRole("trainer", nnodes="2:4").replicas(5)`` is invalid and will
+                   ``Role("trainer", nnodes="2:4", num_replicas=5)`` is invalid and will
                    result in undefined behavior.
 
 

--- a/torchx/components/base/test/roles_test.py
+++ b/torchx/components/base/test/roles_test.py
@@ -91,7 +91,10 @@ class TorchDistRoleBuilderTest(unittest.TestCase):
 
     def test_build_create_torch_dist_role_flag_args(self) -> None:
         role = create_torch_dist_role(
-            "test_role", "torch_image", "user_script.py", no_python=False
+            "test_role",
+            image="torch_image",
+            entrypoint="user_script.py",
+            no_python=False,
         )
         self.assertEqual(
             [
@@ -113,8 +116,8 @@ class TorchDistRoleBuilderTest(unittest.TestCase):
     ) -> None:
         role = create_torch_dist_role(
             "test_role",
-            "torch_image",
-            os.path.join(macros.img_root, "user_script.py"),
+            image="torch_image",
+            entrypoint=os.path.join(macros.img_root, "user_script.py"),
             no_python=False,
         )
         self.assertEqual(
@@ -134,16 +137,16 @@ class TorchDistRoleBuilderTest(unittest.TestCase):
 
     def test_json_serialization_factory(self) -> None:
         """
-        Tests that an ElasticRole can be serialized into json (dict)
-        then recreated as a Role. An ElasticRole is really just a builder
+        Tests that an Role with torchx dist run can be serialized into json (dict)
+        then recreated as a Role. It is really just a builder
         utility to make it easy for users to create a Role with the entrypoint
         being ``torch.distributed.launch``
         """
         resource = Resource(cpu=1, gpu=0, memMB=512)
         role = create_torch_dist_role(
             "test_role",
-            "user_image",
-            "user_script.py",
+            image="user_image",
+            entrypoint="user_script.py",
             resource=resource,
             script_args=["--script_arg", "foo"],
             port_map={"tensorboard": 8080},

--- a/torchx/components/dist/ddp.py
+++ b/torchx/components/dist/ddp.py
@@ -5,10 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import torchx.specs as specs
+from torchx.components.base import torch_dist_role
 
 
 def get_app_spec(fixme: str) -> specs.AppDef:
     # TODO actually return ddp app (to get the resources right needs to be
     #  done after properly implementing torchx.components.base.named_resource)
-    role = specs.ElasticRole(name="foobar", image="<NONE>")
+    role = torch_dist_role(name="foobar", image="<NONE>", entrypoint="dummy")
     return specs.AppDef(name=fixme, roles=[role])


### PR DESCRIPTION
Summary: Remove ElasticRole and ElasticRoleFB classes and use factory methods directly

Reviewed By: d4l3k

Differential Revision: D28925499

