### PR TITLE
kfpint: save tensorboard logs to same location as outputs

### DIFF
--- a/examples/apps/Dockerfile
+++ b/examples/apps/Dockerfile
@@ -1,6 +1,6 @@
 FROM pytorch/pytorch
 
-RUN pip install classy_vision pytorch-lightning fsspec[s3] torch-model-archiver captum
+RUN pip install classy_vision pytorch-lightning fsspec[s3] torch-model-archiver captum boto3
 
 WORKDIR /app
 

--- a/examples/apps/lightning_classy_vision/component.py
+++ b/examples/apps/lightning_classy_vision/component.py
@@ -23,7 +23,7 @@ def trainer(
     output_path: str,
     data_path: str,
     load_path: str = "",
-    log_dir: str = "/logs",
+    log_path: str = "/logs",
     resource: Optional[str] = None,
 ) -> torchx.AppDef:
     """Runs the example lightning_classy_vision app.
@@ -33,7 +33,7 @@ def trainer(
         output_path: output path for model checkpoints (e.g. file:///foo/bar)
         load_path: path to load pretrained model from
         data_path: path to the data to load
-        log_dir: path to save tensorboard logs to
+        log_path: path to save tensorboard logs to
         resource: the resources to use
     """
     return binary_component(
@@ -44,8 +44,8 @@ def trainer(
             output_path,
             "--load_path",
             load_path,
-            "--log_dir",
-            log_dir,
+            "--log_pat",
+            log_path,
             "--data_path",
             data_path,
         ],

--- a/examples/apps/lightning_classy_vision/train.py
+++ b/examples/apps/lightning_classy_vision/train.py
@@ -53,7 +53,10 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         required=True,
     )
     parser.add_argument(
-        "--log_dir", type=str, help="directory to place the logs", default="/tmp"
+        "--log_path",
+        type=str,
+        help="path to place the tensorboard logs",
+        default="/tmp",
     )
 
     return parser.parse_args(argv)
@@ -84,7 +87,7 @@ def main(argv: List[str]) -> None:
             model.load_from_checkpoint(checkpoint_path=args.load_path)
 
         logger = TensorBoardLogger(
-            save_dir=args.log_dir, version=1, name="lightning_logs"
+            save_dir=args.log_path, version=1, name="lightning_logs"
         )
 
         # Initialize a trainer

--- a/examples/pipelines/kfp/kfp_pipeline.py
+++ b/examples/pipelines/kfp/kfp_pipeline.py
@@ -64,7 +64,7 @@ parser.add_argument(
     required=True,
 )
 parser.add_argument(
-    "--log_dir", type=str, help="directory to place the logs", default="/tmp"
+    "--log_path", type=str, help="path to place the tensorboard logs", default="/tmp"
 )
 
 # %%
@@ -147,8 +147,8 @@ trainer_app: specs.AppDef = binary_component(
         args.output_path,
         "--load_path",
         args.load_path or "",
-        "--log_dir",
-        args.log_dir,
+        "--log_path",
+        args.log_path,
         "--data_path",
         args.data_path,
     ],

--- a/scripts/kfpint.py
+++ b/scripts/kfpint.py
@@ -187,6 +187,7 @@ def save_spec(path: str, build: BuildInfo) -> None:
     root = os.path.join(STORAGE_PATH, id)
     data = os.path.join(root, "data")
     output = os.path.join(root, "output")
+    logs = os.path.join(root, "logs")
 
     run(
         "examples/pipelines/kfp/kfp_pipeline.py",
@@ -196,6 +197,8 @@ def save_spec(path: str, build: BuildInfo) -> None:
         output,
         "--image",
         examples_image,
+        "--log_path",
+        logs,
         "--package_path",
         path,
         "--torchx_image",


### PR DESCRIPTION
<!-- Change Summary -->

We currently save tensorboard logs to /tmp in the integration tests. Change it to we save them to remote location with the rest of the outputs.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
script/kfpint.py
pytest
```