### PR TITLE
Extend componets to handle kwargs

### DIFF
--- a/.github/workflows/kubernetes-integration-tests.yaml
+++ b/.github/workflows/kubernetes-integration-tests.yaml
@@ -47,5 +47,7 @@ jobs:
           APP_ID="$(torchx run --wait $ARGS --scheduler kubernetes \
             --scheduler_args queue=test utils.echo \
             --image alpine:latest --num_replicas 3)"
-          torchx status "$APP_ID"
-          torchx describe "$APP_ID"
+          if [ "$ARGS" != "--dryrun" ]; then
+            torchx status "$APP_ID"
+            torchx describe "$APP_ID"
+          fi

--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -28,6 +28,7 @@ def ddp(
     role: str = "worker",
     env: Optional[Dict[str, str]] = None,
     *script_args: str,
+    **script_kwargs: str,
 ) -> specs.AppDef:
     """
     Distributed data parallel style application (one role, multi-replica).
@@ -45,10 +46,16 @@ def ddp(
         script: Main script.
         env: Env variables.
         script_args: Script arguments.
+        script_kwargs: Script arguments as dict.
 
     Returns:
         specs.AppDef: Torchx AppDef
     """
+
+    args = list(script_args)
+    for k, v in script_kwargs.items():
+        args.append(f"--{k}")
+        args.append(v)
 
     ddp_role = torch_dist_role(
         name=role,
@@ -57,7 +64,7 @@ def ddp(
         entrypoint=entrypoint,
         resource=resource or specs.NULL_RESOURCE,
         num_replicas=nnodes,
-        args=list(script_args),
+        args=args,
         env=env,
         nproc_per_node=nproc_per_node,
         nnodes=nnodes,

--- a/torchx/components/test/component_test_base.py
+++ b/torchx/components/test/component_test_base.py
@@ -13,7 +13,7 @@ from torchx.specs.file_linter import validate
 
 class ComponentTestCase(unittest.TestCase):
     def _validate(self, module: ModuleType, function_name: str) -> None:
-        file_path = path = os.path.abspath(module.__file__)
+        file_path = os.path.abspath(module.__file__)
         with open(file_path, "r") as fp:
             file_content = fp.read()
         linter_errors = validate(file_content, file_path, function_name)

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -38,7 +38,6 @@ from .api import (  # noqa: F401 F403
     UnknownAppException,
     make_app_handle,
     parse_app_handle,
-    get_argparse_param_type,
     from_function,
     from_file,
     from_module,

--- a/torchx/specs/file_linter.py
+++ b/torchx/specs/file_linter.py
@@ -18,6 +18,12 @@ def get_arg_names(app_specs_func_def: ast.FunctionDef) -> List[str]:
     arg_names = []
     for arg_def in app_specs_func_def.args.args:
         arg_names.append(arg_def.arg)
+    vararg = app_specs_func_def.args.vararg
+    if vararg:
+        arg_names.append(vararg.arg)
+    kwarg = app_specs_func_def.args.kwarg
+    if kwarg:
+        arg_names.append(kwarg.arg)
     return arg_names
 
 

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -409,6 +409,7 @@ def test_complex_fn(
     nnodes: int = 4,
     first_arg: Optional[str] = None,
     *roles_args: str,
+    **roles_kwargs: str,
 ) -> AppDef:
     """Creates complex application, testing all possible complex types
 
@@ -421,6 +422,7 @@ def test_complex_fn(
         nnodes: Num replicas per role
         first_arg: First argument to the user script
         roles_args: Roles args
+        roles_kwargs: Roles kwargs
     """
     num_roles = len(roles_scripts)
     if not num_cpus:
@@ -438,6 +440,9 @@ def test_complex_fn(
             args = [first_arg, *roles_args]
         else:
             args = [*roles_args]
+        for k, v in roles_kwargs.items():
+            args.append(k)
+            args.append(v)
         role = Role(
             role_name,
             image=container_img,

--- a/torchx/specs/test/file_linter_test.py
+++ b/torchx/specs/test/file_linter_test.py
@@ -10,7 +10,12 @@ import unittest
 from typing import Dict, List, Optional, cast
 
 from pyre_extensions import none_throws
-from torchx.specs.file_linter import get_fn_docstring, parse_fn_docstring, validate
+from torchx.specs.file_linter import (
+    get_fn_docstring,
+    parse_fn_docstring,
+    validate,
+    get_arg_names,
+)
 
 
 # Note if the function is moved, the tests need to be updated with new lineno
@@ -101,6 +106,27 @@ def _test_args_dict_list_complex_types(
     pass
 
 
+def _test_get_arg_names(
+    # pyre-ignore[2]: Omit return value for testing purposes
+    arg0,
+    arg1: str,
+    arg2: Optional[Optional[str]],
+    *arg3: str,
+    **arg4: int,
+) -> "AppDef":
+    """
+    Test description
+
+    Args:
+        arg0: arg0 desc
+        arg1: arg1 desc
+        arg2: arg2 desc
+        arg3: arg3 desc
+        arg4: arg4 desc
+    """
+    pass
+
+
 def current_file_path() -> str:
     return os.path.join(os.path.dirname(__file__), __file__)
 
@@ -154,7 +180,7 @@ class SpecsFileValidatorTest(unittest.TestCase):
             "https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html"
         )
         self.assertEquals(expected_desc, linter_error.description)
-        self.assertEqual(18, linter_error.line)
+        self.assertEqual(23, linter_error.line)
 
     def test_validate_docstring_empty(self) -> None:
         linter_errors = validate(
@@ -267,3 +293,9 @@ class SpecsFileValidatorTest(unittest.TestCase):
         self.assertEqual(
             "Function unknown_function not found", linter_errors[0].description
         )
+
+    def test_get_arg_names(self) -> None:
+        func_def = self._get_function_def("_test_get_arg_names")
+        args = get_arg_names(func_def)
+        expected_args = ["arg0", "arg1", "arg2", "arg3", "arg4"]
+        self.assertListEqual(expected_args, args)


### PR DESCRIPTION
Summary: The diff lets components to define kwargs parameter. The kwargs parameter is only used in the programmatic invocation of the component, as a result no additional tests needed.

Differential Revision: D29915641

