### PR TITLE
schedulers/kubernetes_scheduler: kubernetes support via volcano

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+      fail-fast: false
     steps:
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/docs/source/schedulers/kubernetes.rst
+++ b/docs/source/schedulers/kubernetes.rst
@@ -1,4 +1,9 @@
 Kubernetes
 =================
-<COMING SOON>
+
+.. automodule:: torchx.schedulers.kubernetes_scheduler
+.. currentmodule:: torchx.schedulers.kubernetes_scheduler
+
+.. autoclass:: KubernetesScheduler
+   :members:
 

--- a/torchx/components/utils.py
+++ b/torchx/components/utils.py
@@ -14,12 +14,16 @@ meaningful stages in a workflow.
 import torchx.specs as specs
 
 
-def echo(msg: str = "hello world") -> specs.AppDef:
+def echo(
+    msg: str = "hello world", image: str = "/tmp", num_replicas: int = 1
+) -> specs.AppDef:
     """
     Echos a message to stdout (calls /bin/echo)
 
     Args:
         msg: message to echo
+        image: image to use
+        num_replicas: number of replicas to run
 
     """
     return specs.AppDef(
@@ -27,10 +31,10 @@ def echo(msg: str = "hello world") -> specs.AppDef:
         roles=[
             specs.Role(
                 name="echo",
-                image="/tmp",
+                image=image,
                 entrypoint="/bin/echo",
                 args=[msg],
-                num_replicas=1,
+                num_replicas=num_replicas,
             )
         ],
     )

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import warnings
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional, Iterable
+
+import yaml
+from kubernetes import client, config
+from kubernetes.client.models import (
+    V1Pod,
+    V1PodSpec,
+    V1Container,
+    V1EnvVar,
+    V1ResourceRequirements,
+    V1ContainerPort,
+)
+from torchx.schedulers.api import AppDryRunInfo, DescribeAppResponse, Scheduler
+from torchx.specs.api import (
+    AppState,
+    ReplicaState,
+    AppDef,
+    Role,
+    RunConfig,
+    SchedulerBackend,
+    macros,
+    RetryPolicy,
+    RoleStatus,
+    ReplicaStatus,
+    runopts,
+)
+
+RETRY_POLICIES: Mapping[str, Iterable[Mapping[str, str]]] = {
+    RetryPolicy.REPLICA: [],
+    RetryPolicy.APPLICATION: [
+        {"event": "PodEvicted", "action": "RestartJob"},
+        {"event": "PodFailed", "action": "RestartJob"},
+    ],
+}
+
+JOB_STATE: Dict[str, AppState] = {
+    # Pending is the phase that job is pending in the queue, waiting for
+    # scheduling decision
+    "Pending": AppState.PENDING,
+    # Aborting is the phase that job is aborted, waiting for releasing pods
+    "Aborting": AppState.RUNNING,
+    # Aborted is the phase that job is aborted by user or error handling
+    "Aborted": AppState.CANCELLED,
+    # Running is the phase that minimal available tasks of Job are running
+    "Running": AppState.RUNNING,
+    # Restarting is the phase that the Job is restarted, waiting for pod
+    # releasing and recreating
+    "Restarting": AppState.RUNNING,
+    # Completed is the phase that all tasks of Job are completed successfully
+    "Completed": AppState.SUCCEEDED,
+    # Terminating is the phase that the Job is terminated, waiting for releasing
+    # pods
+    "Terminating": AppState.RUNNING,
+    # Teriminated is the phase that the job is finished unexpected, e.g. events
+    "Terminated": AppState.FAILED,
+}
+
+TASK_STATE: Dict[str, ReplicaState] = {
+    # Pending means the task is pending in the apiserver.
+    "Pending": ReplicaState.PENDING,
+    # Allocated means the scheduler assigns a host to it.
+    "Allocated": ReplicaState.PENDING,
+    # Pipelined means the scheduler assigns a host to wait for releasing
+    # resource.
+    "Pipelined": ReplicaState.PENDING,
+    # Binding means the scheduler send Bind request to apiserver.
+    "Binding": ReplicaState.PENDING,
+    # Bound means the task/Pod bounds to a host.
+    "Bound": ReplicaState.PENDING,
+    # Running means a task is running on the host.
+    "Running": ReplicaState.RUNNING,
+    # Releasing means a task/pod is deleted.
+    "Releasing": ReplicaState.RUNNING,
+    # Succeeded means that all containers in the pod have voluntarily
+    # terminated with a container exit code of 0, and the system is not
+    # going to restart any of these containers.
+    "Succeeded": ReplicaState.SUCCEEDED,
+    # Failed means that all containers in the pod have terminated, and at
+    # least one container has terminated in a failure (exited with a
+    # non-zero exit code or was stopped by the system).
+    "Failed": ReplicaState.FAILED,
+    # Unknown means the status of task/pod is unknown to the scheduler.
+    "Unknown": ReplicaState.UNKNOWN,
+}
+
+
+def sanitize_for_serialization(obj: object) -> object:
+    api = client.ApiClient()
+    return api.sanitize_for_serialization(obj)
+
+
+def role_to_pod(name: str, role: Role) -> V1Pod:
+    assert role.base_image is None, "base_image is not supported by Kubernetes"
+
+    requests = {}
+
+    resource = role.resource
+    if resource.cpu >= 0:
+        requests["cpu"] = f"{int(resource.cpu*1000)}m"
+    if resource.memMB >= 0:
+        requests["memory"] = f"{int(resource.memMB)}M"
+    if resource.gpu >= 0:
+        requests["nvidia.com/gpu"] = str(resource.gpu)
+
+    resources = V1ResourceRequirements(
+        limits=requests,
+        requests=requests,
+    )
+
+    container = V1Container(
+        command=[role.entrypoint] + role.args,
+        image=role.image,
+        name=name,
+        env=[
+            V1EnvVar(
+                name=name,
+                value=value,
+            )
+            for name, value in role.env.items()
+        ],
+        resources=resources,
+        ports=[
+            V1ContainerPort(
+                name=name,
+                container_port=port,
+            )
+            for name, port in role.port_map.items()
+        ],
+    )
+    return V1Pod(
+        spec=V1PodSpec(
+            containers=[container],
+            restart_policy="Never",
+        ),
+    )
+
+
+@dataclass
+class KubernetesJob:
+    resource: Dict[str, object]
+
+    def __str__(self) -> str:
+        return yaml.dump(sanitize_for_serialization(self.resource))
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class KubernetesScheduler(Scheduler):
+    """
+    KubernetesScheduler is a TorchX scheduling interface to Kubernetes.
+
+    Important: Volcano is required to be installed on the Kubernetes cluster.
+    TorchX requires gang scheduling for multi-replica/multi-role execution
+    and Volcano is currently the only supported scheduler with Kubernetes.
+    For installation instructions see: https://github.com/volcano-sh/volcano
+
+    .. code-block:: bash
+
+        $ torchx run --scheduler kubernetes --scheduler_opts namespace=default,queue=test utils.echo --msg hello
+        kubernetes://torchx_user/1234
+        $ torchx status kubernetes://torchx_user/1234
+        ...
+    """
+
+    def __init__(
+        self, session_name: str, client: Optional[client.ApiClient] = None
+    ) -> None:
+        super().__init__("kubernetes", session_name)
+
+        self._client = client
+
+    def _custom_objects_api(self) -> client.CustomObjectsApi:
+        if self._client is None:
+            configuration = client.Configuration()
+            try:
+                config.load_kube_config(client_configuration=configuration)
+            except config.ConfigException as e:
+                warnings.warn(f"failed to load kube config: {e}")
+
+            self._client = client.ApiClient(configuration)
+
+        return client.CustomObjectsApi(self._client)
+
+    def schedule(self, dryrun_info: AppDryRunInfo[KubernetesJob]) -> str:
+        cfg = dryrun_info._cfg
+        assert cfg is not None, f"{dryrun_info} missing cfg"
+        namespace = cfg.get("namespace") or "default"
+        resource = dryrun_info.request.resource
+
+        resp = self._custom_objects_api().create_namespaced_custom_object(
+            group="batch.volcano.sh",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="jobs",
+            body=resource,
+        )
+        return f'{namespace}:{resp["metadata"]["name"]}'
+
+    def _submit_dryrun(
+        self, app: AppDef, cfg: RunConfig
+    ) -> AppDryRunInfo[KubernetesJob]:
+        queue = cfg.get("queue")
+        tasks = []
+        for i, role in enumerate(app.roles):
+            for replica_id in range(role.num_replicas):
+                values = macros.Values(
+                    img_root="",
+                    app_id=macros.app_id,
+                    replica_id=str(replica_id),
+                )
+                name = f"{role.name}-{replica_id}"
+                replica_role = values.apply(role)
+                pod = role_to_pod(name, replica_role)
+                tasks.append(
+                    {
+                        "replicas": 1,
+                        "name": name,
+                        "template": pod,
+                        "maxRetry": role.max_retries,
+                        "policies": RETRY_POLICIES[role.retry_policy],
+                    }
+                )
+
+        job_retries = min(role.max_retries for role in app.roles)
+        resource: Dict[str, object] = {
+            "apiVersion": "batch.volcano.sh/v1alpha1",
+            "kind": "Job",
+            "metadata": {"generateName": f"{app.name}-"},
+            "spec": {
+                "schedulerName": "volcano",
+                "queue": queue,
+                "tasks": tasks,
+                "maxRetry": job_retries,
+            },
+        }
+        req = KubernetesJob(resource=resource)
+        info = AppDryRunInfo(req, repr)
+        info._app = app
+        info._cfg = cfg
+        return info
+
+    def _validate(self, app: AppDef, scheduler: SchedulerBackend) -> None:
+        # Skip validation step
+        pass
+
+    def _cancel_existing(self, app_id: str) -> None:
+        pass
+
+    def run_opts(self) -> runopts:
+        opts = runopts()
+        opts.add(
+            "namespace",
+            type_=str,
+            help="Kubernetes namespace to schedule job in",
+            default="default",
+        )
+        opts.add(
+            "queue", type_=str, help="Volcano queue to schedule job in", required=True
+        )
+        return opts
+
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        namespace, name = app_id.split(":")
+        roles = {}
+        resp = self._custom_objects_api().get_namespaced_custom_object_status(
+            group="batch.volcano.sh",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="jobs",
+            name=name,
+        )
+        status = resp["status"]
+
+        state_str = status["state"]["phase"]
+        app_state = JOB_STATE[state_str]
+
+        TASK_STATUS_COUNT = "taskStatusCount"
+
+        if TASK_STATUS_COUNT in status:
+            for name, status in status[TASK_STATUS_COUNT].items():
+                role, idx = name.split("-")
+
+                state_str = next(iter(status["phase"].keys()))
+                state = TASK_STATE[state_str]
+
+                if role not in roles:
+                    roles[role] = RoleStatus(role, [])
+                roles[role].replicas.append(
+                    ReplicaStatus(id=int(idx), role=role, state=state, hostname="")
+                )
+        return DescribeAppResponse(
+            app_id=app_id,
+            roles_statuses=list(roles.values()),
+            state=app_state,
+        )
+
+
+def create_scheduler(session_name: str, **kwargs: Any) -> KubernetesScheduler:
+    return KubernetesScheduler(
+        session_name=session_name,
+    )

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -1,0 +1,209 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from kubernetes.client.models import (
+    V1Pod,
+    V1PodSpec,
+    V1Container,
+    V1EnvVar,
+    V1ResourceRequirements,
+    V1ContainerPort,
+)
+from torchx import specs
+from torchx.schedulers.api import DescribeAppResponse
+from torchx.schedulers.kubernetes_scheduler import (
+    create_scheduler,
+    KubernetesScheduler,
+    role_to_pod,
+)
+
+
+class KubernetesSchedulerTest(unittest.TestCase):
+    def test_create_scheduler(self) -> None:
+        scheduler = create_scheduler("foo")
+        self.assertIsInstance(scheduler, KubernetesScheduler)
+
+    def _test_app(self) -> specs.AppDef:
+        trainer_role = specs.Role(
+            name="trainer",
+            image="pytorch/torchx:latest",
+            entrypoint="main",
+            args=["--output-path", specs.macros.img_root],
+            env={"FOO": "bar"},
+            resource=specs.Resource(
+                cpu=2,
+                memMB=3000,
+                gpu=4,
+            ),
+            port_map={"foo": 1234},
+            num_replicas=1,
+            max_retries=3,
+        )
+
+        return specs.AppDef("test", roles=[trainer_role])
+
+    def test_role_to_pod(self) -> None:
+        app = self._test_app()
+        pod = role_to_pod("name", app.roles[0])
+
+        requests = {
+            "cpu": "2000m",
+            "memory": "3000M",
+            "nvidia.com/gpu": "4",
+        }
+        resources = V1ResourceRequirements(
+            limits=requests,
+            requests=requests,
+        )
+        container = V1Container(
+            command=["main", "--output-path", specs.macros.img_root],
+            image="pytorch/torchx:latest",
+            name="name",
+            env=[V1EnvVar(name="FOO", value="bar")],
+            resources=resources,
+            ports=[V1ContainerPort(name="foo", container_port=1234)],
+        )
+        want = V1Pod(
+            spec=V1PodSpec(
+                containers=[container],
+                restart_policy="Never",
+            ),
+        )
+
+        self.assertEqual(
+            pod,
+            want,
+        )
+
+    def test_validate(self) -> None:
+        scheduler = create_scheduler("test")
+        app = self._test_app()
+        scheduler._validate(app, "kubernetes")
+
+    def test_submit_dryrun(self) -> None:
+        scheduler = create_scheduler("test")
+        app = self._test_app()
+        cfg = specs.RunConfig()
+        cfg.set("queue", "testqueue")
+        info = scheduler._submit_dryrun(app, cfg)
+
+        resource = str(info.request)
+
+        self.assertEqual(
+            resource,
+            """apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  generateName: test-
+spec:
+  maxRetry: 3
+  queue: testqueue
+  schedulerName: volcano
+  tasks:
+  - maxRetry: 3
+    name: trainer-0
+    policies:
+    - action: RestartJob
+      event: PodEvicted
+    - action: RestartJob
+      event: PodFailed
+    replicas: 1
+    template:
+      spec:
+        containers:
+        - command:
+          - main
+          - --output-path
+          - ''
+          env:
+          - name: FOO
+            value: bar
+          image: pytorch/torchx:latest
+          name: trainer-0
+          ports:
+          - containerPort: 1234
+            name: foo
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 3000M
+              nvidia.com/gpu: '4'
+            requests:
+              cpu: 2000m
+              memory: 3000M
+              nvidia.com/gpu: '4'
+        restartPolicy: Never
+""",
+        )
+
+    @patch("kubernetes.client.CustomObjectsApi.create_namespaced_custom_object")
+    def test_submit(self, create_namespaced_custom_object: MagicMock) -> None:
+        create_namespaced_custom_object.return_value = {
+            "metadata": {"name": "testid"},
+        }
+        scheduler = create_scheduler("test")
+        app = self._test_app()
+        cfg = specs.RunConfig()
+        cfg.set("namespace", "testnamespace")
+        cfg.set("queue", "testqueue")
+        info = scheduler._submit_dryrun(app, cfg)
+        id = scheduler.schedule(info)
+        self.assertEqual(id, "testnamespace:testid")
+        call = create_namespaced_custom_object.call_args
+        args, kwargs = call
+        self.assertEqual(kwargs["group"], "batch.volcano.sh")
+        self.assertEqual(kwargs["version"], "v1alpha1")
+        self.assertEqual(kwargs["namespace"], "testnamespace")
+        self.assertEqual(kwargs["plural"], "jobs")
+        self.assertEqual(kwargs["body"], info.request.resource)
+
+    @patch("kubernetes.client.CustomObjectsApi.get_namespaced_custom_object_status")
+    def test_describe(self, get_namespaced_custom_object_status: MagicMock) -> None:
+        get_namespaced_custom_object_status.return_value = {
+            "status": {
+                "state": {"phase": "Completed"},
+                "succeeded": 1,
+                "taskStatusCount": {"echo-0": {"phase": {"Succeeded": 1}}},
+            }
+        }
+        app_id = "testnamespace:testid"
+        scheduler = create_scheduler("test")
+        info = scheduler.describe(app_id)
+        call = get_namespaced_custom_object_status.call_args
+        args, kwargs = call
+        self.assertEqual(
+            kwargs,
+            {
+                "group": "batch.volcano.sh",
+                "version": "v1alpha1",
+                "namespace": "testnamespace",
+                "plural": "jobs",
+                "name": "testid",
+            },
+        )
+        self.assertEqual(
+            info,
+            DescribeAppResponse(
+                app_id=app_id,
+                state=specs.AppState.SUCCEEDED,
+                roles_statuses=[
+                    specs.RoleStatus(
+                        "echo",
+                        [
+                            specs.ReplicaStatus(
+                                id=0,
+                                role="echo",
+                                state=specs.AppState.SUCCEEDED,
+                                hostname="",
+                            )
+                        ],
+                    ),
+                ],
+            ),
+        )

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -302,6 +302,7 @@ class AppState(int, Enum):
     5. SUCCEEDED - app has successfully completed
     6. FAILED - app has unsuccessfully completed
     7. CANCELLED - app was cancelled before completing
+    8. UNKNOWN - app state is unknown
     """
 
     UNSUBMITTED = 0
@@ -311,6 +312,7 @@ class AppState(int, Enum):
     SUCCEEDED = 4
     FAILED = 5
     CANCELLED = 6
+    UNKNOWN = 7
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
<!-- Change Summary -->

This adds distributed kubernetes support via the volcano scheduler. This currently doesn't have any log fetching support but should be straight forward to add on later.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Install volcano on a kubernetes cluster + setup local kubeconfig:

```
$ torchx run --scheduler kubernetes --scheduler_args queue=test utils.echo --image alpine:latest --num_replicas 3
{"session": "", "scheduler": "kubernetes", "api": "schedule", "app_id": "default:echo-rd9d4", "runcfg": "{\"queue\": \"test\", \"namespace\": \"default\"}", "raw_exception": null, "source": "<unknown>"}
=== RUN RESULT ===
Launched app: kubernetes://torchx_tristanr/default:echo-rd9d4
{"session": "default:echo-rd9d4", "scheduler": "kubernetes", "api": "status", "app_id": "default:echo-rd9d4", "runcfg": null, "raw_exception": null, "source": "<unknown>"}
App status: {
  "state": 3,
  "num_restarts": -1,
  "msg": "<NONE>",
  "ui_url": null,
  "roles": [],
  "structured_error_msg": "<NONE>"
}
Job URL: None

$ torchx status kubernetes://torchx_tristanr/default:echo-rd9d4
{"session": "default:echo-rd9d4", "scheduler": "kubernetes", "api": "status", "app_id": "default:echo-rd9d4", "runcfg": null, "raw_exception": null, "source": "<unknown>"}
AppDef:
  State: SUCCEEDED
  Num Restarts: -1
Roles:
 *echo[0]:SUCCEEDED
  echo[1]:SUCCEEDED
  echo[2]:SUCCEEDED

$ torchx runopts kubernetes
{ 'namespace': { 'default': 'default',
                 'help': 'Kubernetes namespace to schedule job in',
                 'type': 'str'},
  'queue': { 'default': 'None',
             'help': 'Volcano queue to schedule job in',
             'type': 'str'}}

$ torchx run --dryrun --scheduler kubernetes --scheduler_args queue=test utils.echo --image alpine:latest --num_replicas 3
=== APPLICATION ===
{ 'metadata': {},
  'name': 'echo',
  'roles': [ { 'args': ['hello world'],
               'base_image': None,
               'entrypoint': '/bin/echo',
               'env': {},
               'image': 'alpine:latest',
               'max_retries': 0,
               'name': 'echo',
               'num_replicas': 3,
               'port_map': {},
               'resource': { 'capabilities': {},
                             'cpu': -1,
                             'gpu': -1,
                             'memMB': -1},
               'retry_policy': <RetryPolicy.APPLICATION: 'APPLICATION'>}]}
=== SCHEDULER REQUEST ===
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  generateName: echo-
spec:
  maxRetry: 0
  queue: test
  schedulerName: volcano
  tasks:
  - maxRetry: 0
    name: echo-0
    policies:
    - action: RestartJob
      event: PodEvicted
    - action: RestartJob
      event: PodFailed
    replicas: 1
    template:
      spec:
        containers:
        - command:
          - /bin/echo
          - hello world
          env: []
          image: alpine:latest
          name: echo-0
          ports: []
          resources:
            limits: {}
            requests: {}
        restartPolicy: Never
  - maxRetry: 0
    name: echo-1
    policies:
    - action: RestartJob
      event: PodEvicted
    - action: RestartJob
      event: PodFailed
    replicas: 1
    template:
      spec:
        containers:
        - command:
          - /bin/echo
          - hello world
          env: []
          image: alpine:latest
          name: echo-1
          ports: []
          resources:
            limits: {}
            requests: {}
        restartPolicy: Never
  - maxRetry: 0
    name: echo-2
    policies:
    - action: RestartJob
      event: PodEvicted
    - action: RestartJob
      event: PodFailed
    replicas: 1
    template:
      spec:
        containers:
        - command:
          - /bin/echo
          - hello world
          env: []
          image: alpine:latest
          name: echo-2
          ports: []
          resources:
            limits: {}
            requests: {}
        restartPolicy: Never

```
