### PR TITLE
[torchx/release][0.1.0b0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# CHANGELOG
+
+## torchx-0.1.0b0
+
+* `torchx.specs` API release candidate
+  (still experimental but no major changes expected for `0.1.0`)
+
+* `torchx.pipelines` - Kubeflow Pipeline adapter support
+* `torchx.runner` - SLURM and local scheduler support
+* `torchx.components` - several utils, ddp, torchserve builtin components
+* `torchx.examples`
+   * Colab support for examples
+   * `apps`:
+     * classy vision + lightning trainer
+     * torchserve deploy
+     * captum model visualization
+   * `pipelines`:
+     * apps above as a Kubeflow Pipeline
+     * basic vs advanced Kubeflow Pipeline examples
+* CI
+  * unittest, pyre, linter, KFP launch, doc build/test
+
+

--- a/torchx/version.py
+++ b/torchx/version.py
@@ -14,7 +14,7 @@
 # 0.1.0bN  # Beta release
 # 0.1.0rcN  # Release Candidate
 # 0.1.0  # Final release
-__version__ = "0.1.0.dev3"
+__version__ = "0.1.0b0"
 
 # Use the github container registry images corresponding to the current package
 # version.


### PR DESCRIPTION
0.1.0b0 release version bump. See CHANGELOG.md for details

Test plan:
Following release CM.
