### PR TITLE
docs: add ipynb notebook links to examples

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -37,3 +37,7 @@ jobs:
         run: |
           cd docs
           make html
+      - name: Papermill
+        run: |
+          cd docs
+          make papermill

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ clean:
 	rm -rf "$(BUILDDIR)"
 	rm -rf "$(SOURCEDIR)/examples_apps" "$(SOURCEDIR)/examples_pipelines"
 
-.PHONY: help Makefile clean livehtml
+.PHONY: help Makefile clean livehtml papermill
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
@@ -31,3 +31,6 @@ clean:
 # optional live version
 livehtml:
 	sphinx-autobuild --watch ../torchx --watch ../examples --re-ignore ".*examples_.*" "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+papermill: html
+	./papermill.sh

--- a/docs/papermill.sh
+++ b/docs/papermill.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+WORK_DIR=/tmp/papermill
+
+set -e
+mkdir -p "$WORK_DIR"
+files="$(find "$(pwd)"/build -name '*.ipynb')"
+for file in $files
+do
+  echo "Processing $file..."
+  (cd "$WORK_DIR" && papermill "$file" /tmp/papermill-build.ipynb)
+done

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,5 @@ sphinx==4.0.2
 sphinx-gallery
 sphinxcontrib.katex
 matplotlib
+papermill
+ipykernel

--- a/docs/source/_static/css/torchx.css
+++ b/docs/source/_static/css/torchx.css
@@ -13,3 +13,17 @@ article.pytorch-article .py dt a[title] {
 article.pytorch-article .py dt span.pre {
   padding: 0;
 }
+
+#torchx-google-colab-link, #torchx-download-notebook-link,
+#torchx-github-view-link {
+  padding-bottom: 10px;
+  border-bottom: 1px solid #f3f4f7;
+  padding-right: 40px;
+  display: flex;
+  align-items: center;
+}
+#torchx-google-colab-link:hover, #torchx-download-notebook-link:hover,
+#torchx-github-view-link:hover {
+  border-bottom-color: #e44c2c;
+  color: #e44c2c;
+}

--- a/docs/source/_static/js/torchx.js
+++ b/docs/source/_static/js/torchx.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+var downloadNote = $(".sphx-glr-download-link-note.admonition.note");
+if (downloadNote.length >= 1) {
+    var tutorialUrlArray = $("#tutorial-type").text().split('/');
+        tutorialUrlArray[0] = tutorialUrlArray[0].replace("examples_", "")
+
+    var version = $(".version").text().trim().split(" ")[0].substr(1);
+
+    var githubLink = "https://github.com/pytorch/torchx/blob/master/examples/" + tutorialUrlArray.join("/") + ".py",
+        notebookLink = $(".reference.download")[1].href,
+        notebookDownloadPath = notebookLink.split('_downloads')[1],
+        colabLink = "https://colab.research.google.com/github/pytorch/torchx/blob/gh-pages/" + version + "/_downloads" + notebookDownloadPath;
+
+    $("#torchx-google-colab-link").wrap("<a href=" + colabLink + " data-behavior='call-to-action-event' data-response='Run in Google Colab' target='_blank'/>");
+    $("#torchx-download-notebook-link").wrap("<a href=" + notebookLink + " data-behavior='call-to-action-event' data-response='Download Notebook'/>");
+    $("#torchx-github-view-link").wrap("<a href=" + githubLink + " data-behavior='call-to-action-event' data-response='View on Github' target='_blank'/>");
+} else {
+    $(".pytorch-call-to-action-links").hide();
+}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -6,3 +6,48 @@
     </div>
     {% include "searchbox.html" %}
 {% endblock %}
+
+{%- block content %}
+  {% if pagename.startswith("examples") %}
+  <div class="pytorch-call-to-action-links">
+    <div id="tutorial-type">{{ pagename }}</div>
+
+    <div id="torchx-google-colab-link">
+      <img class="call-to-action-img" src="{{ pathto('_static/images/pytorch-colab.svg', 1) }}"/>
+      <div class="call-to-action-desktop-view">Run in Google Colab</div>
+      <div class="call-to-action-mobile-view">Colab</div>
+    </div>
+    <div id="torchx-download-notebook-link">
+      <img class="call-to-action-notebook-img" src="{{ pathto('_static/images/pytorch-download.svg', 1) }}"/>
+      <div class="call-to-action-desktop-view">Download Notebook</div>
+      <div class="call-to-action-mobile-view">Notebook</div>
+    </div>
+    <div id="torchx-github-view-link">
+      <img class="call-to-action-img" src="{{ pathto('_static/images/pytorch-github.svg', 1) }}"/>
+      <div class="call-to-action-desktop-view">View on GitHub</div>
+      <div class="call-to-action-mobile-view">GitHub</div>
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- copied from pytorch_sphinx_theme -->
+  {% if theme_style_external_links|tobool %}
+  <div class="rst-content style-external-links">
+  {% else %}
+  <div class="rst-content">
+  {% endif %}
+    <div role="main" class="main-content" itemscope="itemscope" itemtype="http://schema.org/Article">
+    {%- block document %}
+     <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
+      {% block body %}{% endblock %}
+     </article>
+     {% if self.comments()|trim %}
+     <div class="articleComments">
+      {% block comments %}{% endblock %}
+     </div>
+     {% endif%}
+    </div>
+    {%- endblock %}
+    {% include "footer.html" %}
+  </div>
+{%- endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import subprocess
 import sys
 
 import pytorch_sphinx_theme
@@ -151,6 +152,9 @@ html_static_path = ["_static"]
 html_css_files = [
     "https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css",
     "css/torchx.css",
+]
+html_js_files = [
+    "js/torchx.js",
 ]
 
 
@@ -294,6 +298,27 @@ TypedField.make_field = patched_make_field
 
 
 # -- Options for Sphinx-Gallery -----
+
+tags_raw = subprocess.check_output(["git", "tag", "-l"])
+tags = set(tags_raw.decode("utf-8").strip().split("\n"))
+
+if version in tags:
+    notebook_version = version
+    code_url = (
+        f"https://github.com/pytorch/torchx/archive/refs/tags/{notebook_version}.tar.gz"
+    )
+else:
+    notebook_version = "master"
+    code_url = "https://github.com/pytorch/torchx/archive/refs/heads/master.tar.gz"
+
+first_notebook_cell = f"""
+!pip install torchx
+!wget --no-clobber {code_url}
+!tar xvf {notebook_version}.tar.gz torchx-{notebook_version} --strip-components=1
+
+NOTEBOOK = True
+""".strip()
+
 sphinx_gallery_conf = {
     "examples_dirs": [
         "../../examples/apps",
@@ -303,4 +328,5 @@ sphinx_gallery_conf = {
         "examples_apps",
         "examples_pipelines",
     ],
+    "first_notebook_cell": first_notebook_cell,
 }

--- a/examples/apps/datapreproc/datapreproc.py
+++ b/examples/apps/datapreproc/datapreproc.py
@@ -115,5 +115,5 @@ def main(argv: List[str]) -> None:
         fs.put(tar_path, rpaths[0])
 
 
-if __name__ == "__main__":
+if __name__ == "__main__" and "NOTEBOOK" not in globals():
     main(sys.argv[1:])

--- a/examples/apps/lightning_classy_vision/interpret.py
+++ b/examples/apps/lightning_classy_vision/interpret.py
@@ -28,6 +28,10 @@ from typing import List
 
 import fsspec
 import torch
+
+# ensure data and module are on the path
+sys.path.append("examples/apps/lightning_classy_vision")
+
 from data import TinyImageNetDataModule, download_data
 from model import TinyImageNetModel
 
@@ -126,5 +130,5 @@ def main(argv: List[str]) -> None:
                 fig.savefig(f)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__" and "NOTEBOOK" not in globals():
     main(sys.argv[1:])

--- a/examples/apps/lightning_classy_vision/train.py
+++ b/examples/apps/lightning_classy_vision/train.py
@@ -23,10 +23,13 @@ import tempfile
 from typing import List
 
 import pytorch_lightning as pl
-from data import TinyImageNetDataModule, download_data
-from model import TinyImageNetModel, export_inference_model
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
+
+# ensure data and module are on the path
+sys.path.append("examples/apps/lightning_classy_vision")
+from data import TinyImageNetDataModule, download_data
+from model import TinyImageNetModel, export_inference_model
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
@@ -106,5 +109,5 @@ def main(argv: List[str]) -> None:
             export_inference_model(model, args.output_path, tmpdir)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__" and "NOTEBOOK" not in globals():
     main(sys.argv[1:])

--- a/examples/pipelines/kfp/advanced_pipeline.py
+++ b/examples/pipelines/kfp/advanced_pipeline.py
@@ -100,9 +100,22 @@ parser.add_argument(
     default="pipeline.yaml",
 )
 
+# %% Parse the arguments, you'll need to set these accordingly if running from a
+# notebook.
+
 import sys
 
-args: argparse.Namespace = parser.parse_args(sys.argv[1:])
+if "NOTEBOOK" in globals():
+    argv = [
+        "--data_path",
+        "/tmp/data",
+        "--output_path",
+        "/tmp/output",
+    ]
+else:
+    argv = sys.argv[1:]
+
+args: argparse.Namespace = parser.parse_args(argv)
 
 # %%
 # Creating the Components
@@ -201,7 +214,8 @@ serve_comp: ContainerFactory = component_from_app(serve_app)
 # train components and produces images with integrated gradient results.
 
 # make sure examples is on the path
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if "__file__" in globals():
+    sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from examples.apps.lightning_classy_vision.component import interpret
 


### PR DESCRIPTION
<!-- Change Summary -->

This adds ipynb notebook links to Google collab as well as downloading to run locally for all generated examples. 

Since we need these examples to run from both CLI as well as jupyter notebook I've added a new first cell to all notebooks that will:

1. install torchx if not installed
2. fetch the examples code from github for the current version
3. set the `NOTEBOOK = True` variable so scripts can change their behavior depending on if they're in a notebook or not.

I've added a github workflows step to run papermill on all the generated notebooks to ensure that they're standalone and runnable.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
make -C docs clean html papermill
```
![2021-06-22-145736_1264x1329_scrot](https://user-images.githubusercontent.com/909104/123005296-badd6e00-d36a-11eb-8daa-84f431558056.png)

