### PR TITLE
torchx/cli: enforce correct usage of stderr/stdout + unix codes on error

### DIFF
--- a/.github/workflows/kubernetes-integration-tests.yaml
+++ b/.github/workflows/kubernetes-integration-tests.yaml
@@ -43,6 +43,9 @@ jobs:
             ARGS=
           fi
 
-          torchx run --wait $ARGS --scheduler kubernetes \
+          torchx runopts kubernetes
+          APP_ID="$(torchx run --wait $ARGS --scheduler kubernetes \
             --scheduler_args queue=test utils.echo \
-            --image alpine:latest --num_replicas 3
+            --image alpine:latest --num_replicas 3)"
+          torchx status "$APP_ID"
+          torchx describe "$APP_ID"

--- a/torchx/cli/cmd_describe.py
+++ b/torchx/cli/cmd_describe.py
@@ -7,11 +7,15 @@
 
 import argparse
 import dataclasses
+import logging
 import pprint
+import sys
 
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner
 from torchx.specs import api
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class CmdDescribe(SubCommand):
@@ -31,7 +35,8 @@ class CmdDescribe(SubCommand):
         if app:
             pprint.pprint(dataclasses.asdict(app), indent=2, width=80)
         else:
-            print(
+            logger.error(
                 f"AppDef: {app_id} on session: {session_name},"
                 f" does not exist or has been removed from {scheduler}'s data plane"
             )
+            sys.exit(1)

--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -20,18 +20,21 @@ from torchx.cli.cmd_base import SubCommand
 from torchx.runner import Runner, get_runner
 from torchx.specs.api import make_app_handle
 
-
-GREEN = "\033[32m"
-ENDC = "\033[0m"
-
 logger: logging.Logger = logging.getLogger(__name__)
+
+# only print colors if outputting directly to a terminal
+if sys.stdout.isatty():
+    GREEN = "\033[32m"
+    ENDC = "\033[0m"
+else:
+    GREEN = ""
+    ENDC = ""
 
 
 def validate(job_identifier: str) -> None:
     if not re.match(r"^\w+://[^/.]*/[^/.]+/[^/.]+(/(\d+,?)+)?$", job_identifier):
-        print(
+        logger.error(
             f"{job_identifier} is not of the form SCHEDULER://[SESSION_NAME]/APP_ID/ROLE_NAME/[REPLICA_IDS,...]",
-            file=sys.stderr,
         )
         sys.exit(1)
 
@@ -85,10 +88,9 @@ def get_logs(identifier: str, regex: Optional[str], should_tail: bool = False) -
                 ]
             )
 
-            print(
+            logger.error(
                 f"No role [{role_name}] found for app: {app.name}."
                 f" Did you mean one of the following:\n{valid_ids}",
-                file=sys.stderr,
             )
             sys.exit(1)
 

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import logging
 from dataclasses import asdict
 from pprint import pformat
 from typing import Dict, List, Union, cast
@@ -15,6 +16,8 @@ from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner
 from torchx.specs.finder import get_components, _Component
 from torchx.util.types import to_dict
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def parse_args_children(arg: str) -> Dict[str, Union[str, List[str]]]:
@@ -43,9 +46,9 @@ class CmdBuiltins(SubCommand):
     def run(self, args: argparse.Namespace) -> None:
         builtin_components = self._builtins()
         num_builtins = len(builtin_components)
-        print(f"Found {num_builtins} builtin configs:")
+        logger.info(f"Found {num_builtins} builtin configs:")
         for i, component in enumerate(builtin_components.values()):
-            print(f" {i + 1:2d}. {component.name}")
+            logger.info(f" {i + 1:2d}. {component.name}")
 
 
 class CmdRun(SubCommand):
@@ -100,22 +103,23 @@ class CmdRun(SubCommand):
 
         if args.dryrun:
             app_dryrun_info = cast(specs.AppDryRunInfo, result)
-            print("=== APPLICATION ===")
-            print(pformat(asdict(app_dryrun_info._app), indent=2, width=80))
+            logger.info("=== APPLICATION ===")
+            logger.info(pformat(asdict(app_dryrun_info._app), indent=2, width=80))
 
-            print("=== SCHEDULER REQUEST ===")
-            print(app_dryrun_info)
+            logger.info("=== SCHEDULER REQUEST ===")
+            logger.info(app_dryrun_info)
         else:
             app_handle = cast(specs.AppHandle, result)
             if args.scheduler == "local":
                 runner.wait(app_handle)
             else:
-                print("=== RUN RESULT ===")
-                print(f"Launched app: {app_handle}")
+                logger.info("=== RUN RESULT ===")
+                logger.info(f"Launched app: {app_handle}")
                 status = runner.status(app_handle)
-                print(f"App status: {status}")
-                print(f"Job URL: {none_throws(status).ui_url}")
+                logger.info(f"App status: {status}")
+                logger.info(f"Job URL: {none_throws(status).ui_url}")
 
                 if args.wait:
-                    print("Waiting for the app to finish...")
+                    logger.info("Waiting for the app to finish...")
                     runner.wait(app_handle)
+            print(app_handle)

--- a/torchx/cli/cmd_runopts.py
+++ b/torchx/cli/cmd_runopts.py
@@ -6,9 +6,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import logging
 
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner.api import get_runner
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class CmdRunopts(SubCommand):
@@ -26,6 +29,6 @@ class CmdRunopts(SubCommand):
 
         if not scheduler:
             for scheduler, opts in run_opts.items():
-                print(f"{scheduler}:\n{repr(opts)}")
+                logger.info(f"{scheduler}:\n{repr(opts)}")
         else:
-            print(repr(run_opts[scheduler]))
+            logger.info(repr(run_opts[scheduler]))

--- a/torchx/cli/cmd_status.py
+++ b/torchx/cli/cmd_status.py
@@ -7,7 +7,9 @@
 
 import argparse
 import json
+import logging
 import re
+import sys
 from datetime import datetime
 from string import Template
 from typing import List, Optional, Pattern
@@ -16,6 +18,8 @@ from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner
 from torchx.specs import api
 from torchx.specs.api import NONE
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 _APP_STATUS_FORMAT_TEMPLATE = """AppDef:
@@ -160,9 +164,10 @@ class CmdStatus(SubCommand):
         app_status = runner.status(app_handle)
         filter_roles = parse_list_arg(args.roles)
         if app_status:
-            print(format_app_status(app_status, filter_roles))
+            logger.info(format_app_status(app_status, filter_roles))
         else:
-            print(
+            logger.error(
                 f"AppDef: {app_id} on session: {session_name},"
                 f" does not exist or has been removed from {scheduler}'s data plane"
             )
+            sys.exit(1)

--- a/torchx/cli/main.py
+++ b/torchx/cli/main.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 import sys
 from argparse import ArgumentParser
 from typing import List
@@ -13,7 +14,6 @@ from torchx.cli.cmd_log import CmdLog
 from torchx.cli.cmd_run import CmdBuiltins, CmdRun
 from torchx.cli.cmd_runopts import CmdRunopts
 from torchx.cli.cmd_status import CmdStatus
-
 
 sub_parser_description = """Use the following commands to run operations, e.g.:
 torchx run ${JOB_NAME}
@@ -49,6 +49,11 @@ def create_parser() -> ArgumentParser:
 
 
 def main(argv: List[str] = sys.argv[1:]) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+    )
+
     parser = create_parser()
     args = parser.parse_args(argv)
     if "func" not in args:

--- a/torchx/cli/test/cmd_describe_test.py
+++ b/torchx/cli/test/cmd_describe_test.py
@@ -40,5 +40,15 @@ class CmdDescribeTest(unittest.TestCase):
                     "torchx.runner.api.Runner.describe",
                     return_value=app,
                 ) as desc_mock:
-                    cmd_describe.run(args)
+                    try:
+                        cmd_describe.run(args)
+                        exit_code = None
+                    except SystemExit as e:
+                        exit_code = e.code
+
                     desc_mock.assert_called_once_with(args.app_handle)
+
+                    if app is None:
+                        self.assertEqual(exit_code, 1)
+                    else:
+                        self.assertIsNone(exit_code)

--- a/torchx/cli/test/cmd_status_test.py
+++ b/torchx/cli/test/cmd_status_test.py
@@ -27,8 +27,18 @@ class CmdStatusTest(unittest.TestCase):
                 with patch("torchx.runner.api.Runner.status") as status_mock:
                     status_mock.return_value = app_status
 
-                    cmd_status.run(args)
+                    try:
+                        cmd_status.run(args)
+                        exit_code = None
+                    except SystemExit as e:
+                        exit_code = e.code
+
                     status_mock.assert_called_once_with(args.app_handle)
+
+                    if app_status is None:
+                        self.assertEqual(exit_code, 1)
+                    else:
+                        self.assertIsNone(exit_code)
 
     def test_format_error_message(self) -> None:
         rpc_error_message = """RuntimeError('On WorkerInfo(id=1, name=trainer:0:0):


### PR DESCRIPTION
<!-- Change Summary -->

This updates the CLI to use loggers instead of just raw print statements for non-consumable output. This allows unix style usage in shell scripts + being able to sanely grep through logs.

It also fixes the exit code for a few spots where we log an error but exited cleanly.

NOTE: I'm not sure we want to document programmatic usage of the CLI since we may have breaking changes down the line but it's useful for our integration tests. Anything more complex should use the python API.

The only things still on stdout are:
* log - log lines
* run - app_id
* describe - in case you want to pipe it to a file

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

updated kubernetes integration test to call status, describe, runopts