### PR TITLE
Add component that allows to launch user job without any overhead

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -216,9 +216,9 @@ Now that you've figured out what scheduler args are required, launch your app
 .. code-block:: shell-session
 
  $ torchx run --scheduler <sched_name> --scheduler_args <k1=v1,k2=v2,...> \
-     ~/my_app.py <app_args...>
+     utils.sh ~/my_app.py <app_args...>
  $ torchx run --scheduler local --scheduler_args image_type=dir,log_dir=/tmp \
-     ~/my_app.py --foo=bar
+     utils.sh ~/my_app.py --foo=bar
 
 .. note:: If your app args overlap with the ``run`` subcommand's args, you
           have to use the ``--`` delimiter for argparse to not get confused.

--- a/torchx/components/test/utils_test.py
+++ b/torchx/components/test/utils_test.py
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torchx.components.utils as utils
+from torchx.components.test.component_test_base import ComponentTestCase
+
+
+class UtilsComponentTest(ComponentTestCase):
+    def test_sh(self) -> None:
+        self._validate(utils, "sh")
+
+    def test_touch(self) -> None:
+        self._validate(utils, "touch")
+
+    def test_echo(self) -> None:
+        self._validate(utils, "echo")

--- a/torchx/components/utils.py
+++ b/torchx/components/utils.py
@@ -66,7 +66,8 @@ def touch(file: str) -> specs.AppDef:
 
 def sh(*args: str, image: str = "/tmp", num_replicas: int = 1) -> specs.AppDef:
     """
-    Runs the provided command via sh.
+    Runs the provided command via sh. Currently sh does not support
+    environment vairable substitution.
 
     Args:
         args: bash arguments
@@ -74,6 +75,9 @@ def sh(*args: str, image: str = "/tmp", num_replicas: int = 1) -> specs.AppDef:
         num_replicas: number of replicas to run
 
     """
+
+    escaped_args = " ".join(shlex.quote(arg) for arg in args)
+
     return specs.AppDef(
         name="sh",
         roles=[
@@ -81,7 +85,7 @@ def sh(*args: str, image: str = "/tmp", num_replicas: int = 1) -> specs.AppDef:
                 name="sh",
                 image=image,
                 entrypoint="/bin/sh",
-                args=["-c", shlex.join(args)],
+                args=["-c", escaped_args],
                 num_replicas=num_replicas,
             )
         ],

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -98,11 +98,6 @@ class LocalDirectoryImageProvider(ImageProvider):
                          and if it does not exist or is not a directory
 
         """
-        if not os.path.isabs(image):
-            raise ValueError(
-                f"Invalid image name: {image}, image name must be an absolute path"
-            )
-
         if not os.path.isdir(image):
             raise ValueError(
                 f"Invalid image name: {image}, does not exist or is not a directory"


### PR DESCRIPTION
Summary:
Add component that allows to launch user job without any overhead

Currently there is no way to launch a simple user script on local scheduler via docker or dir. The diff resolves this issue.

Usage:

    torchx run --scheduler local --scheduler_args image_type=docker  \
    utils.sh --image public.ecr.aws/y5x3w0a7/aivanou-tests:latest \
     ./my_job.py

    torchx run --scheduler local utils.standalone --image ./ /apps/cifar10_trainer/trainer.py

Reviewed By: d4l3k

Differential Revision: D30262589

