### PR TITLE
kubernetes_scheduler: enable environment variables + add utils.sh component

### DIFF
--- a/torchx/components/utils.py
+++ b/torchx/components/utils.py
@@ -11,6 +11,8 @@ and are meant to be used as tutorial materials or glue operations between
 meaningful stages in a workflow.
 """
 
+import shlex
+
 import torchx.specs as specs
 
 
@@ -57,6 +59,30 @@ def touch(file: str) -> specs.AppDef:
                 entrypoint="/bin/touch",
                 args=[file],
                 num_replicas=1,
+            )
+        ],
+    )
+
+
+def sh(*args: str, image: str = "/tmp", num_replicas: int = 1) -> specs.AppDef:
+    """
+    Runs the provided command via sh.
+
+    Args:
+        args: bash arguments
+        image: image to use
+        num_replicas: number of replicas to run
+
+    """
+    return specs.AppDef(
+        name="sh",
+        roles=[
+            specs.Role(
+                name="sh",
+                image=image,
+                entrypoint="/bin/sh",
+                args=["-c", shlex.join(args)],
+                num_replicas=num_replicas,
             )
         ],
     )

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -71,6 +71,7 @@ JOB_STATE: Dict[str, AppState] = {
     "Terminating": AppState.RUNNING,
     # Teriminated is the phase that the job is finished unexpected, e.g. events
     "Terminated": AppState.FAILED,
+    "Failed": ReplicaState.FAILED,
 }
 
 TASK_STATE: Dict[str, ReplicaState] = {
@@ -209,6 +210,10 @@ def app_to_resource(app: AppDef, queue: str) -> Dict[str, object]:
             "queue": queue,
             "tasks": tasks,
             "maxRetry": job_retries,
+            "plugins": {
+                "svc": [],
+                "env": [],
+            },
         },
     }
     return resource

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -111,6 +111,9 @@ metadata:
   generateName: test-
 spec:
   maxRetry: 3
+  plugins:
+    env: []
+    svc: []
   queue: testqueue
   schedulerName: volcano
   tasks:


### PR DESCRIPTION
<!-- Change Summary -->

This enables environment variable plugins for the Volcano scheduler which adds extra helpful envs.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ torchx run --scheduler kubernetes --wait --scheduler_args queue=test utils.sh --image alpine:latest --num_replicas 3 env
$ torchx log kubernetes://torchx_tristanr/default:sh-rmpnr/sh/0
sh/0 2021-07-29T22:01:49.655263509Z TORCHSERVE_PORT_8082_TCP_PORT=8082
sh/0 2021-07-29T22:01:49.655283720Z TORCHSERVE_PORT_8081_TCP_PROTO=tcp
sh/0 2021-07-29T22:01:49.655287156Z KUBERNETES_SERVICE_PORT=443
sh/0 2021-07-29T22:01:49.655289501Z TORCHSERVE_PORT_8082_TCP_PROTO=tcp
sh/0 2021-07-29T22:01:49.655291622Z KUBERNETES_PORT=tcp://10.100.0.1:443
sh/0 2021-07-29T22:01:49.655293784Z TORCHSERVE_PORT=tcp://10.100.35.155:8080
sh/0 2021-07-29T22:01:49.655296001Z TORCHSERVE_SERVICE_PORT=8080
sh/0 2021-07-29T22:01:49.655298086Z HOSTNAME=sh-rmpnr-sh-0-0
sh/0 2021-07-29T22:01:49.655300231Z SHLVL=1
sh/0 2021-07-29T22:01:49.655302283Z TORCHSERVE_SERVICE_PORT_MDL=8081
sh/0 2021-07-29T22:01:49.655304757Z HOME=/root
sh/0 2021-07-29T22:01:49.655306890Z TORCHSERVE_PORT_8080_TCP=tcp://10.100.35.155:8080
sh/0 2021-07-29T22:01:49.655309130Z TORCHSERVE_SERVICE_PORT_METRICS=8082
sh/0 2021-07-29T22:01:49.655311221Z TORCHSERVE_PORT_8081_TCP=tcp://10.100.35.155:8081
sh/0 2021-07-29T22:01:49.655313421Z TORCHSERVE_PORT_8082_TCP=tcp://10.100.35.155:8082
sh/0 2021-07-29T22:01:49.655315527Z TORCHSERVE_SERVICE_PORT_PREDS=8080
sh/0 2021-07-29T22:01:49.655317591Z KUBERNETES_PORT_443_TCP_ADDR=10.100.0.1
sh/0 2021-07-29T22:01:49.655319736Z PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
sh/0 2021-07-29T22:01:49.655323075Z KUBERNETES_PORT_443_TCP_PORT=443
sh/0 2021-07-29T22:01:49.655325217Z VC_TASK_INDEX=0
sh/0 2021-07-29T22:01:49.655327274Z VC_SH-0_NUM=1
sh/0 2021-07-29T22:01:49.655329333Z KUBERNETES_PORT_443_TCP_PROTO=tcp
sh/0 2021-07-29T22:01:49.655331441Z VC_SH-1_NUM=1
sh/0 2021-07-29T22:01:49.655333513Z VC_SH-2_NUM=1
sh/0 2021-07-29T22:01:49.655335525Z VC_SH-0_HOSTS=sh-rmpnr-sh-0-0.sh-rmpnr
sh/0 2021-07-29T22:01:49.655337593Z VC_SH-1_HOSTS=sh-rmpnr-sh-1-0.sh-rmpnr
sh/0 2021-07-29T22:01:49.655339669Z VC_SH-2_HOSTS=sh-rmpnr-sh-2-0.sh-rmpnr
sh/0 2021-07-29T22:01:49.655341733Z VK_TASK_INDEX=0
sh/0 2021-07-29T22:01:49.655343757Z KUBERNETES_PORT_443_TCP=tcp://10.100.0.1:443
sh/0 2021-07-29T22:01:49.655345865Z KUBERNETES_SERVICE_PORT_HTTPS=443
sh/0 2021-07-29T22:01:49.655348113Z KUBERNETES_SERVICE_HOST=10.100.0.1
sh/0 2021-07-29T22:01:49.655350198Z PWD=/
sh/0 2021-07-29T22:01:49.655352219Z TORCHSERVE_PORT_8080_TCP_ADDR=10.100.35.155
sh/0 2021-07-29T22:01:49.655354307Z TORCHSERVE_SERVICE_HOST=10.100.35.155
sh/0 2021-07-29T22:01:49.655356381Z TORCHSERVE_PORT_8081_TCP_ADDR=10.100.35.155
sh/0 2021-07-29T22:01:49.655358454Z TORCHSERVE_PORT_8082_TCP_ADDR=10.100.35.155
sh/0 2021-07-29T22:01:49.655360522Z TORCHSERVE_PORT_8080_TCP_PORT=8080
sh/0 2021-07-29T22:01:49.655362643Z TORCHSERVE_PORT_8080_TCP_PROTO=tcp
sh/0 2021-07-29T22:01:49.655364781Z TORCHSERVE_PORT_8081_TCP_PORT=8081
```

env plugin adds:
```
sh/0 2021-07-30T16:19:03.246809861Z VC_TASK_INDEX=0
sh/0 2021-07-30T16:19:03.246818215Z VK_TASK_INDEX=0
```

svc plugin adds:
```
sh/0 2021-07-29T22:01:49.655327274Z VC_SH-0_NUM=1
sh/0 2021-07-29T22:01:49.655331441Z VC_SH-1_NUM=1
sh/0 2021-07-29T22:01:49.655333513Z VC_SH-2_NUM=1
sh/0 2021-07-29T22:01:49.655335525Z VC_SH-0_HOSTS=sh-rmpnr-sh-0-0.sh-rmpnr
sh/0 2021-07-29T22:01:49.655337593Z VC_SH-1_HOSTS=sh-rmpnr-sh-1-0.sh-rmpnr
sh/0 2021-07-29T22:01:49.655339669Z VC_SH-2_HOSTS=sh-rmpnr-sh-2-0.sh-rmpnr
```