### PR TITLE
scripts/kfpint: remove namespace to support new KFP standalone setup

### DIFF
--- a/scripts/kfpint.py
+++ b/scripts/kfpint.py
@@ -74,7 +74,7 @@ def getenv_asserts(env: str) -> str:
     return v
 
 
-def get_client(host: str, namespace: str) -> kfp.Client:
+def get_client(host: str) -> kfp.Client:
     USERNAME = getenv_asserts("KFP_USERNAME")
     PASSWORD = getenv_asserts("KFP_PASSWORD")
 
@@ -92,7 +92,6 @@ def get_client(host: str, namespace: str) -> kfp.Client:
     return kfp.Client(
         host=f"{host}/pipeline",
         cookies=f"authservice_session={session_cookie}",
-        namespace=namespace,
     )
 
 
@@ -219,14 +218,12 @@ def path_or_tmp(path: Optional[str]) -> Iterator[str]:
 
 def run_pipeline(build: BuildInfo, pipeline_file: str) -> object:
     print(f"launching pipeline {pipeline_file}")
-    NAMESPACE: str = getenv_asserts("KFP_NAMESPACE")
     HOST: str = getenv_asserts("KFP_HOST")
 
-    client = get_client(HOST, NAMESPACE)
+    client = get_client(HOST)
     resp = client.create_run_from_pipeline_package(
         pipeline_file,
         arguments={},
-        namespace=NAMESPACE,
         experiment_name="integration-tests",
         run_name=f"integration test {build.id} - {os.path.basename(pipeline_file)}",
     )


### PR DESCRIPTION
<!-- Change Summary -->

```
kfp_server_api.exceptions.ApiException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Date': 'Fri, 06 Aug 2021 21:47:11 GMT', 'Content-Type': 'application/json', 'Content-Length': '441', 'Connection': 'keep-alive', 'x-powered-by': 'Express', 'x-envoy-upstream-service-time': '5', 'server': 'istio-envoy'})
HTTP response body: {"error":"Invalid input error: In single-user mode, ListExperiment cannot filter by namespace.","code":3,"message":"Invalid input error: In single-user mode, ListExperiment cannot filter by namespace.","details":[{"@type":"type.googleapis.c
om/api.Error","error_message":"In single-user mode, ListExperiment cannot filter by namespace.","error_details":"Invalid input error: In single-user mode, ListExperiment cannot filter by namespace."}]}
```

https://github.com/pytorch/torchx/runs/3257269850

With the updated KFP cluster it uses a KFP standalone which is limited to a single namespace. This changes the integration tests to not specify a namespace.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
scripts/kfpint.py
```
CI