### PR TITLE
schedulers/slurm_scheduler: updated to use heterogenous groups correctly

### DIFF
--- a/scripts/slurmint.sh
+++ b/scripts/slurmint.sh
@@ -38,20 +38,14 @@ function cleanup {
 }
 trap cleanup EXIT
 
+
 REMOTE_WHEEL="$DIR/$(basename "$WHEEL")"
+
+SCRIPT="scripts/slurmtest.sh"
+REMOTE_SCRIPT="$DIR/$(basename "$SCRIPT")"
 
 run_cmd mkdir "$DIR"
 run_cmd virtualenv -p /usr/bin/python3.8 "$VENV"
 run_scp "$WHEEL" "$REMOTE_WHEEL"
-run_cmd "\
-    set -ex && \
-    source /opt/slurm/etc/slurm.sh && \
-    sbatch --version && \
-    source $VENV/bin/activate && \
-    python --version && \
-    pip install $REMOTE_WHEEL && \
-    APP_ID=\"\$(torchx run --wait --scheduler slurm  utils.echo --num_replicas 3)\" && \
-    torchx status \"\$APP_ID\" && \
-    torchx describe \"\$APP_ID\" && \
-    cat \"slurm-\$(basename \$APP_ID).out\" \
-"
+run_scp "$SCRIPT" "$REMOTE_SCRIPT"
+run_cmd "$REMOTE_SCRIPT" "$REMOTE_WHEEL" "$VENV"

--- a/scripts/slurmtest.sh
+++ b/scripts/slurmtest.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+REMOTE_WHEEL="$1"
+VENV="$2"
+
+# shellcheck disable=SC1091
+source /opt/slurm/etc/slurm.sh
+sbatch --version
+# shellcheck disable=SC1090
+source "$VENV"/bin/activate
+python --version
+pip install "$REMOTE_WHEEL"
+
+APP_ID="$(torchx run --wait --scheduler slurm utils.echo --num_replicas 3)"
+torchx status "$APP_ID"
+torchx describe "$APP_ID"
+LOG_FILE="slurm-$(basename "$APP_ID").out"
+cat "$LOG_FILE"
+LINES="$(wc -l "$LOG_FILE" | cut -d' ' -f1)"
+
+if [ "$LINES" -ne 3 ]
+then
+    echo "expected 3 log lines"
+    exit 1
+fi

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -11,7 +11,7 @@ import shlex
 import subprocess
 import tempfile
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from torchx.schedulers.api import AppDryRunInfo, DescribeAppResponse, Scheduler
 from torchx.specs.api import (
@@ -22,6 +22,8 @@ from torchx.specs.api import (
     RunConfig,
     SchedulerBackend,
     macros,
+    RoleStatus,
+    ReplicaStatus,
 )
 
 
@@ -44,9 +46,9 @@ SLURM_STATES: Mapping[str, AppState] = {
 }
 
 
-def _slurm_escape(s: str) -> str:
+def _apply_app_id_env(s: str) -> str:
     """
-    _slurm_escape escapes the argument and substitutes in the macros.app_id with
+    _apply_app_id_env escapes the argument and substitutes in the macros.app_id with
     a shell expression that fills in SLURM_JOB_ID from env.
     """
     escaped_parts = [shlex.quote(part) for part in s.split(macros.app_id)]
@@ -59,50 +61,56 @@ class SlurmReplicaRequest:
     Holds parameters for a single replica running on slurm and can be materialized down to a bash script.
     """
 
+    name: str
     dir: str
     entrypoint: str
     args: List[str]
-    opts: Dict[str, str]
+    srun_opts: Dict[str, str]
+    sbatch_opts: Dict[str, str]
     env: Dict[str, str]
 
     @classmethod
-    def from_role(cls, role: Role, cfg: RunConfig) -> "SlurmReplicaRequest":
-        opts = {k: str(v) for k, v in cfg.cfgs.items()}
+    def from_role(cls, name: str, role: Role, cfg: RunConfig) -> "SlurmReplicaRequest":
+        sbatch_opts = {k: str(v) for k, v in cfg.cfgs.items()}
+        sbatch_opts.setdefault("ntasks-per-node", "1")
         resource = role.resource
 
         if resource != NONE:
             if resource.cpu > 0:
-                opts["cpus-per-task"] = str(resource.cpu)
+                sbatch_opts.setdefault("cpus-per-task", str(resource.cpu))
             if resource.memMB > 0:
-                opts["mem"] = str(resource.memMB)
+                sbatch_opts.setdefault("mem", str(resource.memMB))
             if resource.gpu > 0:
-                opts["gpus-per-task"] = str(resource.gpu)
+                sbatch_opts.setdefault("gpus-per-task", str(resource.gpu))
 
         return cls(
+            name=name,
             dir=role.image,
             entrypoint=role.entrypoint,
             args=list(role.args),
-            opts=opts,
+            sbatch_opts=sbatch_opts,
+            srun_opts={},
             env=dict(role.env),
         )
 
-    def materialize(self) -> str:
-        sbatch_opts = [f"#SBATCH --{key}={value}" for key, value in self.opts.items()]
-        sbatch_opts += [
-            f"#SBATCH --export={key}={value}" for key, value in self.env.items()
-        ]
-        sbatch_opts_str = "\n".join(sbatch_opts)
+    def materialize(self) -> Tuple[List[str], List[str]]:
+        """
+        materialize returns the sbatch and srun groups for this role. They
+        should be combined using `:` per slurm heterogenous groups.
+        """
+        sbatch_args = [
+            f"--job-name={self.name}",
+        ] + [f"--{key}={value}" for key, value in self.sbatch_opts.items()]
+        srun_args = (
+            [f"--chdir={self.dir}"]
+            + [f"--{key}={value}" for key, value in self.srun_opts.items()]
+            + [f"--export={key}={value}" for key, value in self.env.items()]
+        )
 
-        escaped_args = [_slurm_escape(arg) for arg in self.args]
+        srun_group = srun_args + [self.entrypoint] + self.args
+        srun_group = [_apply_app_id_env(arg) for arg in srun_group]
 
-        return f"""#!/bin/sh
-{sbatch_opts_str}
-
-# exit on error
-set -e
-
-srun --chdir={self.dir} {self.entrypoint} {" ".join(escaped_args)}
-"""
+        return sbatch_args, srun_group
 
 
 @dataclass
@@ -113,6 +121,28 @@ class SlurmBatchRequest:
 
     cmd: List[str]
     replicas: Dict[str, SlurmReplicaRequest]
+
+    def materialize(self) -> Tuple[List[str], str]:
+        sbatch_groups = []
+        srun_groups = []
+        for i, replica in enumerate(self.replicas.values()):
+            if i > 0:
+                sbatch_groups.append(":")
+                srun_groups.append(":")
+
+            sbatch_group, srun_group = replica.materialize()
+            sbatch_groups += sbatch_group
+            srun_groups += srun_group
+
+        script = f"""#!/bin/sh
+
+# exit on error
+set -e
+
+srun {" ".join(srun_groups)}
+"""
+        sbatch_cmd = self.cmd + sbatch_groups
+        return sbatch_cmd, script
 
 
 class SlurmScheduler(Scheduler):
@@ -149,33 +179,32 @@ class SlurmScheduler(Scheduler):
     def schedule(self, dryrun_info: AppDryRunInfo[SlurmBatchRequest]) -> str:
         req = dryrun_info.request
         with tempfile.TemporaryDirectory() as tmpdir:
-            for i, (name, body) in enumerate(req.replicas.items()):
-                path = os.path.join(tmpdir, name)
-                with open(path, "w") as f:
-                    f.write(body.materialize())
+            cmd, script = req.materialize()
+            path = os.path.join(tmpdir, "job.sh")
 
-                if i > 0:
-                    req.cmd.append(":")
-                req.cmd.append(path)
+            with open(path, "w") as f:
+                f.write(script)
 
-            p = subprocess.run(req.cmd, stdout=subprocess.PIPE, check=True)
+            cmd += [path]
+
+            p = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
             return p.stdout.decode("utf-8").strip()
 
     def _submit_dryrun(
         self, app: AppDef, cfg: RunConfig
     ) -> AppDryRunInfo[SlurmBatchRequest]:
-        cmd = ["sbatch", "--parsable", "--job-name", app.name]
+        cmd = ["sbatch", "--parsable"]
         replicas = {}
-        for i, role in enumerate(app.roles):
+        for role in app.roles:
             for replica_id in range(role.num_replicas):
                 values = macros.Values(
                     img_root=role.image,
                     app_id=macros.app_id,
                     replica_id=str(replica_id),
                 )
-                name = f"role-{i}-{role.name}-{replica_id}.sh"
+                name = f"{app.name}-{role.name}-{replica_id}"
                 replica_role = values.apply(role)
-                replicas[name] = SlurmReplicaRequest.from_role(replica_role, cfg)
+                replicas[name] = SlurmReplicaRequest.from_role(name, replica_role, cfg)
         req = SlurmBatchRequest(
             cmd=cmd,
             replicas=replicas,
@@ -199,20 +228,48 @@ class SlurmScheduler(Scheduler):
 
         reader = csv.DictReader(output, delimiter="|")
 
-        resp = DescribeAppResponse(
-            app_id=app_id,
-        )
+        roles = {}
+        roles_statuses = {}
+        msg = ""
+        app_state = AppState.UNKNOWN
         for row in reader:
-            if row["JobID"] == app_id:
-                state = row["State"]
-                resp.msg = state
-                state_enum = SLURM_STATES.get(state)
-                assert (
-                    state_enum
-                ), f"failed to translate slurm state {state} to torchx state"
-                resp.state = state_enum
+            job_id, *parts = row["JobID"].split("+")
+            if job_id != app_id:
+                continue
+            if len(parts) > 0 and "." in parts[0]:
+                # we only care about the worker not the child jobs
+                continue
 
-        return resp
+            state = row["State"]
+            msg = state
+            state_enum = SLURM_STATES.get(state)
+            assert (
+                state_enum
+            ), f"failed to translate slurm state {state} to torchx state"
+            app_state = state_enum
+
+            name_parts = row["JobName"].split("-")
+            if len(name_parts) < 3:
+                # name should always have at least 3 parts but sometimes sacct
+                # is slow to update
+                continue
+            role = name_parts[-2]
+            replica_id = int(name_parts[-1])
+            if role not in roles:
+                roles[role] = Role(name=role, num_replicas=0, image="")
+                roles_statuses[role] = RoleStatus(role, [])
+            roles[role].num_replicas += 1
+            roles_statuses[role].replicas.append(
+                ReplicaStatus(id=replica_id, role=role, state=app_state, hostname=""),
+            )
+
+        return DescribeAppResponse(
+            app_id=app_id,
+            roles=list(roles.values()),
+            roles_statuses=list(roles_statuses.values()),
+            state=app_state,
+            msg=msg,
+        )
 
 
 def create_scheduler(session_name: str, **kwargs: Any) -> SlurmScheduler:

--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -29,6 +29,9 @@ class SlurmSchedulerTest(unittest.TestCase):
             image="/some/path",
             entrypoint="echo",
             args=["hello slurm", "test"],
+            env={
+                "FOO": "bar",
+            },
             num_replicas=5,
             resource=specs.Resource(
                 cpu=2,
@@ -36,19 +39,22 @@ class SlurmSchedulerTest(unittest.TestCase):
                 gpu=3,
             ),
         )
-        script = SlurmReplicaRequest.from_role(role, specs.RunConfig()).materialize()
+        sbatch, srun = SlurmReplicaRequest.from_role(
+            "role-name", role, specs.RunConfig()
+        ).materialize()
         self.assertEqual(
-            script,
-            """#!/bin/sh
-#SBATCH --cpus-per-task=2
-#SBATCH --mem=10
-#SBATCH --gpus-per-task=3
-
-# exit on error
-set -e
-
-srun --chdir=/some/path echo 'hello slurm' test
-""",
+            sbatch,
+            [
+                "--job-name=role-name",
+                "--ntasks-per-node=1",
+                "--cpus-per-task=2",
+                "--mem=10",
+                "--gpus-per-task=3",
+            ],
+        )
+        self.assertEqual(
+            srun,
+            ["--chdir=/some/path", "--export=FOO=bar", "echo", "'hello slurm'", "test"],
         )
 
     def test_replica_request_app_id(self) -> None:
@@ -58,10 +64,12 @@ srun --chdir=/some/path echo 'hello slurm' test
             entrypoint="echo",
             args=[f"hello {specs.macros.app_id}"],
         )
-        script = SlurmReplicaRequest.from_role(role, specs.RunConfig()).materialize()
+        _, srun = SlurmReplicaRequest.from_role(
+            "role-name", role, specs.RunConfig()
+        ).materialize()
         self.assertIn(
             "echo 'hello '\"$SLURM_JOB_ID\"''",
-            script,
+            " ".join(srun),
         )
 
     def test_replica_request_run_config(self) -> None:
@@ -73,10 +81,10 @@ srun --chdir=/some/path echo 'hello slurm' test
         )
         cfg = specs.RunConfig()
         cfg.set("foo", "bar")
-        script = SlurmReplicaRequest.from_role(role, cfg).materialize()
+        sbatch, _ = SlurmReplicaRequest.from_role("role-name", role, cfg).materialize()
         self.assertIn(
-            "#SBATCH --foo=bar",
-            script,
+            "--foo=bar",
+            sbatch,
         )
 
     def test_dryrun_multi_role(self) -> None:
@@ -101,16 +109,18 @@ srun --chdir=/some/path echo 'hello slurm' test
         info = scheduler.submit_dryrun(app, specs.RunConfig())
         req = info.request
         self.assertIsInstance(req, SlurmBatchRequest)
-        self.assertEqual(req.cmd, ["sbatch", "--parsable", "--job-name", "foo"])
+        self.assertEqual(req.cmd, ["sbatch", "--parsable"])
         self.assertEqual(
             set(req.replicas.keys()),
-            {"role-0-a-0.sh", "role-0-a-1.sh", "role-1-b-0.sh"},
+            {"foo-a-0", "foo-a-1", "foo-b-0"},
         )
+
+        cmd, script = req.materialize()
 
         # check macro substitution
         self.assertIn(
             "echo 1 'hello '\"$SLURM_JOB_ID\"''",
-            req.replicas["role-0-a-1.sh"].materialize(),
+            script,
         )
 
     @patch("subprocess.run")
@@ -141,13 +151,21 @@ srun --chdir=/some/path echo 'hello slurm' test
         args, kwargs = run.call_args
         self.assertEqual(kwargs, {"stdout": subprocess.PIPE, "check": True})
         (args,) = args
-        self.assertEqual(len(args), 9)
-        self.assertEqual(args[:4], ["sbatch", "--parsable", "--job-name", "foo"])
-        self.assertTrue(args[4].endswith("role-0-a-0.sh"))
-        self.assertEqual(args[5], ":")
-        self.assertTrue(args[6].endswith("role-0-a-1.sh"))
-        self.assertEqual(args[7], ":")
-        self.assertTrue(args[8].endswith("role-1-b-0.sh"))
+        self.assertEqual(
+            args[:-1],
+            [
+                "sbatch",
+                "--parsable",
+                "--job-name=foo-a-0",
+                "--ntasks-per-node=1",
+                ":",
+                "--job-name=foo-a-1",
+                "--ntasks-per-node=1",
+                ":",
+                "--job-name=foo-b-0",
+                "--ntasks-per-node=1",
+            ],
+        )
 
     @patch("torchx.schedulers.slurm_scheduler.SlurmScheduler.describe")
     @patch("subprocess.run")
@@ -162,31 +180,39 @@ srun --chdir=/some/path echo 'hello slurm' test
 
     @patch("subprocess.run")
     def test_describe_completed(self, run: MagicMock) -> None:
-        run.return_value.stdout = b"""JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode
-53|echo|compute||1|COMPLETED|0:0
-53.batch|batch|||1|COMPLETED|0:0
-53.0|echo|||1|COMPLETED|0:0"""
+        run.return_value.stdout = b"""
+JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode|
+176+0|echo-echo-0|compute||1|COMPLETED|0:0|
+176+0.batch|batch|||1|COMPLETED|0:0|
+176+0.0|echo|||1|COMPLETED|0:0|
+176+1|echo-echo-1|compute||1|COMPLETED|0:0|
+176+1.0|echo|||1|COMPLETED|0:0|
+176+2|echo-echo-2|compute||1|COMPLETED|0:0|
+176+2.0|echo|||1|COMPLETED|0:0|
+""".strip()
 
         scheduler = create_scheduler("foo")
-        out = scheduler.describe("53")
+        out = scheduler.describe("176")
 
         self.assertEqual(run.call_count, 1)
         self.assertEqual(
             run.call_args,
             call(
-                ["sacct", "--parsable2", "-j", "53"], stdout=subprocess.PIPE, check=True
+                ["sacct", "--parsable2", "-j", "176"],
+                stdout=subprocess.PIPE,
+                check=True,
             ),
         )
 
         self.assertIsNotNone(out)
-        self.assertEqual(out.app_id, "53")
+        self.assertEqual(out.app_id, "176")
         self.assertEqual(out.msg, "COMPLETED")
         self.assertEqual(out.state, specs.AppState.SUCCEEDED)
 
     @patch("subprocess.run")
     def test_describe_running(self, run: MagicMock) -> None:
         run.return_value.stdout = b"""JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode
-54|echo|compute||1|RUNNING|0:0"""
+54|echo-echo-0|compute||1|RUNNING|0:0"""
 
         scheduler = create_scheduler("foo")
         out = scheduler.describe("54")


### PR DESCRIPTION
<!-- Change Summary -->

The previous code generated one sbatch script per worker. It turns out that sbatch only actually supports a single script. This updates the code to correctly use heterogenous groups with a single sbatch script.

The old code tried to do:

```
$ sbatch --ntasks=1 a.sh : --ntasks=1 b.sh
```

and since sbatch only handles one script, only one worker was launched.

The new code does

```
$ sbatch --ntasks=1 :  --ntasks=1 : --ntasks=1 job.sh
$ cat job.sh 
#!/bin/bash

srun hostname : hostname : echo banana
```

This allocates each worker with the resources in each sbatch group separated by `:` and then runs the actual worker with entrypoints in the corresponding srun group separated by  `:`.

https://slurm.schedmd.com/sbatch.html
https://slurm.schedmd.com/srun.html
https://slurm.schedmd.com/heterogeneous_jobs.html

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
scripts/slurmint.sh
```

Updated slurm integration test to test for 3 log lines and manually verified all workers were launched

```
$ torchx run --wait --scheduler slurm utils.echo --num_replicas 3
=== RUN RESULT ===
Launched app: slurm://torchx_ubuntu/198
AppStatus:
  msg: ''
  num_restarts: -1
  roles: []
  state: UNKNOWN (7)
  structured_error_msg: <NONE>
  ui_url: null

Job URL: None
Waiting for the app to finish...

$ torchx status slurm://torchx_ubuntu/198
AppDef:
  State: SUCCEEDED
  Num Restarts: -1
Roles:
 *echo[0]:SUCCEEDED
  echo[1]:SUCCEEDED
  echo[2]:SUCCEEDED

$ torchx describe slurm://torchx_ubuntu/198
{ 'metadata': {},
  'name': '198',
  'roles': [ { 'args': [],
               'base_image': None,
               'entrypoint': '<MISSING>',
               'env': {},
               'image': '',
               'max_retries': 0,
               'name': 'echo',
               'num_replicas': 3,
               'port_map': {},
               'resource': { 'capabilities': {},
                             'cpu': -1,
                             'gpu': -1,
                             'memMB': -1},
               'retry_policy': <RetryPolicy.APPLICATION: 'APPLICATION'>}]}


$ sacct -j 198
```

JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode
---|---|---|---|---|---|---
198+0|echo-echo-0|compute||1|COMPLETED|0:0
198+0.batch|batch|||1|COMPLETED|0:0
198+0.0|echo|||1|COMPLETED|0:0
198+1|echo-echo-1|compute||1|COMPLETED|0:0
198+1.0|echo|||1|COMPLETED|0:0
198+2|echo-echo-2|compute||1|COMPLETED|0:0
198+2.0|echo|||1|COMPLETED|0:0

