### PR TITLE
Remove ``AppDef`` builder methods

### DIFF
--- a/examples/apps/datapreproc/component.py
+++ b/examples/apps/datapreproc/component.py
@@ -54,6 +54,7 @@ def data_preproc(
         ],
         env=env,
         resource=resource,
-    ).replicas(1)
+        num_replicas=1,
+    )
 
-    return specs.AppDef(name).of(ddp_role)
+    return specs.AppDef(name, roles=[ddp_role])

--- a/torchx/cli/test/cmd_describe_test.py
+++ b/torchx/cli/test/cmd_describe_test.py
@@ -26,7 +26,7 @@ class CmdDescribeTest(unittest.TestCase):
             num_replicas=2,
             nnodes="2:3",
         )
-        return AppDef("my_train_job").of(trainer)
+        return AppDef("my_train_job", roles=[trainer])
 
     def test_run(self) -> None:
         parser = argparse.ArgumentParser()

--- a/torchx/cli/test/cmd_log_test.py
+++ b/torchx/cli/test/cmd_log_test.py
@@ -11,7 +11,7 @@ from typing import Iterator, Optional
 from unittest.mock import MagicMock, patch
 
 from torchx.cli.cmd_log import ENDC, GREEN, get_logs
-from torchx.specs.api import AppDef, Role, parse_app_handle
+from torchx.specs import AppDef, Role, parse_app_handle
 
 
 class SentinelError(Exception):
@@ -31,9 +31,12 @@ class MockRunner:
 
     def describe(self, app_handle: str) -> AppDef:
         scheduler_backend, session_name, app_id = parse_app_handle(app_handle)
-        return AppDef(name=app_id).of(
-            Role(name="master", image="test_image").replicas(1),
-            Role(name="trainer", image="test_image").replicas(3),
+        return AppDef(
+            name=app_id,
+            roles=[
+                Role(name="master", image="test_image", num_replicas=1),
+                Role(name="trainer", image="test_image", num_replicas=3),
+            ],
         )
 
     def log_lines(

--- a/torchx/components/base/roles.py
+++ b/torchx/components/base/roles.py
@@ -106,15 +106,16 @@ def create_torch_dist_role(
         entrypoint = os.path.join(macros.img_root, entrypoint)
 
     args = [*torch_run_args, entrypoint, *args]
-    return (
-        Role(
-            name,
-            image=image,
-            base_image=base_image,
-            resource=resource,
-            port_map=port_map,
-        )
-        .runs(entrypoint_override, *args, **env)
-        .replicas(num_replicas)
-        .with_retry_policy(retry_policy, max_retries)
+    return Role(
+        name,
+        image=image,
+        base_image=base_image,
+        entrypoint=entrypoint_override,
+        args=args,
+        env=env,
+        num_replicas=num_replicas,
+        retry_policy=retry_policy,
+        max_retries=max_retries,
+        resource=resource,
+        port_map=port_map,
     )

--- a/torchx/components/base/test/roles_test.py
+++ b/torchx/components/base/test/roles_test.py
@@ -33,7 +33,8 @@ class TorchDistRoleBuilderTest(unittest.TestCase):
             nnodes="2:4",
             max_restarts=3,
             no_python=True,
-        ).replicas(2)
+            num_replicas=2,
+        )
         self.assertEqual("elastic_trainer", elastic_trainer.name)
         self.assertEqual("python", elastic_trainer.entrypoint)
         self.assertEqual(
@@ -153,7 +154,8 @@ class TorchDistRoleBuilderTest(unittest.TestCase):
             nnodes="2:4",
             rdzv_backend="etcd",
             rdzv_id="foobar",
-        ).replicas(3)
+            num_replicas=3,
+        )
 
         # this is effectively JSON
         elastic_json = asdict(role)

--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -63,4 +63,4 @@ def ddp(
         max_restarts=0,
     )
 
-    return specs.AppDef(name).of(ddp_role)
+    return specs.AppDef(name, roles=[ddp_role])

--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -55,11 +55,12 @@ def ddp(
         base_image=base_image,
         entrypoint=entrypoint,
         resource=resource or specs.NULL_RESOURCE,
+        num_replicas=nnodes,
         script_args=list(script_args),
         script_envs=env,
         nproc_per_node=nproc_per_node,
         nnodes=nnodes,
         max_restarts=0,
-    ).replicas(nnodes)
+    )
 
     return specs.AppDef(name).of(ddp_role)

--- a/torchx/pipelines/kfp/test/adapter_test.py
+++ b/torchx/pipelines/kfp/test/adapter_test.py
@@ -28,27 +28,22 @@ class KFPSpecsTest(unittest.TestCase):
     """
 
     def _test_app(self) -> api.AppDef:
-        trainer_role = (
-            api.Role(
-                name="trainer",
-                image="pytorch/torchx:latest",
-                resource=api.Resource(
-                    cpu=2,
-                    memMB=3000,
-                    gpu=4,
-                ),
-                port_map={"foo": 1234},
-            )
-            .runs(
-                "main",
-                "--output-path",
-                "blah",
-                FOO="bar",
-            )
-            .replicas(1)
+        trainer_role = api.Role(
+            name="trainer",
+            image="pytorch/torchx:latest",
+            entrypoint="main",
+            args=["--output-path", "blah"],
+            env={"FOO": "bar"},
+            resource=api.Resource(
+                cpu=2,
+                memMB=3000,
+                gpu=4,
+            ),
+            port_map={"foo": 1234},
+            num_replicas=1,
         )
 
-        return api.AppDef("test").of(trainer_role)
+        return api.AppDef("test", roles=[trainer_role])
 
     def _compile_pipeline(self, pipeline: Callable[[], None]) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -248,7 +248,7 @@ class Runner:
             if role.num_replicas <= 0:
                 raise ValueError(
                     f"Non-positive replicas for role: {role.name}."
-                    f" Did you forget to call role.replicas(positive_number)?"
+                    f" Did you forget to set role.num_replicas?"
                 )
         sched = self._scheduler(scheduler)
         sched._validate(app, scheduler)

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -236,7 +236,7 @@ class Runner:
         # input validation
         if not app.roles:
             raise ValueError(
-                f"No roles for app: {app.name}. Did you forget to call app.of(roles..)?"
+                f"No roles for app: {app.name}. Did you forget to add roles to AppDef?"
             )
 
         for role in app.roles:
@@ -394,7 +394,7 @@ class Runner:
             if not app:
                 desc = scheduler.describe(app_id)
                 if desc:
-                    app = AppDef(name=app_id).of(*desc.roles)
+                    app = AppDef(name=app_id, roles=desc.roles)
             return app
 
     def log_lines(

--- a/torchx/runner/test/resource/distributed.py
+++ b/torchx/runner/test/resource/distributed.py
@@ -37,16 +37,16 @@ def ddp(
     if env:
         app_env.update(env)
     entrypoint = os.path.join(specs.macros.img_root, script)
-    ddp_role = (
-        specs.Role(
-            name=role,
-            image="dummy_image",
-            resource=specs.Resource(cpu=1, gpu=0, memMB=1),
-        )
-        .runs(entrypoint, *script_args, **app_env)
-        .replicas(nnodes)
+    ddp_role = specs.Role(
+        name=role,
+        image="dummy_image",
+        entrypoint=entrypoint,
+        args=list(script_args),
+        env=app_env,
+        num_replicas=nnodes,
+        resource=specs.Resource(cpu=1, gpu=0, memMB=1),
     )
 
     # get app name from cli or extract from fbpkg. Note that fbpkg name can has "."
     # but not allowed in app name.
-    return specs.AppDef(name).of(ddp_role)
+    return specs.AppDef(name, roles=[ddp_role])

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -280,21 +280,6 @@ class AppDef:
     roles: List[Role] = field(default_factory=list)
     metadata: Dict[str, str] = field(default_factory=dict)
 
-    def of(self, *roles: Role) -> "AppDef":
-        self.roles += [*roles]
-        return self
-
-    def add_metadata(self, key: str, value: str) -> "AppDef":
-        """
-        Adds metadata to the application.
-        .. note:: If the key already exists, this method overwrites the metadata value.
-        """
-        self.metadata[key] = value
-        return self
-
-    def get_metadata(self, key: str) -> Optional[str]:
-        return self.metadata.get(key)
-
 
 class AppState(int, Enum):
     """

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -194,9 +194,9 @@ class AppDefTest(unittest.TestCase):
         self.assertEqual(0, len(app.roles))
 
     def test_getset_metadata(self) -> None:
-        app = AppDef(name="test_app").add_metadata("test_key", "test_value")
-        self.assertEqual("test_value", app.get_metadata("test_key"))
-        self.assertEqual(None, app.get_metadata("non_existent"))
+        app = AppDef(name="test_app", metadata={"test_key": "test_value"})
+        self.assertEqual("test_value", app.metadata["test_key"])
+        self.assertEqual(None, app.metadata.get("non_existent"))
 
 
 class RunConfigTest(unittest.TestCase):


### PR DESCRIPTION
Summary: The diff removes ``of``, ``get_metadata`` and ``add_metadata`` methods from the ``AppDef`` class

Reviewed By: kiukchung

Differential Revision: D29176342

