### PR TITLE
adapters/kfp: support distributed training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 cython_debug/
 
 wordlist.dic
+pipeline.yaml

--- a/docs/papermill.sh
+++ b/docs/papermill.sh
@@ -7,8 +7,15 @@
 
 WORK_DIR=/tmp/papermill
 
-set -e
+set -ex
 mkdir -p "$WORK_DIR"
+
+# create empty master.tar.gz file and setup symlinks instead of pulling from
+# master so we can handle local changes
+tar -cJf "$WORK_DIR/master.tar.gz" -T /dev/null
+ROOT="$(pwd)/.."
+(cd "$WORK_DIR" && ln -s "$ROOT/torchx" . && ln -s "$ROOT/examples" .)
+
 files="$(find "$(pwd)"/build -name '*.ipynb')"
 for file in $files
 do

--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -13,6 +13,7 @@ torchx.pipelines.kfp
 .. currentmodule:: torchx.pipelines.kfp.adapter
 
 .. autofunction:: container_from_app
+.. autofunction:: resource_from_app
 .. autofunction:: component_from_app
 .. autofunction:: component_spec_from_app
 

--- a/examples/pipelines/kfp/dist_pipeline.py
+++ b/examples/pipelines/kfp/dist_pipeline.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Distributed KubeFlow Pipelines Example
+======================================
+
+This is an example KFP pipeline that uses resource_from_app to launch a
+distributed operator using the kubernetes/volcano job scheduler. This only works
+in Kubernetes KFP clusters with https://volcano.sh/en/docs/ installed on them.
+"""
+
+import kfp
+from torchx import specs
+from torchx.pipelines.kfp.adapter import resource_from_app
+
+
+def pipeline() -> None:
+    # First we define our AppDef for the component, we set
+    echo_app = specs.AppDef(
+        name="test-dist",
+        roles=[
+            specs.Role(
+                name="dist-echo",
+                image="alpine",
+                entrypoint="/bin/echo",
+                args=["hello dist!"],
+                num_replicas=3,
+            ),
+        ],
+    )
+
+    # To convert the TorchX AppDef into a KFP container we use
+    # the resource_from_app adapter. This takes generates a KFP Kubernetes
+    # resource operator definition from the TorchX app def and instantiates it.
+    echo_container: kfp.dsl.BaseOp = resource_from_app(echo_app, queue="test")
+
+
+# %%
+# To generate the pipeline definition file we need to call into the KFP compiler
+# with our pipeline function.
+
+kfp.compiler.Compiler().compile(
+    pipeline_func=pipeline,
+    package_path="pipeline.yaml",
+)
+
+with open("pipeline.yaml", "rt") as f:
+    print(f.read())
+
+# %%
+# Once this has all run you should have a pipeline file (typically
+# pipeline.yaml) that you can upload to your KFP cluster via the UI or
+# a kfp.Client.
+#
+# See the
+# `KFP SDK Examples <https://www.kubeflow.org/docs/components/pipelines/tutorials/sdk-examples/#examples>`_
+# for more info on launching KFP pipelines.
+
+# %%
+# See the :ref:`Advanced KubeFlow Pipelines Example` for how to chain multiple
+# components together and use builtin components.


### PR DESCRIPTION
<!-- Change Summary -->

This adds a new `resource_to_app` KFP adapter that allows adapting an app to a kfp ResourceOp that launches the operator using the Volcano scheduler. This reuses the same code that creates the resources for the kubernetes scheduler and embeds the resource inside a KFP pipeline.

This isn't supported under KFP v2 since it interacts directly with kubernetes resources/volcano. This also requires volcano to be installed on the cluster to use which is why it's a new adapter instead of automatically being used.

This is still fairly experimental and once KFP has better distributed support we likely want to rely on that instead since this has some less than ideal UX. You need to use the CLI to access the individual worker logs and there isn't any support for UI metadata yet.

UI metadata I think can be added by providing an output annotation for argo as part of the resource but I haven't looked into it.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pyre
pytest
python dist_pipeline.py
```
http://5ab6bab9-istiosystem-istio-2af2-1926929629.us-west-2.elb.amazonaws.com/_/pipeline/#/runs/details/27707de9-bc67-42da-ab86-af2127ee54d1

![20210726_14h12m04s_grim](https://user-images.githubusercontent.com/909104/127059928-b4787429-e895-4b97-b53e-c6262e99c52b.png)

