### PR TITLE
Rename ``named_resource`` to ``named_resources``, make ``named_resources`` statically initialize resources

### DIFF
--- a/docs/source/components/base.rst
+++ b/docs/source/components/base.rst
@@ -4,8 +4,6 @@ Base
 .. automodule:: torchx.components.base
 .. currentmodule:: torchx.components.base
 
-.. autofunction:: named_resource
-
 .. automodule:: torchx.components.base.binary_component
 .. currentmodule:: torchx.components.base.binary_component
 .. autofunction:: binary_component

--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -70,11 +70,21 @@ representation:
 
 ::
 
- [torchx.schedulers]
+ [torchx.named_resources]
  gpu_x_2 = my_module.resources:gpu_x_2
 
 
 The named resource after that can be used in the following manner:
+
+.. code-block:: python
+
+  # my_module.component
+  from torchx.specs import AppDef, Role, named_resources
+  from torchx.components.base import torch_dist_role
+
+  app = AppDef(name="test_app", roles=[Role(.., resource=named_resources("gpu_x_2"))])
+
+or using ``torch.distributed.run``:
 
 .. code-block:: python
 

--- a/docs/source/specs.rst
+++ b/docs/source/specs.rst
@@ -24,6 +24,8 @@ Resource
 .. autoclass:: Resource
    :members:
 
+.. autofunction:: get_named_resources
+
 Macros
 ------------
 .. autoclass:: macros

--- a/examples/apps/lightning_classy_vision/component.py
+++ b/examples/apps/lightning_classy_vision/component.py
@@ -14,7 +14,7 @@ This is a component definition that runs the example lightning_classy_vision app
 from typing import Optional
 
 import torchx.specs.api as torchx
-from torchx.components.base import named_resource
+from torchx.components.base import named_resources
 from torchx.components.base.binary_component import binary_component
 
 
@@ -50,7 +50,7 @@ def trainer(
             data_path,
         ],
         image=image,
-        resource=named_resource(resource)
+        resource=named_resources[resource]
         if resource
         else torchx.Resource(cpu=1, gpu=0, memMB=1024),
     )
@@ -85,7 +85,7 @@ def interpret(
             output_path,
         ],
         image=image,
-        resource=named_resource(resource)
+        resource=named_resources[resource]
         if resource
         else torchx.Resource(cpu=1, gpu=0, memMB=1024),
     )

--- a/torchx/components/base/__init__.py
+++ b/torchx/components/base/__init__.py
@@ -12,7 +12,7 @@ TorchX's configurable extension points.
 """
 from typing import Any, Dict, List, Optional, Union
 
-from torchx.specs import named_resource
+from torchx.specs import named_resources
 from torchx.specs.api import NULL_RESOURCE, Resource, RetryPolicy, Role
 from torchx.util.entrypoints import load
 
@@ -23,7 +23,7 @@ def _resolve_resource(resource: Union[str, Resource]) -> Resource:
     if isinstance(resource, Resource):
         return resource
     else:
-        return named_resource(resource.lower())
+        return named_resources[resource.upper()]
 
 
 def torch_dist_role(

--- a/torchx/components/base/test/lib_test.py
+++ b/torchx/components/base/test/lib_test.py
@@ -18,7 +18,7 @@ class TorchxBaseLibTest(unittest.TestCase):
         expected_resources = {}
         with patch.object(metadata, "entry_points") as entry_points_mock:
             entry_points_mock.return_value = {}
-            with self.assertRaises(ValueError):
+            with self.assertRaises(KeyError):
                 torch_dist_role(
                     name="dist_role",
                     image="test_image",


### PR DESCRIPTION
Summary: Rename ``named_resource`` to ``named_resources``, make ``named_resources`` statically initialize resources

Reviewed By: kiukchung

Differential Revision: D29153123

