### PR TITLE
cli, runner: improve behavior around run --wait

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -6,6 +6,7 @@
 
 import argparse
 import logging
+import sys
 from dataclasses import asdict
 from pprint import pformat
 from typing import Dict, List, Union, cast
@@ -13,7 +14,7 @@ from typing import Dict, List, Union, cast
 import torchx.specs as specs
 from pyre_extensions import none_throws
 from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
+from torchx.runner import get_runner, Runner
 from torchx.specs.finder import get_components, _Component
 from torchx.util.types import to_dict
 
@@ -110,8 +111,9 @@ class CmdRun(SubCommand):
             logger.info(app_dryrun_info)
         else:
             app_handle = cast(specs.AppHandle, result)
+            print(app_handle)
             if args.scheduler == "local":
-                runner.wait(app_handle)
+                self._wait_and_exit(runner, app_handle)
             else:
                 logger.info("=== RUN RESULT ===")
                 logger.info(f"Launched app: {app_handle}")
@@ -120,6 +122,13 @@ class CmdRun(SubCommand):
                 logger.info(f"Job URL: {none_throws(status).ui_url}")
 
                 if args.wait:
-                    logger.info("Waiting for the app to finish...")
-                    runner.wait(app_handle)
-            print(app_handle)
+                    self._wait_and_exit(runner, app_handle)
+
+    def _wait_and_exit(self, runner: Runner, app_handle: str) -> None:
+        logger.info("Waiting for the app to finish...")
+        status = runner.wait(app_handle, wait_interval=1)
+        logger.info(f"App status: {status}")
+        if not status:
+            raise RuntimeError(f"unknown status, wait returned {status}")
+        if status.state != specs.AppState.SUCCEEDED:
+            sys.exit(1)

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -55,7 +55,6 @@ class Runner:
         self,
         name: str,
         schedulers: Dict[SchedulerBackend, Scheduler],
-        wait_interval: int = 10,
     ) -> None:
         """
         Creates a new runner instance.
@@ -64,7 +63,6 @@ class Runner:
             name: the human readable name for this session. Jobs launched will
                 inherit this name.
             schedulers: a list of schedulers the runner can use.
-            wait_interval: how long to sleep between polls when waiting for app completion
         """
         if "default" not in schedulers:
             raise ValueError(
@@ -72,7 +70,6 @@ class Runner:
             )
         self._name: str = name
         self._schedulers = schedulers
-        self._wait_interval = wait_interval
         self._apps: Dict[AppHandle, AppDef] = {}
 
     def run_component(
@@ -313,7 +310,9 @@ class Runner:
                 app_status.ui_url = desc.ui_url
             return app_status
 
-    def wait(self, app_handle: AppHandle) -> Optional[AppStatus]:
+    def wait(
+        self, app_handle: AppHandle, wait_interval: float = 10
+    ) -> Optional[AppStatus]:
         """
         Block waits (indefinitely) for the application to complete.
         Possible implementation:
@@ -325,6 +324,10 @@ class Runner:
              if app_status.is_terminal():
                  return
              sleep(10)
+
+        Args:
+            app_handle: the app handle to wait for completion
+            wait_interval: the minimum interval to wait before polling for status
 
         Returns:
             The terminal status of the application, or ``None`` if the app does not exist anymore
@@ -341,7 +344,7 @@ class Runner:
                 if app_status.is_terminal():
                     return app_status
                 else:
-                    time.sleep(self._wait_interval)
+                    time.sleep(wait_interval)
 
     def list(self) -> Dict[AppHandle, AppDef]:
         """
@@ -501,7 +504,7 @@ class Runner:
         return scheduler, scheduler_backend, app_id
 
     def __repr__(self) -> str:
-        return f"Runner(name={self._name}, schedulers={self._schedulers}, apps={self._apps}, wait_interval={self._wait_interval})"
+        return f"Runner(name={self._name}, schedulers={self._schedulers}, apps={self._apps})"
 
 
 def get_runner(name: Optional[str] = None, **scheduler_params: Any) -> Runner:

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -93,7 +93,6 @@ class RunnerTest(unittest.TestCase):
         session = Runner(
             name=SESSION_NAME,
             schedulers={"default": self.scheduler},
-            wait_interval=1,
         )
         self.assertEqual(1, len(session.scheduler_backends()))
         role = Role(
@@ -106,13 +105,14 @@ class RunnerTest(unittest.TestCase):
         app = AppDef("name", roles=[role])
 
         app_handle = session.run(app, cfg=self.cfg)
-        app_status = none_throws(session.wait(app_handle))
+        app_status = none_throws(session.wait(app_handle, wait_interval=0.1))
         self.assertEqual(AppState.SUCCEEDED, app_status.state)
 
     def test_dryrun(self, _) -> None:
         scheduler_mock = MagicMock()
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": scheduler_mock}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": scheduler_mock},
         )
         role = Role(
             name="touch",
@@ -144,7 +144,8 @@ class RunnerTest(unittest.TestCase):
 
     def test_list(self, _) -> None:
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": self.scheduler}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": self.scheduler},
         )
         role = Role(
             name="touch",
@@ -173,7 +174,8 @@ class RunnerTest(unittest.TestCase):
 
         scheduler = LocalScheduler(session_name=SESSION_NAME, cache_size=1)
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": scheduler}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": scheduler},
         )
         test_file = os.path.join(self.test_dir, "test_file")
         role = Role(
@@ -189,10 +191,10 @@ class RunnerTest(unittest.TestCase):
         # run the same app twice (the first will be removed from the scheduler's cache)
         # then validate that the first one will drop from the session's app cache as well
         app_id1 = session.run(app, cfg=self.cfg)
-        session.wait(app_id1)
+        session.wait(app_id1, wait_interval=0.1)
 
         app_id2 = session.run(app, cfg=self.cfg)
-        session.wait(app_id2)
+        session.wait(app_id2, wait_interval=0.1)
 
         apps = session.list()
 
@@ -202,7 +204,8 @@ class RunnerTest(unittest.TestCase):
 
     def test_status(self, _) -> None:
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": self.scheduler}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": self.scheduler},
         )
         role = Role(
             name="sleep",
@@ -221,7 +224,8 @@ class RunnerTest(unittest.TestCase):
 
     def test_status_unknown_app(self, _) -> None:
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": self.scheduler}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": self.scheduler},
         )
         self.assertIsNone(session.status("default://test_session/unknown_app_id"))
 
@@ -273,20 +277,27 @@ class RunnerTest(unittest.TestCase):
 
     def test_wait_unknown_app(self, _) -> None:
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": self.scheduler}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": self.scheduler},
         )
-        self.assertIsNone(session.wait("default://test_session/unknown_app_id"))
-        self.assertIsNone(session.wait("default://another_session/some_app"))
+        self.assertIsNone(
+            session.wait("default://test_session/unknown_app_id", wait_interval=0.1)
+        )
+        self.assertIsNone(
+            session.wait("default://another_session/some_app", wait_interval=0.1)
+        )
 
     def test_stop(self, _) -> None:
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": self.scheduler}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": self.scheduler},
         )
         self.assertIsNone(session.stop("default://test_session/unknown_app_id"))
 
     def test_log_lines_unknown_app(self, _) -> None:
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": self.scheduler}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": self.scheduler},
         )
         with self.assertRaises(UnknownAppException):
             session.log_lines("default://test_session/unknown", "trainer")
@@ -300,7 +311,8 @@ class RunnerTest(unittest.TestCase):
         )
         scheduler_mock.log_iter.return_value = iter(["hello", "world"])
         session = Runner(
-            name=SESSION_NAME, schedulers={"default": scheduler_mock}, wait_interval=1
+            name=SESSION_NAME,
+            schedulers={"default": scheduler_mock},
         )
 
         role_name = "trainer"

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -154,7 +154,7 @@ class LocalSchedulerTest(unittest.TestCase):
         """
         scheduler_ = scheduler or self.scheduler
 
-        interval = timeout / 100
+        interval = 0.1
         expiry = time.time() + timeout
         while expiry > time.time():
             desc = scheduler_.describe(app_id)

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -28,6 +28,7 @@ from typing import (
     Union,
 )
 
+import yaml
 from pyre_extensions import none_throws
 from torchx.specs.file_linter import parse_fn_docstring, validate
 from torchx.util.io import read_conf_file
@@ -317,6 +318,9 @@ class AppState(int, Enum):
     def __str__(self) -> str:
         return self.name
 
+    def __repr__(self) -> str:
+        return f"{self.name} ({self.value})"
+
 
 _TERMINAL_STATES: List[AppState] = [
     AppState.SUCCEEDED,
@@ -403,7 +407,8 @@ class AppStatus:
         else:
             structured_error_msg_parsed = NONE
         app_status_dict["structured_error_msg"] = structured_error_msg_parsed
-        return json.dumps(app_status_dict, indent=2)
+        app_status_dict["state"] = repr(app_status_dict["state"])
+        return yaml.dump({"status": app_status_dict})
 
 
 # valid ``RunConfig`` values; only support primitives (str, int, float, bool, List[str])

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -6,7 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import json
 import pathlib
 import sys
 import unittest
@@ -61,26 +60,36 @@ class AppDefStatusTest(unittest.TestCase):
 
     def test_serialize(self) -> None:
         status = AppStatus(AppState.FAILED)
-        serialized = status.__repr__()
-        deser_status_dict = json.loads(serialized)
-        deser_status = AppStatus(**deser_status_dict)
-        self.assertEqual(status.state, deser_status.state)
-        self.assertEqual(status.msg, deser_status.msg)
-        self.assertEqual(status.structured_error_msg, deser_status.structured_error_msg)
+        serialized = repr(status)
+        self.assertEqual(
+            serialized,
+            """status:
+  msg: ''
+  num_restarts: 0
+  roles: []
+  state: FAILED (5)
+  structured_error_msg: <NONE>
+  ui_url: null
+""",
+        )
 
     def test_serialize_embed_json(self) -> None:
         status = AppStatus(
             AppState.FAILED, structured_error_msg='{"message": "test error"}'
         )
-        serialized = status.__repr__()
-        deser_status_dict = json.loads(serialized)
-        scheduler_msg = deser_status_dict.pop("structured_error_msg")
-        scheduler_msg_json = json.dumps(scheduler_msg)
-        deser_status_dict["structured_error_msg"] = scheduler_msg_json
-        deser_status = AppStatus(**deser_status_dict)
-        self.assertEqual(status.state, deser_status.state)
-        self.assertEqual(status.msg, deser_status.msg)
-        self.assertEqual(status.structured_error_msg, deser_status.structured_error_msg)
+        serialized = repr(status)
+        self.assertEqual(
+            serialized,
+            """status:
+  msg: ''
+  num_restarts: 0
+  roles: []
+  state: FAILED (5)
+  structured_error_msg:
+    message: test error
+  ui_url: null
+""",
+        )
 
 
 class ResourceTest(unittest.TestCase):


### PR DESCRIPTION
<!-- Change Summary -->

This improves the experience when --wait is used by logging the new status and using an appropriate exit code.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

  pytest

```
$ torchx run --scheduler kubernetes --wait --scheduler_args queue=test utils.sh --image alpine:latest exit 1
kubernetes://torchx_tristanr/default:sh-5vnkd
=== RUN RESULT ===
Launched app: kubernetes://torchx_tristanr/default:sh-5vnkd
App status: status:
  msg: <NONE>
  num_restarts: -1
  roles: []
  state: PENDING (2)
  structured_error_msg: <NONE>
  ui_url: null

Job URL: None
Waiting for the app to finish...
App status: status:
  msg: <NONE>
  num_restarts: -1
  roles: []
  state: FAILED (5)
  structured_error_msg: <NONE>
  ui_url: null

$ echo $status
1
```