### PR TITLE
(torchx/examples) fix typo (--logpat -> --logpath) in arguments to examples/apps/lightning_classy_vision/component.py

### DIFF
--- a/examples/apps/lightning_classy_vision/component.py
+++ b/examples/apps/lightning_classy_vision/component.py
@@ -51,7 +51,7 @@ def trainer(
         output_path,
         "--load_path",
         load_path,
-        "--log_pat",
+        "--log_path",
         log_path,
         "--data_path",
         data_path,


### PR DESCRIPTION
Summary: See title

Differential Revision: D30201156

