### PR TITLE
schedulers: add feature compatibility matrix per scheduler

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.util.docfields import TypedField
 
+sys.path.append(os.path.abspath("./ext"))
 
 if True:  # stop isort from reordering
     sys.path.append(os.path.abspath("../.."))
@@ -59,6 +60,7 @@ extensions = [
     "sphinxcontrib.katex",
     "sphinx.ext.autosectionlabel",
     "sphinx_gallery.gen_gallery",
+    "compatibility",
 ]
 
 # katex options

--- a/docs/source/ext/compatibility.py
+++ b/docs/source/ext/compatibility.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import yaml
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+COMPATIBILITY_SETS = {
+    "scheduler": {
+        "logs": "Fetch Logs",
+        "distributed": "Distributed Jobs",
+        "cancel": "Cancel Job",
+        "describe": "Describe Job",
+    },
+}
+
+
+class CompatibilityDirective(SphinxDirective):
+    # this enables content in the directive
+    has_content = True
+
+    def run(self):
+        """
+        targetid = "todo-%d" % self.env.new_serialno("todo")
+        targetnode = nodes.target("", "", ids=[targetid])
+        todo_node = todo("\n".join(self.content))
+        todo_node += nodes.title(_("Todo"), _("Todo"))
+        self.state.nested_parse(self.content, self.content_offset, todo_node)
+        if not hasattr(self.env, "todo_all_todos"):
+            self.env.todo_all_todos = []
+
+        self.env.todo_all_todos.append(
+            {
+                "docname": self.env.docname,
+                "lineno": self.lineno,
+                "todo": todo_node.deepcopy(),
+                "target": targetnode,
+            }
+        )
+        """
+
+        raw_content = "\n".join(self.content)
+        args = yaml.safe_load(raw_content)
+        fields = COMPATIBILITY_SETS[args["type"]]
+        features = args["features"]
+
+        assert set(fields.keys()) == set(
+            features.keys()
+        ), f"features keys don't match expected {list(fields.keys())}"
+
+        table = nodes.table("")
+        group = nodes.tgroup("", cols=2)
+        table.append(group)
+        group.append(nodes.colspec("", colwidth=20))
+        group.append(nodes.colspec("", colwidth=80))
+
+        head = nodes.thead("")
+        group.append(head)
+        head_row = nodes.row()
+        head.append(head_row)
+
+        headers = ["Feature", "Scheduler Support"]
+        for header in headers:
+            entry = nodes.entry()
+            entry += nodes.paragraph(text=header)
+            head_row.append(entry)
+
+        body = nodes.tbody("")
+        group.append(body)
+
+        for field, name in fields.items():
+            row = nodes.row("")
+            row.append(nodes.entry("", nodes.paragraph(text=name)))
+            value = features[field]
+            if value is True:
+                text = "✔️"
+            elif value is False:
+                text = "❌"
+            else:
+                text = value
+            row.append(nodes.entry("", nodes.paragraph(text=text)))
+            body.append(row)
+
+        return [
+            table,
+        ]
+
+
+def setup(app):
+    app.add_directive("compatibility", CompatibilityDirective)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -250,6 +250,16 @@ class KubernetesScheduler(Scheduler):
         kubernetes://torchx_user/1234
         $ torchx status kubernetes://torchx_user/1234
         ...
+
+    .. compatibility::
+        type: scheduler
+        features:
+            cancel: true
+            logs: true
+            distributed: true
+            describe: |
+                Partial support. KubernetesScheduler will return job and replica
+                status but does not provide the complete original AppSpec.
     """
 
     def __init__(self, session_name: str, client: Optional["ApiClient"] = None) -> None:

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -399,10 +399,20 @@ class LocalScheduler(Scheduler):
     4. Retry counts (no retries supported)
     5. Deployment preferences
 
-    ..note:: Use this scheduler sparingly since an application
-             that runs successfully on a session backed by this
-             scheduler may not work on an actual production cluster
-             using a different scheduler.
+    .. note::
+        Use this scheduler sparingly since an application that runs successfully
+        on a session backed by this scheduler may not work on an actual
+        production cluster using a different scheduler.
+
+    .. compatibility::
+        type: scheduler
+        features:
+            cancel: true
+            logs: true
+            distributed: |
+                LocalScheduler supports multiple replicas but all replicas will
+                execute on the local host.
+            describe: true
     """
 
     def __init__(self, session_name: str, cache_size: int = 100) -> None:

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -171,6 +171,18 @@ class SlurmScheduler(Scheduler):
         $ torchx status slurm://torchx_user/1234
         $ less slurm-1234.out
         ...
+
+    .. compatibility::
+        type: scheduler
+        features:
+            cancel: true
+            logs: |
+                Logs are accessible via the default slurm log file but not the
+                programmatic API.
+            distributed: true
+            describe: |
+                Partial support. SlurmScheduler will return job and replica
+                status but does not provide the complete original AppSpec.
     """
 
     def __init__(self, session_name: str) -> None:


### PR DESCRIPTION
<!-- Change Summary -->

This adds a feature compatibility matrix. It's implemented as a sphinx extension and can easily updated to add new feature compatibility tables such as for pipelines.




Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ env O="--port 4444" make clean livehtml
```

![2021-08-26-183430_887x844_scrot](https://user-images.githubusercontent.com/909104/131057580-bec803e9-7b05-441a-a994-c5a905f96871.png)
![2021-08-26-183421_815x399_scrot](https://user-images.githubusercontent.com/909104/131057581-1f4bd2cd-2b47-400a-b2e0-e63857ee2ffc.png)
![2021-08-26-183357_884x995_scrot](https://user-images.githubusercontent.com/909104/131057582-5f316015-e72b-47a3-b9f8-a8941d20a1e9.png)

