### PR TITLE
docs/doc_push: stop on error

### DIFF
--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -29,6 +29,8 @@
 #   Makefile (redirect target)
 #  (on gh-pages branch) _layouts/docs_redirect.html
 
+set -ex
+
 dry_run=0
 for arg in "$@"; do
     shift


### PR DESCRIPTION


<!-- Change Summary -->
This makes the doc_push.sh script stop if any command fails to avoid pushing broken builds like:
https://github.com/pytorch/torchx/commit/7d7a1179747940378f10a38219ed965aef1007e7

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

screw up the build environment
```
docs/doc_push.sh
```