### PR TITLE
kubernetes_scheduler/kfp: add pod labels and annotations

### DIFF
--- a/torchx/pipelines/kfp/adapter.py
+++ b/torchx/pipelines/kfp/adapter.py
@@ -22,7 +22,10 @@ from kubernetes.client.models import (
     V1VolumeMount,
     V1EmptyDirVolumeSource,
 )
-from torchx.schedulers.kubernetes_scheduler import app_to_resource
+from torchx.schedulers.kubernetes_scheduler import (
+    app_to_resource,
+    pod_labels,
+)
 from torchx.specs import api
 from typing_extensions import Protocol
 
@@ -176,6 +179,8 @@ def component_from_app(
                     container_port=port,
                 ),
             )
+
+        c.pod_labels.update(pod_labels(app, 0, role_spec, 0))
 
         return c
 

--- a/torchx/pipelines/kfp/test/adapter_test.py
+++ b/torchx/pipelines/kfp/test/adapter_test.py
@@ -10,6 +10,7 @@ import tempfile
 import unittest
 from typing import List, Callable
 
+import torchx
 import yaml
 from kfp import compiler, components, dsl
 from kubernetes.client.models import V1ContainerPort, V1ResourceRequirements
@@ -124,6 +125,16 @@ outputs: []
             self.assertEqual(
                 a.output_artifact_paths["mlpipeline-ui-metadata"],
                 "/tmp/outputs/mlpipeline-ui-metadata/data.json",
+            )
+            self.assertEqual(
+                a.pod_labels,
+                {
+                    "torchx.pytorch.org/version": torchx.__version__,
+                    "torchx.pytorch.org/app-name": "test",
+                    "torchx.pytorch.org/role-index": "0",
+                    "torchx.pytorch.org/role-name": "trainer",
+                    "torchx.pytorch.org/replica-id": "0",
+                },
             )
 
         self._compile_pipeline(pipeline)


### PR DESCRIPTION
<!-- Change Summary -->

This adds two things: pod labels for tracking purposes for TorchX and an annotation to volcano to disable istio sidecars.

TorchX labels:

```
LABEL_VERSION = "torchx.pytorch.org/version"
LABEL_APP_NAME = "torchx.pytorch.org/app-name"
LABEL_ROLE_INDEX = "torchx.pytorch.org/role-index"
LABEL_ROLE_NAME = "torchx.pytorch.org/role-name"
LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
```

Istio sidecars:

We currently disable istio sidecars at the namespace level via:
```
kubectl label namespaces torchx-dev istio-injection=enabled-
```

but disabling it at the pod level will work everywhere and reduce user burden.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Kubernetes / KFP integration tests CI

```
tristanr@tristanr-arch2 ~/D/torchx (k8sannotations)> torchx run --scheduler kubernetes --scheduler_args queue=test --wait utils.sh --image alpine:latest env
tristanr@tristanr-arch2 ~/D/torchx (k8sannotations)> kubectl get --namespace default pods sh-d7qm4-sh-0-0 -oyaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubernetes.io/psp: eks.privileged
    scheduling.k8s.io/group-name: sh-d7qm4
    sidecar.istio.io/inject: "false"
    volcano.sh/job-name: sh-d7qm4
    volcano.sh/job-version: "0"
    volcano.sh/queue-name: test
    volcano.sh/task-spec: sh-0
    volcano.sh/template-uid: sh-d7qm4-sh-0
  creationTimestamp: "2021-08-26T21:57:10Z"
  labels:
    torchx.pytorch.org/app-name: sh
    torchx.pytorch.org/replica-id: "0"
    torchx.pytorch.org/role-index: "0"
    torchx.pytorch.org/role-name: sh
    torchx.pytorch.org/version: 0.1.0rc0
    volcano.sh/job-name: sh-d7qm4
    volcano.sh/job-namespace: default
    volcano.sh/queue-name: test
  name: sh-d7qm4-sh-0-0
  namespace: default
  ownerReferences:
  - apiVersion: batch.volcano.sh/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: sh-d7qm4
    uid: 49615424-e184-40ff-9929-e2748ca8562b
  resourceVersion: "968176"
  selfLink: /api/v1/namespaces/default/pods/sh-d7qm4-sh-0-0
  uid: 6606d021-db1e-4edd-8503-7c87cbf08178
spec:
  containers:
  - command:
    - /bin/sh
    - -c
    - env
    env:
    - name: VK_TASK_INDEX
      value: "0"
    - name: VC_TASK_INDEX
      value: "0"
    - name: VC_SH-0_HOSTS
      valueFrom:
        configMapKeyRef:
          key: VC_SH-0_HOSTS
          name: sh-d7qm4-svc
    - name: VC_SH-0_NUM
      valueFrom:
        configMapKeyRef:
          key: VC_SH-0_NUM
          name: sh-d7qm4-svc
    image: alpine:latest
    imagePullPolicy: Always
    name: sh-0
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /etc/volcano
      name: sh-d7qm4-svc
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-z8vb9
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  hostname: sh-d7qm4-sh-0-0
  nodeName: ip-192-168-24-51.us-west-2.compute.internal
  priority: 0
  restartPolicy: Never
  schedulerName: volcano
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  subdomain: sh-d7qm4
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - configMap:
      defaultMode: 420
      name: sh-d7qm4-svc
    name: sh-d7qm4-svc
  - name: default-token-z8vb9
    secret:
      defaultMode: 420
      secretName: default-token-z8vb9
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2021-08-26T21:57:11Z"
    reason: PodCompleted
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2021-08-26T21:57:11Z"
    reason: PodCompleted
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2021-08-26T21:57:11Z"
    reason: PodCompleted
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2021-08-26T21:57:11Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://7ea2b47040ad0329b66d77c725e67d2d9d634fbf318e8d68debec2cb4591935b
    image: alpine:latest
    imageID: docker-pullable://alpine@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae
    lastState: {}
    name: sh-0
    ready: false
    restartCount: 0
    started: false
    state:
      terminated:
        containerID: docker://7ea2b47040ad0329b66d77c725e67d2d9d634fbf318e8d68debec2cb4591935b
        exitCode: 0
        finishedAt: "2021-08-26T21:57:14Z"
        reason: Completed
        startedAt: "2021-08-26T21:57:14Z"
  hostIP: 192.168.24.51
  phase: Succeeded
  podIP: 192.168.10.192
  podIPs:
  - ip: 192.168.10.192
  qosClass: BestEffort
  startTime: "2021-08-26T21:57:11Z"
```