### PR TITLE
torchx/schedulers: add support for slurm

### DIFF
--- a/docs/source/schedulers/slurm.rst
+++ b/docs/source/schedulers/slurm.rst
@@ -1,4 +1,8 @@
 Slurm
 =================
-<COMING SOON>
 
+.. automodule:: torchx.schedulers.slurm_scheduler
+.. currentmodule:: torchx.schedulers.slurm_scheduler
+
+.. autoclass:: SlurmScheduler
+   :members:

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -153,6 +153,12 @@ class CmdRun(SubCommand):
             " just prints the scheduler request",
         )
         subparser.add_argument(
+            "--wait",
+            action="store_true",
+            default=False,
+            help="Wait for the app to finish before exiting.",
+        )
+        subparser.add_argument(
             "conf_file",
             type=str,
             help="Name of builtin conf or path of the *.torchx.conf file."
@@ -179,7 +185,7 @@ class CmdRun(SubCommand):
             print(f"Launched app: {app_handle}")
             status = runner.status(app_handle)
             print(f"App status: {status}")
-            if args.scheduler == "local":
+            if args.scheduler == "local" or args.wait:
                 runner.wait(app_handle)
             else:
                 print(f"Job URL: {none_throws(status).ui_url}")

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -8,6 +8,7 @@
 from typing import Dict
 
 import torchx.schedulers.local_scheduler as local_scheduler
+import torchx.schedulers.slurm_scheduler as slurm_scheduler
 from torchx.schedulers.api import Scheduler
 from torchx.specs.api import SchedulerBackend
 from torchx.util.entrypoints import load_group
@@ -24,6 +25,7 @@ def get_schedulers(
         default={
             "local": local_scheduler.create_scheduler,
             "default": local_scheduler.create_scheduler,
+            "slurm": slurm_scheduler.create_scheduler,
         },
         ignore_missing=True,
     )

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import csv
+import os.path
+import shlex
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from typing import Optional, List, Dict, Mapping
+
+from torchx.schedulers.api import AppDryRunInfo, DescribeAppResponse, Scheduler
+from torchx.specs.api import (
+    macros,
+    NONE,
+    AppDef,
+    RunConfig,
+    SchedulerBackend,
+    Role,
+    AppState,
+)
+
+SLURM_STATES: Mapping[str, AppState] = {
+    "BOOT_FAIL": AppState.FAILED,
+    "CANCELLED": AppState.CANCELLED,
+    "COMPLETED": AppState.SUCCEEDED,
+    "DEADLINE": AppState.FAILED,
+    "FAILED": AppState.FAILED,
+    "NODE_FAIL": AppState.FAILED,
+    "OUT_OF_MEMORY": AppState.FAILED,
+    "PENDING": AppState.PENDING,
+    "PREEMPTED": AppState.FAILED,
+    "RUNNING": AppState.RUNNING,
+    "REQUEUED": AppState.PENDING,
+    "RESIZING": AppState.PENDING,
+    "REVOKED": AppState.FAILED,
+    "SUSPENDED": AppState.PENDING,
+    "TIMEOUT": AppState.FAILED,
+}
+
+
+def _slurm_escape(s: str) -> str:
+    """
+    _slurm_escape escapes the argument and substitutes in the macros.app_id with
+    a shell expression that fills in SLURM_JOB_ID from env.
+    """
+    escaped_parts = [shlex.quote(part) for part in s.split(macros.app_id)]
+    return '"$SLURM_JOB_ID"'.join(escaped_parts)
+
+
+@dataclass
+class SlurmReplicaRequest:
+    """
+    Holds parameters for a single replica running on slurm and can be materialized down to a bash script.
+    """
+
+    dir: str
+    entrypoint: str
+    args: List[str]
+    opts: Dict[str, str]
+    env: Dict[str, str]
+
+    @classmethod
+    def from_role(cls, role: Role, cfg: RunConfig) -> "SlurmReplicaRequest":
+        opts = {k: str(v) for k, v in cfg.cfgs.items()}
+
+        if (resource := role.resource) != NONE:
+            if (cpu := resource.cpu) > 0:
+                opts["cpus-per-task"] = str(cpu)
+            if (memMB := resource.memMB) > 0:
+                opts["mem"] = str(memMB)
+            if (gpu := resource.gpu) > 0:
+                opts["gpus-per-task"] = str(gpu)
+
+        return cls(
+            dir=role.image,
+            entrypoint=role.entrypoint,
+            args=list(role.args),
+            opts=opts,
+            env=dict(role.env),
+        )
+
+    def materialize(self) -> str:
+        sbatch_opts = [f"#SBATCH --{key}={value}" for key, value in self.opts.items()]
+        sbatch_opts += [
+            f"#SBATCH --export={key}={value}" for key, value in self.env.items()
+        ]
+        sbatch_opts_str = "\n".join(sbatch_opts)
+
+        escaped_args = [_slurm_escape(arg) for arg in self.args]
+
+        return f"""#!/bin/sh
+{sbatch_opts_str}
+
+# exit on error
+set -e
+
+srun --chdir={self.dir} {self.entrypoint} {" ".join(escaped_args)}
+"""
+
+
+@dataclass
+class SlurmBatchRequest:
+    """
+    Holds parameters used to launch a slurm job via sbatch.
+    """
+
+    cmd: List[str]
+    replicas: Dict[str, SlurmReplicaRequest]
+
+
+class SlurmScheduler(Scheduler):
+    """
+    SlurmScheduler is a TorchX scheduling interface to slurm. TorchX expects
+    that slurm CLI tools are locally installed and job accounting is enabled.
+
+    Each app def is scheduled using a heterogenous job via sbatch.
+    Each replica of each role has a unique shell script generated with it's
+    resource allocations and args and then sbatch is used to launch all of them
+    together.
+
+    Logs are written to the default slurm log file.
+
+    Any scheduler options passed to it are added as SBATCH arguments to each replica.
+
+    For more info see:
+
+    * https://slurm.schedmd.com/sbatch.html
+    * https://slurm.schedmd.com/heterogeneous_jobs.html
+
+    .. code-block:: bash
+
+        $ torchx run --scheduler slurm utils.echo --msg hello
+        slurm://torchx_user/1234
+        $ torchx status slurm://torchx_user/1234
+        $ less slurm-1234.out
+        ...
+    """
+
+    def __init__(self, session_name: str) -> None:
+        super().__init__("slurm", session_name)
+
+    def schedule(self, dryrun_info: AppDryRunInfo[SlurmBatchRequest]) -> str:
+        req = dryrun_info.request
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for i, (name, body) in enumerate(req.replicas.items()):
+                path = os.path.join(tmpdir, name)
+                with open(path, "w") as f:
+                    f.write(body.materialize())
+
+                if i > 0:
+                    req.cmd.append(":")
+                req.cmd.append(path)
+
+            p = subprocess.run(req.cmd, stdout=subprocess.PIPE, check=True)
+            return p.stdout.decode("utf-8").strip()
+
+    def _submit_dryrun(
+        self, app: AppDef, cfg: RunConfig
+    ) -> AppDryRunInfo[SlurmBatchRequest]:
+        cmd = ["sbatch", "--parsable", "--job-name", app.name]
+        replicas = {}
+        for i, role in enumerate(app.roles):
+            for replica_id in range(role.num_replicas):
+                values = macros.Values(
+                    img_root=role.image,
+                    app_id=macros.app_id,
+                    replica_id=str(replica_id),
+                )
+                name = f"role-{i}-{role.name}-{replica_id}.sh"
+                replica_role = values.apply(role)
+                replicas[name] = SlurmReplicaRequest.from_role(replica_role, cfg)
+        req = SlurmBatchRequest(
+            cmd=cmd,
+            replicas=replicas,
+        )
+        return AppDryRunInfo(req, repr)
+
+    def _validate(self, app: AppDef, scheduler: SchedulerBackend) -> None:
+        # Skip validation step for slurm
+        pass
+
+    def _cancel_existing(self, app_id: str) -> None:
+        subprocess.run(["scancel", app_id], check=True)
+
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        p = subprocess.run(
+            ["sacct", "--parsable2", "-j", app_id], stdout=subprocess.PIPE, check=True
+        )
+        output = p.stdout.decode("utf-8").split("\n")
+        if len(output) <= 1:
+            return None
+
+        reader = csv.DictReader(output, delimiter="|")
+
+        resp = DescribeAppResponse(
+            app_id=app_id,
+        )
+        for row in reader:
+            if row["JobID"] == app_id:
+                state = row["State"]
+                resp.msg = state
+                state_enum = SLURM_STATES.get(state)
+                assert (
+                    state_enum
+                ), f"failed to translate slurm state {state} to torchx state"
+                resp.state = state_enum
+
+        return resp
+
+
+def create_scheduler(session_name: str) -> SlurmScheduler:
+    return SlurmScheduler(
+        session_name=session_name,
+    )

--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -1,0 +1,206 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import subprocess
+import unittest
+from unittest.mock import patch, MagicMock, call
+
+from torchx import specs
+from torchx.schedulers.api import DescribeAppResponse
+from torchx.schedulers.slurm_scheduler import (
+    create_scheduler,
+    SlurmScheduler,
+    SlurmReplicaRequest,
+    SlurmBatchRequest,
+)
+
+
+class SlurmSchedulerTest(unittest.TestCase):
+    def test_create_scheduler(self) -> None:
+        scheduler = create_scheduler("foo")
+        self.assertIsInstance(scheduler, SlurmScheduler)
+
+    def test_replica_request(self) -> None:
+        role = specs.Role(
+            name="foo",
+            image="/some/path",
+            entrypoint="echo",
+            args=["hello slurm", "test"],
+            num_replicas=5,
+            resource=specs.Resource(
+                cpu=2,
+                memMB=10,
+                gpu=3,
+            ),
+        )
+        script = SlurmReplicaRequest.from_role(role, specs.RunConfig()).materialize()
+        self.assertEqual(
+            script,
+            """#!/bin/sh
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=10
+#SBATCH --gpus-per-task=3
+
+# exit on error
+set -e
+
+srun --chdir=/some/path echo 'hello slurm' test
+""",
+        )
+
+    def test_replica_request_app_id(self) -> None:
+        role = specs.Role(
+            name="foo",
+            image="/some/path",
+            entrypoint="echo",
+            args=[f"hello {specs.macros.app_id}"],
+        )
+        script = SlurmReplicaRequest.from_role(role, specs.RunConfig()).materialize()
+        self.assertIn(
+            "echo 'hello '\"$SLURM_JOB_ID\"''",
+            script,
+        )
+
+    def test_replica_request_run_config(self) -> None:
+        role = specs.Role(
+            name="foo",
+            image="/some/path",
+            entrypoint="echo",
+            args=["hello"],
+        )
+        cfg = specs.RunConfig()
+        cfg.set("foo", "bar")
+        script = SlurmReplicaRequest.from_role(role, cfg).materialize()
+        self.assertIn(
+            "#SBATCH --foo=bar",
+            script,
+        )
+
+    def test_dryrun_multi_role(self) -> None:
+        scheduler = create_scheduler("foo")
+        app = specs.AppDef(
+            name="foo",
+            roles=[
+                specs.Role(
+                    name="a",
+                    image="/some/path",
+                    entrypoint="echo",
+                    args=[specs.macros.replica_id, f"hello {specs.macros.app_id}"],
+                    num_replicas=2,
+                ),
+                specs.Role(
+                    name="b",
+                    image="/some/path",
+                    entrypoint="echo",
+                ),
+            ],
+        )
+        info = scheduler.submit_dryrun(app, specs.RunConfig())
+        req = info.request
+        self.assertIsInstance(req, SlurmBatchRequest)
+        self.assertEqual(req.cmd, ["sbatch", "--parsable", "--job-name", "foo"])
+        self.assertEqual(
+            set(req.replicas.keys()),
+            {"role-0-a-0.sh", "role-0-a-1.sh", "role-1-b-0.sh"},
+        )
+
+        # check macro substitution
+        self.assertIn(
+            "echo 1 'hello '\"$SLURM_JOB_ID\"''",
+            req.replicas["role-0-a-1.sh"].materialize(),
+        )
+
+    @patch("subprocess.run")
+    def test_run_multi_role(self, run: MagicMock) -> None:
+        run.return_value.stdout = b"1234"
+        scheduler = create_scheduler("foo")
+        app = specs.AppDef(
+            name="foo",
+            roles=[
+                specs.Role(
+                    name="a",
+                    image="/some/path",
+                    entrypoint="echo",
+                    args=[specs.macros.replica_id, f"hello {specs.macros.app_id}"],
+                    num_replicas=2,
+                ),
+                specs.Role(
+                    name="b",
+                    image="/some/path",
+                    entrypoint="echo",
+                ),
+            ],
+        )
+        app_id = scheduler.submit(app, specs.RunConfig())
+        self.assertEqual(app_id, "1234")
+
+        self.assertEqual(run.call_count, 1)
+        self.assertEqual(
+            run.call_args.kwargs, {"stdout": subprocess.PIPE, "check": True}
+        )
+        (args,) = run.call_args.args
+        self.assertEqual(len(args), 9)
+        self.assertEqual(args[:4], ["sbatch", "--parsable", "--job-name", "foo"])
+        self.assertTrue(args[4].endswith("role-0-a-0.sh"))
+        self.assertEqual(args[5], ":")
+        self.assertTrue(args[6].endswith("role-0-a-1.sh"))
+        self.assertEqual(args[7], ":")
+        self.assertTrue(args[8].endswith("role-1-b-0.sh"))
+
+    @patch("torchx.schedulers.slurm_scheduler.SlurmScheduler.describe")
+    @patch("subprocess.run")
+    def test_cancel(self, run: MagicMock, describe: MagicMock) -> None:
+        describe.return_value = DescribeAppResponse()
+
+        scheduler = create_scheduler("foo")
+        scheduler.cancel("1234")
+
+        self.assertEqual(run.call_count, 1)
+        self.assertEqual(run.call_args, call(["scancel", "1234"], check=True))
+
+    @patch("subprocess.run")
+    def test_describe_completed(self, run: MagicMock) -> None:
+        run.return_value.stdout = b"""JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode
+53|echo|compute||1|COMPLETED|0:0
+53.batch|batch|||1|COMPLETED|0:0
+53.0|echo|||1|COMPLETED|0:0"""
+
+        scheduler = create_scheduler("foo")
+        out = scheduler.describe("53")
+
+        self.assertEqual(run.call_count, 1)
+        self.assertEqual(
+            run.call_args,
+            call(
+                ["sacct", "--parsable2", "-j", "53"], stdout=subprocess.PIPE, check=True
+            ),
+        )
+
+        self.assertIsNotNone(out)
+        self.assertEqual(out.app_id, "53")
+        self.assertEqual(out.msg, "COMPLETED")
+        self.assertEqual(out.state, specs.AppState.SUCCEEDED)
+
+    @patch("subprocess.run")
+    def test_describe_running(self, run: MagicMock) -> None:
+        run.return_value.stdout = b"""JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode
+54|echo|compute||1|RUNNING|0:0"""
+
+        scheduler = create_scheduler("foo")
+        out = scheduler.describe("54")
+
+        self.assertEqual(run.call_count, 1)
+        self.assertEqual(
+            run.call_args,
+            call(
+                ["sacct", "--parsable2", "-j", "54"], stdout=subprocess.PIPE, check=True
+            ),
+        )
+
+        self.assertIsNotNone(out)
+        self.assertEqual(out.app_id, "54")
+        self.assertEqual(out.msg, "RUNNING")
+        self.assertEqual(out.state, specs.AppState.RUNNING)


### PR DESCRIPTION
<!-- Change Summary -->

  SlurmScheduler is a TorchX scheduling interface to slurm. TorchX expects
  that slurm CLI tools are locally installed and job accounting is enabled.

  Each app def is scheduled using a heterogenous job via sbatch.
  Each replica of each role has a unique shell script generated with it's
  resource allocations and args and then sbatch is used to launch all of them
  together.

  Logs are written to the default slurm log file.

  For more info see:

  * https://slurm.schedmd.com/sbatch.html
  * https://slurm.schedmd.com/heterogeneous_jobs.html

```
$ torchx run --scheduler slurm utils.echo --msg hello
slurm://torchx_user/1234
$ torchx status slurm://torchx_user/1234
$ less slurm-1234.out
```


Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Setup test slurm cluster with job accounting enabled

```
$ python setup.py bdist_wheel; and scp dist/torchx-0.1.0.dev2-py3-none-any.whl user@host:
$ ssh user@host
$ python3.8 -m pip install --user ./torchx-0.1.0.dev2-py3-none-any.whl

$ torchx run --scheduler slurm tests.echo
{"session": "", "scheduler": "slurm", "api": "schedule", "app_id": "55", "runcfg": "{}", "raw_exception": null, "source": "<unknown>"}
=== RUN RESULT ===
Launched app: slurm://torchx_ubuntu/55
{"session": "55", "scheduler": "slurm", "api": "status", "app_id": "55", "runcfg": null, "raw_exception": null, "source": "<unknown>"}
App status: {
  "state": 0,
  "num_restarts": -1,
  "msg": "<NONE>",
  "ui_url": null,
  "roles": [],
  "structured_error_msg": "<NONE>"
}
$ torchx status slurm://torchx_ubuntu/55
{"session": "55", "scheduler": "slurm", "api": "status", "app_id": "55", "runcfg": null, "raw_exception": null, "source": "<unknown>"}
AppDef:
  State: SUCCEEDED
  Num Restarts: -1
Roles:
$ cat slurm-55.out 
hello world
```