### PR TITLE
Add unit test for stl apps

### DIFF
--- a/torchx/components/test/component_test_base.py
+++ b/torchx/components/test/component_test_base.py
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+from types import ModuleType
+
+from torchx.specs.file_linter import validate
+
+
+class ComponentTestCase(unittest.TestCase):
+    def _validate(self, module: ModuleType, function_name: str) -> None:
+        file_path = path = os.path.abspath(module.__file__)
+        with open(file_path, "r") as fp:
+            file_content = fp.read()
+        linter_errors = validate(file_content, file_path, function_name)
+        if len(linter_errors) != 0:
+            error_msg = ""
+            for linter_error in linter_errors:
+                error_msg += f"Lint Error: {linter_error.description}\n"
+            raise ValueError(error_msg)
+        self.assertEquals(0, len(linter_errors))

--- a/torchx/components/test/distributed_test.py
+++ b/torchx/components/test/distributed_test.py
@@ -4,21 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-import unittest
-from types import ModuleType
-
 import torchx.components.distributed as distributed_components
-from torchx.specs.file_linter import validate
+
+from .component_test_base import ComponentTestCase
 
 
-class DistributedComponentTest(unittest.TestCase):
-    def _validate(self, module: ModuleType, function_name: str) -> None:
-        file_path = path = os.path.abspath(distributed_components.__file__)
-        with open(file_path, "r") as fp:
-            file_content = fp.read()
-        linter_errors = validate(file_content, file_path, function_name)
-        self.assertEquals(0, len(linter_errors))
-
+class DistributedComponentTest(ComponentTestCase):
     def test_ddp(self) -> None:
         self._validate(distributed_components, "ddp")

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -761,12 +761,13 @@ def get_argparse_param_type(parameter: inspect.Parameter) -> Callable[[str], obj
 
 
 def _create_args_parser(
+    fn_name: str,
     parameters: Mapping[str, inspect.Parameter],
     function_desc: str,
     args_desc: Dict[str, str],
 ) -> argparse.ArgumentParser:
     script_parser = argparse.ArgumentParser(
-        prog="torchx run",
+        prog=f"torchx run ...torchx_params... {fn_name} ",
         description=f"App spec: {function_desc}",
     )
 
@@ -795,7 +796,9 @@ def _get_function_args(
     function_desc, args_desc = parse_fn_docstring(docstring)
 
     parameters = inspect.signature(app_fn).parameters
-    script_parser = _create_args_parser(parameters, function_desc, args_desc)
+    script_parser = _create_args_parser(
+        app_fn.__name__, parameters, function_desc, args_desc
+    )
 
     parsed_args = script_parser.parse_args(app_args)
 


### PR DESCRIPTION
Summary:
The diffs adds unit tests for stl apps, adds support for default values for ``fb.stl_apps.video_classification`` component. With this change users can just tests run via:

  torchx run --scheduler flow \
    --scheduler_args secure_group=oncall_dai_pet,entitlement=bigbasin_atn_prod \
    fb.stl_apps.video_classification

Reviewed By: d4l3k

Differential Revision: D28983911

