### PR TITLE
torchx/schedulers/kubernetes_scheduler: add logs and cancellation support

### DIFF
--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import abc
+import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Iterable, List, Optional
@@ -249,3 +250,13 @@ class Scheduler(abc.ABC):
                     f"No resource for role: {role.image}."
                     f" Did you forget to attach resource to the role"
                 )
+
+
+def filter_regex(regex: str, data: Iterable[str]) -> Iterable[str]:
+    """
+    filter_regex takes a string iterator and returns an iterator that only has
+    values that match the regex.
+    """
+
+    r = re.compile(regex)
+    return filter(lambda datum: r.search(datum), data)


### PR DESCRIPTION
<!-- Change Summary -->

This adds logs and cancellation support to the kubernetes scheduler.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
tristanr@tristanr-arch2 ~/D/torchx (k8s-logs)> torchx run --scheduler kubernetes --scheduler_args queue=test utils.echo --image alpine:latest --num_replicas 3
=== RUN RESULT ===
Launched app: kubernetes://torchx_tristanr/default:echo-9wzql
App status: {
  "state": 2,
  "num_restarts": -1,
  "msg": "<NONE>",
  "ui_url": null,
  "roles": [],
  "structured_error_msg": "<NONE>"
}
Job URL: None

tristanr@tristanr-arch2 ~/D/torchx (k8s-logs) > torchx log --regex world kubernetes://torchx_tristanr/default:echo-9wzql/echo
echo/0 2021-07-15T23:25:58.270863359Z hello world
echo/2 2021-07-15T23:25:59.494542001Z hello world
echo/1 2021-07-15T23:26:00.730378354Z hello world

tristanr@tristanr-arch2 ~/D/torchx (k8s-logs)> torchx log --regex world kubernetes://torchx_tristanr/default:echo-9wzql/echo/2
echo/2 2021-07-15T23:25:59.494542001Z hello world
```
added unit tests for cancellation + since/regexp