### PR TITLE
workflows/container: push to Github container registry

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,4 +1,4 @@
-name: Docker Container
+name: Publish Docker Containers
 
 on:
   push:
@@ -10,18 +10,33 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
       - name: Checkout TorchX
         uses: actions/checkout@v2
-      - name: Configure Docker
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Get TorchX version
         run: |
           set -eux
-          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 495572122715.dkr.ecr.us-west-2.amazonaws.com
-      - name: Build container
-        run: torchx/runtime/container/build.sh
-      - name: Tag container
-        run: docker tag torchx ${{secrets.TORCHX_CONTAINER_REPO}}:latest
-      - name: Push container
-        run: docker push ${{secrets.TORCHX_CONTAINER_REPO}}:latest
+          python setup.py install
+          echo "VERSION=$(python -c 'import torchx; print(torchx.__version__)')" >> $GITHUB_ENV
+      - name: Configure Docker
+        run: |
+          set -eux
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Build torchx container
+        run: |
+          set -eux
+          torchx/runtime/container/build.sh
+          docker tag torchx "ghcr.io/pytorch/torchx:$VERSION"
+      - name: Build examples container
+        run: |
+          set -eux
+          docker build -t "ghcr.io/pytorch/torchx-examples:$VERSION" examples/apps/
+      - name: Push containers
+        run: |
+          set -eux
+          docker push "ghcr.io/pytorch/torchx-examples:$VERSION"
+          docker push "ghcr.io/pytorch/torchx:$VERSION"

--- a/examples/pipelines/kfp/kfp_pipeline.py
+++ b/examples/pipelines/kfp/kfp_pipeline.py
@@ -32,17 +32,20 @@ parser = argparse.ArgumentParser(description="example kfp pipeline")
 # docker containers. We have one container for the example apps and one for
 # the standard built in apps. If you modify the torchx example code you'll
 # need to rebuild the container before launching it on KFP
+
+from torchx.version import TORCHX_IMAGE, EXAMPLES_IMAGE
+
 parser.add_argument(
     "--image",
     type=str,
-    help="docker image to use",
-    default="495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/examples:latest",
+    help="docker image to use for the examples apps",
+    default=EXAMPLES_IMAGE,
 )
 parser.add_argument(
     "--torchx_image",
     type=str,
-    help="docker image to use",
-    default="495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx:latest",
+    help="docker image to use for the builtin torchx apps",
+    default=TORCHX_IMAGE,
 )
 
 # %%

--- a/torchx/components/serve/serve.py
+++ b/torchx/components/serve/serve.py
@@ -7,12 +7,13 @@
 from typing import Dict, Optional
 
 import torchx.specs as specs
+from torchx.version import TORCHX_IMAGE
 
 
 def torchserve(
     model_path: str,
     management_api: str,
-    image: str = "495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx:latest",
+    image: str = TORCHX_IMAGE,
     params: Optional[Dict[str, object]] = None,
 ) -> specs.AppDef:
     """Deploys the provided model to the given torchserve management API

--- a/torchx/test/version_test.py
+++ b/torchx/test/version_test.py
@@ -13,3 +13,11 @@ class VersionTest(unittest.TestCase):
         import torchx
 
         self.assertIsNotNone(torchx.__version__)
+
+    def test_images(self) -> None:
+        from torchx.version import __version__, TORCHX_IMAGE, EXAMPLES_IMAGE
+
+        self.assertEqual(TORCHX_IMAGE, f"ghcr.io/pytorch/torchx:{__version__}")
+        self.assertEqual(
+            EXAMPLES_IMAGE, f"ghcr.io/pytorch/torchx-examples:{__version__}"
+        )

--- a/torchx/version.py
+++ b/torchx/version.py
@@ -15,3 +15,8 @@
 # 0.1.0rcN  # Release Candidate
 # 0.1.0  # Final release
 __version__ = "0.1.0.dev0"
+
+# Use the github container registry images corresponding to the current package
+# version.
+TORCHX_IMAGE = f"ghcr.io/pytorch/torchx:{__version__}"
+EXAMPLES_IMAGE = f"ghcr.io/pytorch/torchx-examples:{__version__}"


### PR DESCRIPTION
<!-- Change Summary -->

This sets up automatic push for the latest package version for the torchx container image and torchx-examples container image. For each container it pushes two tags, one with the version specified in version.py and the other with "latest".

I updated any usages of images to point to the new versioned containers.


Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

push to torchxcontainer branch + CI

https://github.com/pytorch/torchx/runs/2824238961?check_suite_focus=true

https://github.com/orgs/pytorch/packages?repo_name=torchx

https://github.com/orgs/pytorch/packages/container/package/torchx-examples
https://github.com/orgs/pytorch/packages/container/package/torchx
