### PR TITLE
Dockerfiles: use pytorch 1.9.0 instead of latest (1.8.0)

### DIFF
--- a/examples/apps/Dockerfile
+++ b/examples/apps/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch
+FROM pytorch/pytorch:1.9.0-cuda10.2-cudnn7-runtime
 
 RUN pip install classy_vision pytorch-lightning fsspec[s3] torch-model-archiver captum boto3
 

--- a/torchx/runtime/container/Dockerfile
+++ b/torchx/runtime/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch
+FROM pytorch/pytorch:1.9.0-cuda10.2-cudnn7-runtime
 
 RUN pip install fsspec[s3]
 


### PR DESCRIPTION
<!-- Change Summary -->

The docker container `pytorch/pytorch:latest` is still on pytorch 1.8.0. This updates the docker containers to use 1.9.0.
https://hub.docker.com/r/pytorch/pytorch/tags?page=1&ordering=last_updated

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
scripts/kfpint.py
```
CI
