### PR TITLE
pin dev-requirements.txt to torch 1.8.1 and torchvision 0.9.1 until classy-vision is torch 1.9.0 compliant

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,8 +5,12 @@ pyre-extensions>=0.0.21
 black>=21.5b1
 usort==0.6.4
 pytorch-lightning>=0.5.3
-torch>=1.8.1
-torchvision>=0.9.1
+# TODO update to 1.9.0 once classy-vision is 1.9 compliant
+# see: https://github.com/facebookresearch/ClassyVision/issues/749
+# torch and torch vision versions need to be updated simultaneously
+# see: https://github.com/pytorch/vision#installation
+torch==1.8.1
+torchvision==0.9.1
 classy-vision>=0.5.0
 flake8==3.9.0
 ts>=0.5.1

--- a/examples/apps/lightning_classy_vision/interpret.py
+++ b/examples/apps/lightning_classy_vision/interpret.py
@@ -63,7 +63,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def convert_to_rgb(arr: torch.Tensor) -> np.ndarray:
+def convert_to_rgb(arr: torch.Tensor) -> np.ndarray:  # pyre-ignore[24]
     """
     This converts the image from a torch tensor with size (1, 1, 64, 64) to
     numpy array with size (64, 64, 3).


### PR DESCRIPTION
Summary: classy-vision 0.5.0 is not compatible with torch 1.9.0, hence pin to torch 1.8.1. Fixes: https://github.com/pytorch/torchx/runs/2888860646?check_suite_focus=true

Differential Revision: D29316429

