### PR TITLE
github/workflows/pyre: use pyre-check-nightly to be in sync with FB internal

### DIFF
--- a/.github/workflows/pyre.yaml
+++ b/.github/workflows/pyre.yaml
@@ -21,6 +21,6 @@ jobs:
         run: |
           set -eux
           pip install -r dev-requirements.txt
-          pip install pyre-check
+          pip install pyre-check-nightly
       - name: Run Pyre
         run: scripts/pyre.sh


### PR DESCRIPTION
<!-- Change Summary -->

FB internal runs off of pyre master so we need to use the nightly builds to minimize pyre errors due to sync issues.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI

```
pip install pyre-check-nightly
pyre
```