### PR TITLE
README + deps improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 # TorchX
 
 
+TorchX is a library containing standard DSLs for authoring and running PyTorch
+related components for an E2E production ML pipeline.
+
 For the latest documentation, please refer to our [website](https://pytorch.org/torchx).
 
 
@@ -18,19 +21,21 @@ TorchX Kubeflow Pipelines Support (torchx-kfp):
 
 ## Installation
 ```bash
-# install torchx sdk
+# install torchx sdk and CLI
 pip install torchx
 
 # install torchx kubeflow pipelines (kfp) support
-pip intall torchx-kfp
+pip intall torchx[kfp]
 ```
 
 ## Quickstart
-<TODO PLACEHOLDER>
+
+See the [quickstart guide](https://pytorch.org/torchx/latest/quickstart.html).
 
 ## Contributing
 
 We welcome PRs! See the [CONTRIBUTING](CONTRIBUTING.md) file.
 
 ## License
+
 TorchX is BSD licensed, as found in the [LICENSE](LICENSE) file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-torch>=1.8.1
 pyre-extensions
-# (optional) kfp==1.6.2
 docstring-parser==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         reqs = f.read()
 
     with open("dev-requirements.txt") as f:
-        test_reqs = f.read()
+        dev_reqs = f.read()
 
     version = get_version()
     print("-- Building version: " + version)
@@ -52,7 +52,6 @@ if __name__ == "__main__":
         keywords=["pytorch", "machine learning"],
         python_requires=">=3.8",
         install_requires=reqs.strip().split("\n"),
-        tests_requires=test_reqs.strip().split("\n"),
         include_package_data=True,
         packages=find_packages(exclude=("examples", "*.test", "aws*", "*.fb")),
         test_suite="torchx.test.suites.unittests",
@@ -60,6 +59,10 @@ if __name__ == "__main__":
             "console_scripts": [
                 "torchx=torchx.cli.main:main",
             ],
+        },
+        extras_require={
+            "kfp": ["kfp==1.6.2"],
+            "dev": dev_reqs,
         },
         # PyPI package information.
         classifiers=[


### PR DESCRIPTION
<!-- Change Summary -->

This updates the readme with missing sections as well as improves our deps handling to match. It also defines extras_require so you can install KFP dependencies via `pip install torchx[kfp]`.

TorchX has amazingly few dependencies for the core launcher + dsl.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
virtualenv /tmp/venv
source /tmp/venv/bin/activate.fish
pip install -e .
torchx run --scheduler local utils.echo.get_app_spec --msg test

pip install -e .[kfp]
python examples/pipelines/kfp/kfp_pipeline.py --data_path /tmp/ --output_path /tmp/ --package_path /tmp/pipeline.yaml
```
