### PR TITLE
docs: added versions index

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,8 @@
+{% extends "!layout.html" %}
+
+{% block sidebartitle %}
+    <div class="version">
+      <a href='/torchx/versions.html'>{{ version }} &#x25BC</a>
+    </div>
+    {% include "searchbox.html" %}
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch>=1.8.1
 pyre-extensions
 # (optional) kfp==1.6.2
+docstring-parser==0.8.1


### PR DESCRIPTION
<!-- Change Summary -->

This adds a link to versions.html as well as generates the versions.html using the `tree` command. It's not super pretty but it's easy to modify the CSS down the line.

I've also modified the script to push to the current origin so forks push to their own fork gh-pages.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
./doc_push.sh
```
https://d4l3k.github.io/torchx/versions.html
