### PR TITLE
docs: add train, interpret, metrics component info + polish 

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,7 +30,7 @@ clean:
 
 # optional live version
 livehtml:
-	sphinx-autobuild --watch ../torchx --watch ../examples --re-ignore ".*examples_.*" "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	sphinx-autobuild --watch ../torchx --watch ../examples --re-ignore ".*(examples_.*|.new)" "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 papermill: html
 	./papermill.sh

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -5,13 +5,13 @@ Project Structure
 -------------------
 The top level modules in TorchX are:
 
-1. ``torchx.specs``: application spec (job definition) APIs
-2. ``torchx.components``: predefined (builtin) app specs
-3. ``torchx.runner``: given an app spec, submits the app as a job on a scheduler
-4. ``torchx.schedulers``: backend job schedulers that the runner supports
-5. ``torchx.pipelines``: adapters that convert the given app spec to a "stage" in an ML pipeline platform
-6. ``torchx.runtime``: util and abstraction libraries you can use in authoring apps (not app spec)
-7. ``torchx.cli``: CLI tool
+1. :mod:`torchx.specs`: application spec (job definition) APIs
+2. :mod:`torchx.components`: predefined (builtin) app specs
+3. :mod:`torchx.runner`: given an app spec, submits the app as a job on a scheduler
+4. :mod:`torchx.schedulers`: backend job schedulers that the runner supports
+5. :mod:`torchx.pipelines`: adapters that convert the given app spec to a "stage" in an ML pipeline platform
+6. :mod:`torchx.runtime`: util and abstraction libraries you can use in authoring apps (not app spec)
+7. :mod:`torchx.cli`: CLI tool
 
 Below is a UML diagram
 
@@ -62,7 +62,7 @@ Specifying multiple ``specs.Roles`` makes it possible to represent a
 non-homogeneous distributed application, such as those that require a single
 "coordinator" and many "workers".
 
-Refer to ``torchx.specs`` :ref:`API Docs<torchx.specs>` to learn more.
+Refer to ``torchx.specs`` :ref:`API Docs<specs:torchx.specs>` to learn more.
 
 What makes app specs flexible also makes it have many fields. The good
 news is that in most cases you don't have to build an app spec from scratch.
@@ -116,11 +116,11 @@ However **we do not recommend component composition** for maintainability
 purposes.
 
 **PROTIP 2:** To define dependencies between components, use a pipelining DSL.
-See :ref:`Pipeline Adapters` section below to understand how TorchX components
+See :ref:`basics:Pipeline Adapters` section below to understand how TorchX components
 are used in the context of pipelines.
 
 Before authoring your own component, browse through the library of
-:ref:`Builtin Components<torchx.components>` that are included with TorchX
+:ref:`Builtin Components<components:torchx.components>` that are included with TorchX
 to see if one fits your needs.
 
 
@@ -134,7 +134,7 @@ There are two ways to access runners in TorchX:
 1. CLI: ``torchx run ~/app_spec.py``
 2. Programmatically: ``torchx.runner.get_runner().run(appspec)``
 
-See :ref:`torchx.schedulers` for a list of schedulers that the runner can
+See :ref:`schedulers:torchx.schedulers` for a list of schedulers that the runner can
 launch apps to.
 
 Pipeline Adapters
@@ -198,7 +198,7 @@ The binary above makes an implicit assumption that the ``input_path``
 is an AWS S3 path. One way to make this trainer storage agnostic is to introduce
 a ``FileSystem`` abstraction layer. For file systems, frameworks like
 `PyTorch Lightning <https://www.pytorchlightning.ai/>`_  already define ``io``
-layers (lightning uses `FSSPEC <https://filesystem-spec.readthedocs.io/en/latest/index.html>`_
+layers (lightning uses `fsspec <https://filesystem-spec.readthedocs.io/en/latest/index.html>`_
 under the hood). The binary above can be rewritten to be storage agnostic with
 lightning.
 

--- a/docs/source/components/hpo.rst
+++ b/docs/source/components/hpo.rst
@@ -1,5 +1,5 @@
-HPO
-==============
+Hyperparameter Optimization
+===========================
 
 .. automodule:: torchx.components.hpo
 .. currentmodule:: torchx.components.hpo

--- a/docs/source/components/interpret.rst
+++ b/docs/source/components/interpret.rst
@@ -1,0 +1,5 @@
+Interpret
+==============
+
+.. automodule:: torchx.components.interpret
+.. currentmodule:: torchx.components.intepret

--- a/docs/source/components/metrics.rst
+++ b/docs/source/components/metrics.rst
@@ -1,0 +1,5 @@
+Metrics
+==============
+
+.. automodule:: torchx.components.metrics
+.. currentmodule:: torchx.components.metrics

--- a/docs/source/components/train.rst
+++ b/docs/source/components/train.rst
@@ -1,0 +1,5 @@
+Train
+==============
+
+.. automodule:: torchx.components.train
+.. currentmodule:: torchx.components.train

--- a/docs/source/components/utils.rst
+++ b/docs/source/components/utils.rst
@@ -6,3 +6,4 @@ Utils
 
 .. autofunction:: torchx.components.utils.echo
 .. autofunction:: torchx.components.utils.touch
+.. autofunction:: torchx.components.utils.sh

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -330,3 +330,8 @@ sphinx_gallery_conf = {
     ],
     "first_notebook_cell": first_notebook_cell,
 }
+
+# -- Options for autosectionlabel
+
+# add the document to avoid collisions for common titles
+autosectionlabel_prefix_document = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,8 +12,8 @@ as a stage in an ML pipeline/workflow. TorchX works with several mainstream
 job schedulers and ML pipeline platforms so chances are you are already familiar
 with one that works with TorchX.
 
-Just getting started? First learn the :ref:`basic concepts<Basics>` and
-take a look at the :ref:`builtin components<Components Library>` library.
+Just getting started? First learn the :ref:`basic concepts<basics:Basics>` and
+take a look at the :ref:`builtin components<index:Components Library>` library.
 
 Not finding the component or adapter you are looking for? Write a custom one
 that fits your needs by using our :ref:`SDK<torchx.api>`.
@@ -57,10 +57,13 @@ Components Library
    :maxdepth: 1
    :caption: Components
 
+   components/train
+   components/serve
+   components/interpret
+   components/metrics
+   components/hpo
    components/base
    components/distributed
-   components/serve
-   components/hpo
    components/utils
 
 Works With

--- a/docs/source/pipelines/kfp.rst
+++ b/docs/source/pipelines/kfp.rst
@@ -2,7 +2,7 @@ Kubeflow Pipelines
 ======================
 
 TorchX provides an adapter to run TorchX components as part of Kubeflow
-Pipelines. See :ref:`KubeFlow Pipelines Examples` and the
-:ref:`torchx.pipelines.kfp` for API reference.
+Pipelines. See :ref:`examples_pipelines/index:KubeFlow Pipelines Examples` and
+the :mod:`torchx.pipelines.kfp` for API reference.
 
 .. image:: kfp_diagram.jpg

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -44,7 +44,7 @@ We can see that it takes a ``--msg`` argument. Lets try running it locally
 .. note:: ``echo`` in this context is just an app spec. It is not the application
           logic itself but rather just the "job definition" for running `/bin/echo`.
           If you haven't done so already, this is a good time to read through the
-          :ref:`Basic Concepts<Basics>` familiarize yourself with the basic concepts.
+          :ref:`Basic Concepts<basics:Basics>` familiarize yourself with the basic concepts.
 
 Defining Your Own Component
 ----------------------------
@@ -122,7 +122,7 @@ Had we specified ``entrypoint=echo`` the local scheduler would have tried to inv
 If you have a pre-built application binary, setting the image to a local directory is a
 quick way to validate the application and the ``specs.AppDef``. But its not all
 that useful if you want to run the application on a remote scheduler
-(see :ref:`Running On Other Schedulers`).
+(see :ref:`quickstart:Running On Other Schedulers`).
 
 .. note:: The ``image`` string in ``specs.Role`` is an identifier to a container image
           supported by the scheduler. Refer to the scheduler documentation to find out
@@ -232,8 +232,8 @@ Now that you've figured out what scheduler args are required, launch your app
 
 Next Steps
 ------------
-1. Checkout other features of the :ref:`torchx CLI<CLI>`
-2. Learn how to author more complex app specs by referencing :ref:`torchx.specs`
-3. Browse through the collection of :ref:`builtin components<Components Library>`
+1. Checkout other features of the :ref:`torchx CLI<cli:CLI>`
+2. Learn how to author more complex app specs by referencing :ref:`specs:torchx.specs`
+3. Browse through the collection of :ref:`builtin components<index:Components Library>`
 4. Take a look at the :ref:`list of schedulers<Schedulers>` supported by the runner
 5. See which :ref:`ML pipeline platforms<Pipelines>` you can run components on

--- a/examples/pipelines/kfp/dist_pipeline.py
+++ b/examples/pipelines/kfp/dist_pipeline.py
@@ -62,5 +62,5 @@ with open("pipeline.yaml", "rt") as f:
 # for more info on launching KFP pipelines.
 
 # %%
-# See the :ref:`Advanced KubeFlow Pipelines Example` for how to chain multiple
+# See the :ref:`examples_pipelines/kfp/advanced_pipeline:Advanced KubeFlow Pipelines Example` for how to chain multiple
 # components together and use builtin components.

--- a/examples/pipelines/kfp/intro_pipeline.py
+++ b/examples/pipelines/kfp/intro_pipeline.py
@@ -72,5 +72,5 @@ with open("pipeline.yaml", "rt") as f:
 # for more info on launching KFP pipelines.
 
 # %%
-# See the :ref:`Advanced KubeFlow Pipelines Example` for how to chain multiple
+# See the :ref:`examples_pipelines/kfp/advanced_pipeline:Advanced KubeFlow Pipelines Example` for how to chain multiple
 # components together and use builtin components.

--- a/torchx/cli/__init__.py
+++ b/torchx/cli/__init__.py
@@ -125,7 +125,7 @@ subcommands to identify your job.
 
 .. note:: If the ``--scheduler`` option is not provided, then it defaults to
           the scheduler backend ``default`` which points to ``local``. To change
-          the default scheduler, see: :ref:`Registering Custom Schedulers`.
+          the default scheduler, see: :ref:`configure:Registering Custom Schedulers`.
 
 
 Inspecting what will run (dryrun)

--- a/torchx/components/__init__.py
+++ b/torchx/components/__init__.py
@@ -12,7 +12,7 @@ of job definitions. The functions that return ``specs.AppDef`` in this
 module are what we refer to as components.
 
 You can browse the library of components in the ``torchx.components`` module
-or on our :ref:`docs page<Components Library>`.
+or on our :ref:`docs page<index:Components Library>`.
 
 Components can be used out of the box by either torchx cli or torchx sdk.
 

--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -32,6 +32,10 @@ def ddp(
     """
     Distributed data parallel style application (one role, multi-replica).
 
+    This uses `Torch Elastic
+    <https://pytorch.org/docs/stable/distributed.elastic.html>`_ to manage the
+    distributed workers.
+
     Args:
         image: container image.
         entrypoint: script or binary to run within the image.

--- a/torchx/components/hpo.py
+++ b/torchx/components/hpo.py
@@ -6,4 +6,8 @@
 
 """
 <COMING SOON>
+
+Hyperparameter optimization support is not yet available.
+
+For progress and more info see: https://github.com/pytorch/torchx/issues/71
 """

--- a/torchx/components/interpret.py
+++ b/torchx/components/interpret.py
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Model interpretability is often very specific to the model and thus TorchX
+provides examples of how to create model interpretability apps and components.
+
+We recommend creating a custom application and component built using
+`Captum <https://captum.ai/>`_ .
+Captum provides a number of out of the box analyzers and renderers to understand
+your model.
+
+See the
+:ref:`examples_apps/lightning_classy_vision/interpret:Model Interpretability App Example`
+and the corresponding
+:ref:`Interpret component definition<examples_apps/lightning_classy_vision/component:Trainer Component Example>`
+for an example of how to use Captum with TorchX.
+"""

--- a/torchx/components/metrics.py
+++ b/torchx/components/metrics.py
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+For metrics we recommend using Tensorboard to log metrics directly to cloud
+storage along side your model. As the model trains you can use launch a
+tensorboard instance locally to monitor your model progress:
+
+.. code-block:: shell-session
+
+ $ tensorboard --log-dir provider://path/to/logs
+
+See the :ref:`examples_apps/lightning_classy_vision/train:Trainer App Example` for an example on how to use the PyTorch
+Lightning TensorboardLogger.
+
+A TorchX Tensorboard builtin component is being tracked via
+https://github.com/pytorch/torchx/issues/128.
+
+Reference
+----------------
+
+* PyTorch Tensorboard Tutorial https://pytorch.org/tutorials/intermediate/tensorboard_tutorial.html
+* PyTorch Lightning Loggers https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html
+
+"""

--- a/torchx/components/train.py
+++ b/torchx/components/train.py
@@ -1,0 +1,30 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Training machine learning models often requires custom train loop and custom
+code. As such, we don't provide an out of the box training loop app. We do
+however have examples for how you can construct your training app as well as
+generic components you can use to run your custom training app.
+
+
+Trainer Examples
+----------------
+
+* :ref:`examples_apps/lightning_classy_vision/component:Trainer Component Example`
+* :ref:`examples_apps/lightning_classy_vision/train:Trainer App Example`
+
+Components
+-----------
+
+These are generic components for common patterns that that can be used in your
+train components.
+
+* Single Node Component - :meth:`torchx.components.base.binary_component`
+* Distributed Data Parallel Component - :meth:`torchx.components.dist.ddp`
+
+
+"""


### PR DESCRIPTION
<!-- Change Summary -->

This adds a section for train, interpret and metrics usage under components. These don't technically have code in the modules for now but it's confusing if we don't show them at all. They provide links to the corresponding examples and docs.

This also changes https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html to append the document name since header collisions were getting annoying.

There's also some other polish to some of the other pages.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
make -C docs clean html papermill
```

![2021-08-18-172153_1249x1320_scrot](https://user-images.githubusercontent.com/909104/129988562-d0f5382e-1344-418c-abdc-5dc80fe9b5c8.png)

