### PR TITLE
kubernetes_scheduler: avoid crash on missing Volcano status

### DIFF
--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -222,6 +222,34 @@ spec:
             ),
         )
 
+    @patch("kubernetes.client.CustomObjectsApi.get_namespaced_custom_object_status")
+    def test_describe_unknown(
+        self, get_namespaced_custom_object_status: MagicMock
+    ) -> None:
+        get_namespaced_custom_object_status.return_value = {}
+        app_id = "testnamespace:testid"
+        scheduler = create_scheduler("test")
+        info = scheduler.describe(app_id)
+        call = get_namespaced_custom_object_status.call_args
+        args, kwargs = call
+        self.assertEqual(
+            kwargs,
+            {
+                "group": "batch.volcano.sh",
+                "version": "v1alpha1",
+                "namespace": "testnamespace",
+                "plural": "jobs",
+                "name": "testid",
+            },
+        )
+        self.assertEqual(
+            info,
+            DescribeAppResponse(
+                app_id=app_id,
+                state=specs.AppState.UNKNOWN,
+            ),
+        )
+
     def test_runopts(self) -> None:
         scheduler = kubernetes_scheduler.create_scheduler("foo")
         runopts = scheduler.run_opts()


### PR DESCRIPTION
<!-- Change Summary -->

This updates the kubernetes scheduler documentation for Volcano/Kubernetes version support as well as makes the describe method not crash if Volcano has no status information available. 

See #120 for more context

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ pyre
$ pytest torchx/schedulers/test/kubernetes_scheduler_test.py

$ torchx run --scheduler kubernetes --scheduler_args queue=test utils.echo --image alpine:lat
est --msg hello
kubernetes://torchx_tristanr/default:echo-56klb
=== RUN RESULT ===
Launched app: kubernetes://torchx_tristanr/default:echo-56klb
AppStatus:
  msg: <NONE>
  num_restarts: -1
  roles: []
  state: UNKNOWN (7)
  structured_error_msg: <NONE>
  ui_url: null

Job URL: None
```

CI
