### PR TITLE
examples/pipelines/kfp: add intro pipeline example

### DIFF
--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -12,6 +12,7 @@ torchx.pipelines.kfp
 
 .. currentmodule:: torchx.pipelines.kfp.adapter
 
+.. autofunction:: container_from_app
 .. autofunction:: component_from_app
 .. autofunction:: component_spec_from_app
 

--- a/docs/source/pipelines/kfp.rst
+++ b/docs/source/pipelines/kfp.rst
@@ -1,6 +1,8 @@
 Kubeflow Pipelines
 ======================
 
-<TODO> describe KFP adapters and usage
+TorchX provides an adapter to run TorchX components as part of Kubeflow
+Pipelines. See :ref:`KubeFlow Pipelines Examples` and the
+:ref:`torchx.pipelines.kfp` for API reference.
 
 .. image:: kfp_diagram.jpg

--- a/examples/pipelines/kfp/advanced_pipeline.py
+++ b/examples/pipelines/kfp/advanced_pipeline.py
@@ -6,8 +6,8 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-KubeFlow Pipelines Example
-==========================
+Advanced KubeFlow Pipelines Example
+===================================
 
 This is an example pipeline using KubeFlow Pipelines built with only TorchX
 components.

--- a/examples/pipelines/kfp/intro_pipeline.py
+++ b/examples/pipelines/kfp/intro_pipeline.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Intro KubeFlow Pipelines Example
+================================
+
+This an introductory pipeline using KubeFlow Pipelines built with only TorchX
+components.
+
+TorchX is intended to allow making cross platform components. As such, we have
+a standard definition that uses adapters to convert it to the specific
+pipeline platform. This is an example of using the KFP adapter to run a TorchX
+component as part of a KubeFlow Pipeline.
+
+TorchX tries to leverage standard mechanisms wherever possible. For KFP we use
+the existing KFP pipeline definition syntax and add a single
+`component_from_app` conversion step to convert a TorchX component into one
+KFP can understand.
+
+Typically you have a separate component file but for this example we define the
+AppDef inline.
+"""
+
+import kfp
+from torchx import specs
+from torchx.components.base.binary_component import binary_component
+from torchx.pipelines.kfp.adapter import container_from_app
+
+
+def pipeline() -> None:
+    # First we define our AppDef for the component. We use the binary_component
+    # helper for making single node components. AppDef is a core part of TorchX
+    # and can be used to describe complex distributed multi container apps or
+    # just a single node component like here.
+    echo_app: specs.AppDef = binary_component(
+        name="examples-intro",
+        entrypoint="/bin/echo",
+        args=["Hello TorchX!"],
+        image="alpine",
+    )
+
+    # To convert the TorchX AppDef into a KFP container we use
+    # the container_from_app adapter. This takes generates a KFP component
+    # definition from the TorchX app def and instantiates it into a container.
+    echo_container: kfp.dsl.ContainerOp = container_from_app(echo_app)
+
+
+# %%
+# To generate the pipeline definition file we need to call into the KFP compiler
+# with our pipeline function.
+
+kfp.compiler.Compiler().compile(
+    pipeline_func=pipeline,
+    package_path="pipeline.yaml",
+)
+
+# %%
+# Once this has all run you should have a pipeline file (typically
+# pipeline.yaml) that you can upload to your KFP cluster via the UI or
+# a kfp.Client.
+#
+# See the
+# `KFP SDK Examples <https://www.kubeflow.org/docs/components/pipelines/tutorials/sdk-examples/#examples>`_
+# for more info on launching KFP pipelines.
+
+# %%
+# See the :ref:`Advanced KubeFlow Pipelines Example` for how to chain multiple
+# components together and use builtin components.

--- a/examples/pipelines/kfp/test/kfp_pipeline_test.py
+++ b/examples/pipelines/kfp/test/kfp_pipeline_test.py
@@ -17,8 +17,26 @@ class KFPPipelineTest(unittest.TestCase):
             orig_dir = os.getcwd()
             os.chdir(tmpdir)
 
-            sys.argv = ["kfp_pipeline.py", "--data_path", "foo", "--output_path", "bar"]
-            from examples.pipelines.kfp import kfp_pipeline  # noqa: F401
+            sys.argv = [
+                "advanced_pipeline.py",
+                "--data_path",
+                "foo",
+                "--output_path",
+                "bar",
+            ]
+            from examples.pipelines.kfp import advanced_pipeline  # noqa: F401
+
+            self.assertTrue(os.path.exists("pipeline.yaml"))
+
+            os.chdir(orig_dir)
+
+    def test_intro_pipeline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            orig_dir = os.getcwd()
+            os.chdir(tmpdir)
+
+            sys.argv = ["intro_pipeline.py"]
+            from examples.pipelines.kfp import intro_pipeline  # noqa: F401
 
             self.assertTrue(os.path.exists("pipeline.yaml"))
 

--- a/scripts/kfpint.py
+++ b/scripts/kfpint.py
@@ -190,7 +190,7 @@ def save_spec(path: str, build: BuildInfo) -> None:
     logs = os.path.join(root, "logs")
 
     run(
-        "examples/pipelines/kfp/kfp_pipeline.py",
+        "examples/pipelines/kfp/advanced_pipeline.py",
         "--data_path",
         data,
         "--output_path",

--- a/torchx/pipelines/kfp/adapter.py
+++ b/torchx/pipelines/kfp/adapter.py
@@ -192,3 +192,36 @@ def _ui_metadata_sidecar(
         ],
         mirror_volume_mounts=True,
     )
+
+
+def container_from_app(
+    app: api.AppDef,
+    *args: object,
+    ui_metadata: Optional[Mapping[str, object]] = None,
+    **kwargs: object,
+) -> dsl.ContainerOp:
+    """
+    container_from_app transforms the app into a KFP component and returns a
+    corresponding ContainerOp instance.
+
+    See component_from_app for description on the arguments. Any unspecified
+    arguments are passed through to the KFP container factory method.
+
+    >>> import kfp
+    >>> from torchx import specs
+    >>> from torchx.pipelines.kfp.adapter import container_from_app
+    >>> app_def = specs.AppDef(
+    ...     name="trainer",
+    ...     roles=[specs.Role("trainer", image="foo:latest")],
+    ... )
+    >>> def pipeline():
+    ...     trainer = container_from_app(app_def)
+    ...     print(trainer)
+    >>> kfp.compiler.Compiler().compile(
+    ...     pipeline_func=pipeline,
+    ...     package_path="/tmp/pipeline.yaml",
+    ... )
+    {'ContainerOp': {... 'name': 'trainer-trainer', ...}}
+    """
+    factory = component_from_app(app, ui_metadata)
+    return factory(*args, **kwargs)


### PR DESCRIPTION
<!-- Change Summary -->

This adds a barebones introductory KFP pipeline example that has a single TorchX component and is fully self contained.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

![2021-06-18-123714_1287x1300_scrot](https://user-images.githubusercontent.com/909104/122608925-f3f7a480-d031-11eb-95cb-ef3142005bc9.png)



Added unit test
