### PR TITLE
Enable dist.ddp role to run on local scheduler

### DIFF
--- a/scripts/kfpint.py
+++ b/scripts/kfpint.py
@@ -226,21 +226,15 @@ def save_advanced_pipeline_spec(path: str, build: BuildInfo) -> None:
 
     STORAGE_PATH = os.getenv("INTEGRATION_TEST_STORAGE", "/tmp/storage")
     root = os.path.join(STORAGE_PATH, id)
-    data = os.path.join(root, "data")
     output = os.path.join(root, "output")
-    logs = os.path.join(root, "logs")
 
     save_pipeline_spec(
         path,
         "advanced_pipeline.py",
-        "--data_path",
-        data,
         "--output_path",
         output,
         "--image",
         examples_image,
-        "--log_path",
-        logs,
         "--torchx_image",
         torchx_image,
         "--model_name",


### PR DESCRIPTION
Summary:
This diff enables dist.ddp to run on local scheduler. When the dist example with cifar will be landed, users will be able to dist.ddp role as:

    torchx run --scheduler local dist.ddp --image ./ --entrypoint my_job.py --launch_kwargs rdzv_backend=c10d,rdzv_endpoint=localhost:30002

Differential Revision: D30307869

