### PR TITLE
github/kfp: run integration tests even for external users

### DIFF
--- a/.github/workflows/kfp-build.yaml
+++ b/.github/workflows/kfp-build.yaml
@@ -1,0 +1,38 @@
+name: KFP Pipeline Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  kfp-build:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout TorchX
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          set -eux
+          pip install -r dev-requirements.txt
+          python setup.py install
+      - run: df -h
+      - name: Build KFP Pipeline
+        env:
+          EXAMPLES_CONTAINER_REPO: 495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/examples
+          TORCHX_CONTAINER_REPO: 495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx
+          INTEGRATION_TEST_STORAGE: s3://torchx-test/integration-tests/
+        run: scripts/kfpint.py --path kfp-build/ --save
+      - run: df -h
+      - name: Upload kfp-build
+        uses: actions/upload-artifact@v2
+        with:
+          name: kfp-build
+          path: kfp-build/
+          retention-days: 1

--- a/.github/workflows/kfp-integration-tests.yaml
+++ b/.github/workflows/kfp-integration-tests.yaml
@@ -1,13 +1,14 @@
 name: KFP Integration Tests
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  workflow_run:
+    workflows: ["KFP Pipeline Build"]
+    types:
+      - completed
 
 jobs:
-  kfp:
+  kfp-launch:
+    if: github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -24,6 +25,12 @@ jobs:
         run: |
           set -eux
           aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 495572122715.dkr.ecr.us-west-2.amazonaws.com
+      - name: Download kfp-build
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          run_id: ${{github.event.workflow_run.id }}
+          name: kfp-build
+          path: kfp-build/
       - name: Install dependencies
         run: |
           set -eux
@@ -38,4 +45,4 @@ jobs:
           INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
           EXAMPLES_CONTAINER_REPO: ${{ secrets.EXAMPLES_CONTAINER_REPO }}
           TORCHX_CONTAINER_REPO: ${{ secrets.TORCHX_CONTAINER_REPO }}
-        run: scripts/kfpint.py
+        run: scripts/kfpint.py --path kfp-build/ --load


### PR DESCRIPTION
<!-- Change Summary -->

This splits the kfp integration tests into two steps.
1. without secrets on PR branch: builds the pipeline + containers and saves them as a GitHub artifact
2. with secrets from master branch: loads the artifact and launches it on the KFP cluster

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
scripts/kfpint.py --path /tmp/foo --save
scripts/kfpint.py --path /tmp/foo --load
```

CI