### PR TITLE
github/kubernetes: add kubernetes integration test

### DIFF
--- a/.github/workflows/kubernetes-integration-tests.yaml
+++ b/.github/workflows/kubernetes-integration-tests.yaml
@@ -1,0 +1,48 @@
+name: Kubernetes Integration Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  kubernetes-launch:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout TorchX
+        uses: actions/checkout@v2
+      - name: Configure Kube Config
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -eux
+          if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+            aws eks update-kubeconfig --region=us-west-2 --name=torchx-dev
+          fi
+      - name: Install dependencies
+        run: |
+          set -eux
+          pip install -e .[kubernetes]
+      - name: Run Kubernetes Integration Tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -eux
+          if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+            # only dryrun if no secrets
+            ARGS="--dryrun"
+          else
+            ARGS=
+          fi
+
+          torchx run --wait $ARGS --scheduler kubernetes \
+            --scheduler_args queue=test utils.echo \
+            --image alpine:latest --num_replicas 3

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ if __name__ == "__main__":
         },
         extras_require={
             "kfp": ["kfp==1.6.2"],
+            "kubernetes": ["kubernetes>=11"],
             "dev": dev_reqs,
             ':python_version < "3.8"': [
                 "importlib-metadata",

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -166,6 +166,7 @@ class KubernetesScheduler(Scheduler):
 
     .. code-block:: bash
 
+        $ pip install torchx[kubernetes]
         $ torchx run --scheduler kubernetes --scheduler_opts namespace=default,queue=test utils.echo --msg hello
         kubernetes://torchx_user/1234
         $ torchx status kubernetes://torchx_user/1234


### PR DESCRIPTION
<!-- Change Summary -->

This adds a simple kubernetes integration test that runs echo on 3 replicas. If the PR doesn't have secrets it just runs dryrun instead.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

OSS CI

https://github.com/pytorch/torchx/pull/97/checks?check_run_id=3024028316