### PR TITLE
workflows: add docs push on master

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -1,4 +1,4 @@
-name: DocBuild
+name: Docs Build
 
 on:
   push:
@@ -41,3 +41,31 @@ jobs:
         run: |
           cd docs
           make papermill
+
+  docpush:
+    runs-on: ubuntu-18.04
+    needs: docbuild
+    if: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout TorchX
+        uses: actions/checkout@v2
+      - name: Set Identity
+        run: |
+          set -ex
+          git config --global user.email "runner@github.com"
+          git config --global user.name "TorchX CI Runner"
+      - name: Build
+        run: |
+          set -ex
+          docs/doc_push.sh --dry-run
+      - name: Push
+        run: |
+          set -ex
+          cd /tmp/torchx_docs_tmp/torchx_gh_pages
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git push


### PR DESCRIPTION
<!-- Change Summary -->

This adds a new docs-push variant that only runs on master. This will automatically push a new version of the website on successful build.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->


CI

https://github.com/pytorch/torchx/runs/3303839301

https://github.com/pytorch/torchx/commit/5c7eea4e70329a3e6d656515abdd30fe74661f78