### PR TITLE
Refactor components discovery logic

### DIFF
--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -107,16 +107,36 @@ when they run
 
  $ torchx builtins
 
-Custom components can be registered via the following endpoint:
+Custom components can be registered via the following modification of the ``entry_points.txt``:
 
 ::
 
  [torchx.components]
- custom_component = my_module.components:my_component
+ foo = my_project.bar
+
+The line above registers a group ``foo`` that is associated with the module ``my_project.bar``.
+Torchx will recursively traverse lowest level dir associated with the ``my_project.bar`` and will find
+all defined components.
+
+.. note:: If there are two registry entries, e.g. ``foo = my_project.bar`` and ``test = my_project``
+          there will be two sets of overlapping components with different aliases.
 
 
-Custom components can be executed in the following manner:
+After registration, torchx cli will display registered components via:
 
 .. code-block:: shell-session
 
- $ torchx run --scheduler local --scheduler_args image_fetcher=...,root_dir=/tmp custom_component -- --name "test app"
+ $ torchx builtins
+
+If ``my_project.bar`` had the following directory structure:
+
+::
+
+ $PROJECT_ROOT/my_project/bar/
+     |- baz.py
+
+And `baz.py` defines a component (function) called `trainer`. Then the component can be run as a job in the following manner:
+
+.. code-block:: shell-session
+
+ $ torchx run foo.baz.trainer -- --name "test app"

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -5,20 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import glob
-import importlib
-import os
-from dataclasses import dataclass
-from inspect import getmembers, isfunction
-from typing import Dict, List, Optional, Union
+from dataclasses import asdict
+from pprint import pformat
+from typing import Dict, List, Union, cast
 
 import torchx.specs as specs
 from pyre_extensions import none_throws
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner
-from torchx.specs.file_linter import get_fn_docstring, validate
-from torchx.util import entrypoints
-from torchx.util.io import COMPONENTS_DIR, get_abspath, read_conf_file
+from torchx.specs.finder import get_components, _Component
 from torchx.util.types import to_dict
 
 
@@ -38,96 +33,19 @@ def _parse_run_config(arg: str) -> specs.RunConfig:
     return conf
 
 
-def _to_module(filepath: str) -> str:
-    path, _ = os.path.splitext(filepath)
-    return path.replace(os.path.sep, ".")
-
-
-def _get_builtin_description(filepath: str, function_name: str) -> Optional[str]:
-    source = read_conf_file(filepath)
-    if len(validate(source, torchx_function=function_name)) != 0:
-        return None
-
-    func_definition, _ = none_throws(get_fn_docstring(source, function_name))
-    return func_definition
-
-
-@dataclass
-class BuiltinComponent:
-    definition: str
-    description: str
-
-
-def _get_component_definition(module: str, function_name: str) -> str:
-    if module.startswith("torchx.components"):
-        module = module.split("torchx.components.")[1]
-    return f"{module}.{function_name}"
-
-
-def _to_relative(filepath: str) -> str:
-    if os.path.isabs(filepath):
-        # make path torchx/components/$suffix out of the abs
-        rel_path = filepath.split(str(COMPONENTS_DIR))[1]
-        return f"{str(COMPONENTS_DIR)}{rel_path}"
-    else:
-        return os.path.join(str(COMPONENTS_DIR), filepath)
-
-
-def _get_components_from_file(filepath: str) -> List[BuiltinComponent]:
-    components_path = _to_relative(filepath)
-    components_module_path = _to_module(components_path)
-    module = importlib.import_module(components_module_path)
-    functions = getmembers(module, isfunction)
-    buitin_functions = []
-    for function_name, _ in functions:
-        # Ignore private functions.
-        if function_name.startswith("_"):
-            continue
-        component_desc = _get_builtin_description(filepath, function_name)
-        if component_desc:
-            definition = _get_component_definition(
-                components_module_path, function_name
-            )
-            builtin_component = BuiltinComponent(
-                definition=definition,
-                description=component_desc,
-            )
-            buitin_functions.append(builtin_component)
-    return buitin_functions
-
-
-def _allowed_path(path: str) -> bool:
-    filename = os.path.basename(path)
-    if filename.startswith("_"):
-        return False
-    return True
-
-
-def _builtins() -> List[BuiltinComponent]:
-    components_dir = entrypoints.load(
-        "torchx.file", "get_dir_path", default=get_abspath
-    )(COMPONENTS_DIR)
-
-    builtins: List[BuiltinComponent] = []
-    search_pattern = os.path.join(components_dir, "**", "*.py")
-    for filepath in glob.glob(search_pattern, recursive=True):
-        if not _allowed_path(filepath):
-            continue
-        components = _get_components_from_file(filepath)
-        builtins += components
-    return builtins
-
-
 class CmdBuiltins(SubCommand):
     def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        pass  # no arguments
+        pass
+
+    def _builtins(self) -> Dict[str, _Component]:
+        return get_components()
 
     def run(self, args: argparse.Namespace) -> None:
-        builtin_configs = _builtins()
-        num_builtins = len(builtin_configs)
+        builtin_components = self._builtins()
+        num_builtins = len(builtin_components)
         print(f"Found {num_builtins} builtin configs:")
-        for i, component in enumerate(builtin_configs):
-            print(f" {i + 1:2d}. {component.definition} - {component.description}")
+        for i, component in enumerate(builtin_components.values()):
+            print(f" {i + 1:2d}. {component.name}")
 
 
 class CmdRun(SubCommand):
@@ -172,7 +90,7 @@ class CmdRun(SubCommand):
     def run(self, args: argparse.Namespace) -> None:
         # TODO: T91790598 - remove the if condition when all apps are migrated to pure python
         runner = get_runner()
-        app_handle = runner.run_from_path(
+        result = runner.run_component(
             args.conf_file,
             args.conf_args,
             args.scheduler,
@@ -180,7 +98,15 @@ class CmdRun(SubCommand):
             dryrun=args.dryrun,
         )
 
-        if not args.dryrun:
+        if args.dryrun:
+            app_dryrun_info = cast(specs.AppDryRunInfo, result)
+            print("=== APPLICATION ===")
+            print(pformat(asdict(app_dryrun_info._app), indent=2, width=80))
+
+            print("=== SCHEDULER REQUEST ===")
+            print(app_dryrun_info)
+        else:
+            app_handle = cast(specs.AppHandle, result)
             if args.scheduler == "local":
                 runner.wait(app_handle)
             else:

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
-from torchx.cli.cmd_run import CmdBuiltins, CmdRun, _builtins, _parse_run_config
+from torchx.cli.cmd_run import CmdBuiltins, CmdRun, _parse_run_config
 
 
 @contextmanager
@@ -109,7 +109,8 @@ class CmdBuiltinTest(unittest.TestCase):
         cmd_builtins.run(args)
 
     def test_builtins(self) -> None:
-        builtins = _builtins()
+        cmd_builtins = CmdBuiltins()
+        builtins = cmd_builtins._builtins()
         # make sure there's at least one
         # there will always be one (example.torchx)
         self.assertTrue(len(builtins) > 0)

--- a/torchx/components/__init__.py
+++ b/torchx/components/__init__.py
@@ -20,7 +20,7 @@ Components can be used out of the box by either torchx cli or torchx sdk.
 
   # using via sdk
   from torchx.runner import get_runner
-  get_runner().run_from_path("distributed.ddp", app_args=[], scheduler="local", ...)
+  get_runner().run_component("distributed.ddp", app_args=[], scheduler="local", ...)
 
   # using via torchx-cli
 

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -355,7 +355,7 @@ class RunnerTest(unittest.TestCase):
 
         app_args = ["--image", "dummy_image", "--entrypoint", "test.py"]
         with patch.object(runner, "run") as run_mock:
-            app_handle = runner.run_from_path("dist.ddp", app_args, "local")
+            app_handle = runner.run_component("dist.ddp", app_args, "local")
             args, kwargs = run_mock.call_args
             actual_app = args[0]
 
@@ -369,7 +369,7 @@ class RunnerTest(unittest.TestCase):
         runner = Runner(name="test_session", schedulers=schedulers)
         with patch.object(runner, "run") as run_mock:
             with self.assertRaises(ValueError):
-                runner.run_from_path("distributed.unknown_module.ddp", [], "local")
+                runner.run_component("distributed.unknown_module.ddp", [], "local")
 
     def test_run_from_file(self, _) -> None:
         local_sched_mock = MagicMock()
@@ -379,7 +379,7 @@ class RunnerTest(unittest.TestCase):
         app_args = ["--script", "test.py"]
         component_path = get_full_path("distributed.py")
         with patch.object(runner, "run") as run_mock:
-            app_handle = runner.run_from_path(
+            app_handle = runner.run_component(
                 f"{component_path}:ddp", app_args, "local"
             )
             args, kwargs = run_mock.call_args
@@ -404,7 +404,7 @@ class RunnerTest(unittest.TestCase):
         runner = Runner(name="test_session", schedulers=schedulers)
         with patch.object(runner, "run") as run_mock:
             with self.assertRaises(ValueError):
-                app_handle = runner.run_from_path("file_path/dir:", [], "local")
+                app_handle = runner.run_component("file_path/dir:", [], "local")
 
     def test_run_from_file_no_function_found(self, _) -> None:
         local_sched_mock = MagicMock()
@@ -413,4 +413,4 @@ class RunnerTest(unittest.TestCase):
         component_path = get_full_path("distributed.py")
         with patch.object(runner, "run") as run_mock:
             with self.assertRaises(ValueError):
-                runner.run_from_path(f"{component_path}:unknown_function", [], "local")
+                runner.run_component(f"{component_path}:unknown_function", [], "local")

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -68,14 +68,15 @@ class SlurmReplicaRequest:
     @classmethod
     def from_role(cls, role: Role, cfg: RunConfig) -> "SlurmReplicaRequest":
         opts = {k: str(v) for k, v in cfg.cfgs.items()}
+        resource = role.resource
 
-        if (resource := role.resource) != NONE:
-            if (cpu := resource.cpu) > 0:
-                opts["cpus-per-task"] = str(cpu)
-            if (memMB := resource.memMB) > 0:
-                opts["mem"] = str(memMB)
-            if (gpu := resource.gpu) > 0:
-                opts["gpus-per-task"] = str(gpu)
+        if resource != NONE:
+            if resource.cpu > 0:
+                opts["cpus-per-task"] = str(resource.cpu)
+            if resource.memMB > 0:
+                opts["mem"] = str(resource.memMB)
+            if resource.gpu > 0:
+                opts["gpus-per-task"] = str(resource.gpu)
 
         return cls(
             dir=role.image,

--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -138,10 +138,9 @@ srun --chdir=/some/path echo 'hello slurm' test
         self.assertEqual(app_id, "1234")
 
         self.assertEqual(run.call_count, 1)
-        self.assertEqual(
-            run.call_args.kwargs, {"stdout": subprocess.PIPE, "check": True}
-        )
-        (args,) = run.call_args.args
+        args, kwargs = run.call_args
+        self.assertEqual(kwargs, {"stdout": subprocess.PIPE, "check": True})
+        (args,) = args
         self.assertEqual(len(args), 9)
         self.assertEqual(args[:4], ["sbatch", "--parsable", "--job-name", "foo"])
         self.assertTrue(args[4].endswith("role-0-a-0.sh"))

--- a/torchx/specs/finder.py
+++ b/torchx/specs/finder.py
@@ -1,0 +1,228 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+import glob
+import importlib
+import logging
+import os
+from collections import OrderedDict
+from dataclasses import dataclass
+from inspect import getmembers, isfunction
+from types import ModuleType
+from typing import Dict, List, Optional, Union, Callable
+
+from pyre_extensions import none_throws
+from torchx.specs import AppDef
+from torchx.specs.file_linter import get_fn_docstring, validate
+from torchx.util import entrypoints
+from torchx.util.io import read_conf_file
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _Component:
+    """
+    Definition of the component
+
+    Args:
+        name: The name of the component, which usually MODULE_PATH.FN_NAME
+        module_name: Full module name, equivalent to ``module.__name__``
+        description: The description of the component, taken from the desrciption
+            of the function that creates component
+        group: Logic group of the component
+        fn_name: Function name that creates component
+        fn: Function that creates component
+    """
+
+    name: str
+    module_name: str
+    description: str
+    group: str
+    fn_name: str
+    fn: Callable[..., AppDef]
+
+
+class ComponentsFinder(abc.ABC):
+    @abc.abstractmethod
+    def find(self) -> List[_Component]:
+        """
+        Retrieves a set of components. A component is defined as a python
+        function that conforms to ``torchx.specs.file_linter`` linter.
+
+        Returns:
+            List of components
+        """
+
+    def _validate_and_get_description(
+        self, module: ModuleType, function_name: str
+    ) -> Optional[str]:
+        module_path = os.path.abspath(module.__file__)
+        source = read_conf_file(module_path)
+        if len(validate(source, torchx_function=function_name)) != 0:
+            return None
+        func_definition, _ = none_throws(get_fn_docstring(source, function_name))
+        return func_definition
+
+
+class ModuleComponentsFinder(ComponentsFinder):
+    """Retrieves components from the directory associated with module.
+
+    Finds all components inside a directory associated with the module path in a recursive
+    manner. Class finds the lowest level directory for the ``module.__file`` and uses it
+    as a base dir. Then it recursively traverses the base dir to find all modules. For each
+    module it tries to find a component, which is a well-defined python function that
+    returns ``torchx.specs.AppDef``.
+
+    ``group`` can be supplied, which is used to construct component name and specify
+    the logical grouping of the components.
+
+    ::
+     module = "main.foo.bar" # resolves to main/foo/bar.py
+     # main.foo will be replaced by the "trainer" in component.name
+     components = ModuleComponentsFinder(module, alias = "trainer").find()
+
+
+    """
+
+    def __init__(self, module: Union[str, ModuleType], group: str) -> None:
+        self._module = module
+        self._group = group
+
+    def find(self) -> List[_Component]:
+        module = self._try_load_module(self._module)
+        dir_name = os.path.dirname(module.__file__)
+        return self._get_components_from_dir(
+            dir_name, self._get_base_module_name(module)
+        )
+
+    def _get_base_module_name(self, module: ModuleType) -> str:
+        filepath = module.__file__
+        if filepath.endswith("__init__.py"):
+            return module.__name__
+        else:
+            return module.__name__.rsplit(".", 1)[0]
+
+    def _try_load_module(self, module: Union[str, ModuleType]) -> ModuleType:
+        if isinstance(module, str):
+            return importlib.import_module(module)
+        else:
+            return module
+
+    def _get_components_from_dir(
+        self, search_dir: str, base_module: str
+    ) -> List[_Component]:
+        search_pattern = os.path.join(search_dir, "**", "*.py")
+        component_defs = []
+        for filepath in glob.glob(search_pattern, recursive=True):
+            module = self._try_load_module(
+                self._get_module_name(filepath, search_dir, base_module)
+            )
+            defs = self._get_components_from_module(base_module, module)
+            component_defs += defs
+        return component_defs
+
+    def _is_private_function(self, function_name: str) -> bool:
+        return function_name.startswith("_")
+
+    def _get_component_name(
+        self, base_module: str, module_name: str, fn_name: str
+    ) -> str:
+        if self._group is not None:
+            module_name = module_name.replace(base_module, none_throws(self._group), 1)
+            if module_name.startswith("."):
+                module_name = module_name[1:]
+        return f"{module_name}.{fn_name}"
+
+    def _get_components_from_module(
+        self, base_module: str, module: ModuleType
+    ) -> List[_Component]:
+        functions = getmembers(module, isfunction)
+        component_defs = []
+        for function_name, function in functions:
+            component_desc = self._validate_and_get_description(module, function_name)
+            if self._is_private_function(function_name) or not component_desc:
+                continue
+            component_def = _Component(
+                name=self._get_component_name(
+                    base_module, module.__name__, function_name
+                ),
+                module_name=module.__name__,
+                description=component_desc,
+                group=self._group,
+                fn_name=function_name,
+                fn=function,
+            )
+            component_defs.append(component_def)
+        return component_defs
+
+    def _strip_init(self, module_name: str) -> str:
+        if module_name.endswith(".__init__"):
+            return module_name.rsplit(".__init__")[0]
+        elif module_name == "__init__":
+            return ""
+        else:
+            return module_name
+
+    def _get_module_name(self, filepath: str, search_dir: str, base_module: str) -> str:
+        module_path = os.path.relpath(filepath, search_dir)
+        module_path, _ = os.path.splitext(module_path)
+        module_name = module_path.replace(os.path.sep, ".")
+        module_name = self._strip_init(module_name)
+        if not module_name:
+            return base_module
+        else:
+            return f"{base_module}.{module_name}"
+
+
+def _load_components() -> Dict[str, _Component]:
+    component_modules = entrypoints.load_group("torchx.components", default={})
+    component_defs: OrderedDict[str, _Component] = OrderedDict()
+
+    finder = ModuleComponentsFinder("torchx.components", "")
+    for component in finder.find():
+        component_defs[component.name] = component
+
+    for component_group, component_module in component_modules.items():
+        finder = ModuleComponentsFinder(component_module, component_group)
+        found_components = finder.find()
+        for component in found_components:
+            component_defs[component.name] = component
+    return component_defs
+
+
+_components: Optional[Dict[str, _Component]] = None
+
+
+def get_components() -> Dict[str, _Component]:
+    """
+    Returns all components registered in the [torchx.components] entry_points.txt
+    Each line is a key, value pair in a format:
+    ::
+      foo = test.bar
+
+    Where ``test.bar`` is a valid path to the python module and ``foo`` is alias.
+    Note: the module mast be discoverable by the torchx. A
+
+    Returns:
+        Components in a format : {ALIAS: LIST_OF_COMPONENTS}
+    """
+    global _components
+    if not _components:
+        _components = _load_components()
+    return none_throws(_components)
+
+
+def get_component(name: str) -> Optional[_Component]:
+    """
+    Retrieves components by the provided name.
+
+    Returns:
+        Component or None if no component with ``name`` exists
+    """
+    components = get_components()
+    return components.get(name, None)

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import unittest
+from unittest.mock import patch
+
+from pyre_extensions import none_throws
+from torchx.specs.api import AppDef, Role
+from torchx.specs.finder import (
+    ModuleComponentsFinder,
+    get_component,
+    _load_components,
+)
+
+
+def test_component(name: str, role_name: str = "worker") -> AppDef:
+    """
+    Test component
+
+    Args:
+        name: AppDef name
+        role_name: Role name
+
+    Returns:
+        AppDef
+    """
+    return AppDef(
+        name, roles=[Role(name=role_name, image="test_image", entrypoint="main.py")]
+    )
+
+
+def invalid_component(name: str, role_name: str = "worker") -> AppDef:
+    return AppDef(
+        name, roles=[Role(name=role_name, image="test_image", entrypoint="main.py")]
+    )
+
+
+class DirComponentsFinderTest(unittest.TestCase):
+    def test_get_components(self) -> None:
+        components = _load_components()
+        self.assertTrue(len(components) > 1)
+        component = components["utils.echo"]
+        self.assertEqual("torchx.components.utils", component.module_name)
+        self.assertEqual("utils.echo", component.name)
+        self.assertEqual(
+            "Echos a message to stdout (calls /bin/echo)", component.description
+        )
+        self.assertEqual("echo", component.fn_name)
+        self.assertEqual("", component.group)
+        self.assertIsNotNone(component.fn)
+
+    def test_get_component_by_name(self) -> None:
+        component = none_throws(get_component("utils.echo"))
+        self.assertEqual("utils.echo", component.name)
+        self.assertEqual("torchx.components.utils", component.module_name)
+        self.assertEqual("echo", component.fn_name)
+        self.assertIsNotNone(component.fn)
+
+    def test_get_entrypoints_components(self) -> None:
+        test_torchx_group = {"foobar": sys.modules[__name__]}
+        with patch("torchx.specs.finder.entrypoints") as entrypoints_mock:
+            entrypoints_mock.load_group.return_value = test_torchx_group
+            components = _load_components()
+        foobar_component = components["foobar.finder_test.test_component"]
+        self.assertEqual(test_component, foobar_component.fn)
+        self.assertEqual("test_component", foobar_component.fn_name)
+        self.assertEqual("foobar.finder_test.test_component", foobar_component.name)
+        self.assertEqual("torchx.specs.test.finder_test", foobar_component.module_name)
+        self.assertEqual("Test component", foobar_component.description)
+
+    def test_validate_and_get_description(self) -> None:
+        expected_desc = "Test component"
+        finder = ModuleComponentsFinder(sys.modules[__name__], "")
+        actual_desc = finder._validate_and_get_description(
+            sys.modules[__name__], "test_component"
+        )
+        self.assertEqual(expected_desc, actual_desc)
+
+    def test_validate_and_get_description_invalid_component(self) -> None:
+        finder = ModuleComponentsFinder(sys.modules[__name__], "")
+        actual_desc = finder._validate_and_get_description(
+            sys.modules[__name__], "invalid_component"
+        )
+        self.assertIsNone(actual_desc)
+
+    def test_get_base_module_name(self) -> None:
+        finder = ModuleComponentsFinder(sys.modules[__name__], "")
+        expected_name = "torchx.specs.test"
+        actual_name = finder._get_base_module_name(sys.modules[__name__])
+        self.assertEqual(expected_name, actual_name)
+
+    def test_get_base_module_name_for_init_module(self) -> None:
+        finder = ModuleComponentsFinder("", "")
+        expected_name = "torchx.specs"
+        actual_name = finder._get_base_module_name(sys.modules["torchx.specs"])
+        self.assertEqual(expected_name, actual_name)
+
+    def test_get_component_name(self) -> None:
+        finder = ModuleComponentsFinder("", group="foobar")
+        actual_name = finder._get_component_name(
+            "test.main_module", "test.main_module.sub_module.bar", "get_component"
+        )
+        expected_name = "foobar.sub_module.bar.get_component"
+        self.assertEqual(expected_name, actual_name)
+
+    def test_strip_init(self) -> None:
+        finder = ModuleComponentsFinder("", "")
+        self.assertEqual("foobar", finder._strip_init("foobar.__init__"))
+        self.assertEqual("", finder._strip_init("__init__"))
+        self.assertEqual("foobar", finder._strip_init("foobar"))
+
+    def test_get_module_name(self) -> None:
+        finder = ModuleComponentsFinder("", "")
+        actual_name = finder._get_module_name(
+            "/test/path/main_module/foobar.py", "/test/path", "main"
+        )
+        expected_name = "main.main_module.foobar"
+        self.assertEqual(expected_name, actual_name)


### PR DESCRIPTION
Summary:
Move component search registration into a separate module and share it across runner and torch_cli
Introduce new format for ``[torchx.components]`` :

    foo = my_project.some_module.bar

Where ``my_project.some_module.bar`` is a python module. The components will be recursively found in the dir for ``my_project.some_module.bar.__file__`` file.

Reviewed By: kiukchung

Differential Revision: D29202878

