### PR TITLE
specs: relax definition of cpu to be a logical cpu core

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -46,11 +46,15 @@ class Resource:
     Represents resource requirements for a ``Role``.
 
     Args:
-        cpu: number of cpu cores (note: not hyper threads)
+        cpu: number of logical cpu cores. The definition of a CPU core depends
+            on the scheduler. See your scheduler documentation for how a logical
+            CPU core maps to physical cores and threads.
         gpu: number of gpus
         memMB: MB of ram
         capabilities: additional hardware specs (interpreted by scheduler)
 
+    Note: you should prefer to use named_resources instead of specifying the raw
+    resource requirement directly.
     """
 
     cpu: int


### PR DESCRIPTION
<!-- Change Summary -->

This updates the documentation to relax the definition of CPU core from physical core to logical core as the specific schedulers / cloud providers have varying definitions of it.

I.e. in Kubernetes:

> One cpu, in Kubernetes, is equivalent to 1 vCPU/Core for cloud providers and 1 hyperthread on bare-metal Intel processors.

https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu

This makes it impossible for torchx to ensure that one cpu maps to a single physical core and thus we should document the behavior as such.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

no logic changes, CI
