### PR TITLE
(torchx/hpo) v0 proof-of-concept of torchx<>ax plugin (#683)

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dependencies
         run: |
           set -eux
-          pip install -r dev-requirements.txt
+          pip install -e .[dev]
           pip install -r docs/requirements.txt
       - name: Install TorchX
         run: |

--- a/.github/workflows/pyre.yaml
+++ b/.github/workflows/pyre.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dependencies
         run: |
           set -eux
-          pip install -r dev-requirements.txt
+          pip install -e .[dev]
           VERSION=$(grep "version" .pyre_configuration | sed -n -e 's/.*\(0\.0\.[0-9]*\).*/\1/p')
           pip install pyre-check-nightly==$VERSION
       - name: Run Pyre

--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
-          pip install -r dev-requirements.txt
+          pip install -e .[dev]
       - name: Run tests
+
         run: python -m unittest discover --verbose --start-directory . --pattern "*_test.py"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ ts>=0.5.1
 torchserve>=0.4.0
 captum>=0.3.1
 importlib-metadata
+ax-platform[mysql]>=0.2.1

--- a/torchx/apps/hpo/ax.py
+++ b/torchx/apps/hpo/ax.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, Dict, Optional, Set, cast
+
+import pandas as pd
+from ax.core import Trial
+from ax.core.abstract_data import AbstractDataFrameData
+from ax.core.base_trial import BaseTrial
+from ax.core.data import Data
+from ax.core.metric import Metric
+from ax.core.runner import Runner as ax_Runner
+from ax.service.scheduler import Scheduler as ax_Scheduler, TrialStatus
+from pyre_extensions import none_throws
+from torchx.runner import Runner, get_runner
+from torchx.specs import AppDef, AppState, AppStatus, RunConfig
+
+
+_TORCHX_APP_HANDLE: str = "torchx_app_handle"
+_TORCHX_RUNNER: str = "torchx_runner"
+
+# maps torchx AppState to Ax's TrialStatus equivalent
+APP_STATE_TO_TRIAL_STATUS: Dict[AppState, TrialStatus] = {
+    AppState.UNSUBMITTED: TrialStatus.CANDIDATE,
+    AppState.SUBMITTED: TrialStatus.STAGED,
+    AppState.PENDING: TrialStatus.STAGED,
+    AppState.RUNNING: TrialStatus.RUNNING,
+    AppState.SUCCEEDED: TrialStatus.COMPLETED,
+    AppState.CANCELLED: TrialStatus.ABANDONED,
+    AppState.FAILED: TrialStatus.FAILED,
+    AppState.UNKNOWN: TrialStatus.FAILED,
+}
+
+
+class AppMetric(Metric):
+    def fetch_trial_data(
+        self, trial: BaseTrial, **kwargs: Any
+    ) -> AbstractDataFrameData:
+        # TODO implement
+        # sketch of idea:
+        #  1. Have the job take --trial_result_path = s3://foo/bar
+        #     (the argument name can be whatever, we just care about the uri)
+        #  2. Read the uri
+        #  3. return the resulting metrics wrapped in ax.core.data.Data
+        #
+        # for now just return the trial idx
+
+        # no need to check for trial type since we checked already in TorchXRunner
+        # and refused to run anythin other than trials of type `Trial`
+
+        df_dict = {
+            "arm_name": none_throws(cast(Trial, trial).arm).name,
+            "trial_index": trial.index,
+            "metric_name": self.name,  # FIXME get this from the output file
+            "mean": trial.index,  # FIXME get this from the output file
+            "sem": None,
+        }
+        return Data(df=pd.DataFrame.from_records([df_dict]))
+
+
+class TorchXRunner(ax_Runner):
+    """
+    An implementation of ``ax.core.runner.Runner`` that delegates job submission
+    to the TorchX Runner. This runner is coupled with the torchx component
+    since Ax runners run trials of a single component with different parameters.
+
+    It is expected that the experiment parameter names and types match
+    EXACTLY with component function args.
+
+    For example for the component shown below:
+
+    .. code-block:: python
+
+     def trainer_component(x1: int, x2: float) -> spec.AppDef:
+        # ... implementation omitted for brevity ...
+        pass
+
+    The experiment should be set up as:
+
+    .. code-block:: python
+
+     parameters=[
+       {
+         "name": "x1",
+         "value_type": "int",
+         # ... other options...
+       },
+       {
+         "name": "x2",
+         "value_type": "float",
+         # ... other options...
+       }
+     ]
+
+    """
+
+    def __init__(
+        self,
+        component: Callable[..., AppDef],
+        scheduler: str,
+        scheduler_args: Optional[RunConfig] = None,
+        torchx_runner: Optional[Runner] = None,
+    ) -> None:
+        self._component: Callable[..., AppDef] = component
+        self._scheduler: str = scheduler
+        self._scheduler_args: Optional[RunConfig] = scheduler_args
+        # need to use the same runner in case it has state
+        # e.g. torchx's local_scheduler has state hence need to poll status
+        # on the same scheduler instance
+        self._torchx_runner: Runner = torchx_runner or get_runner()
+
+    def run(self, trial: BaseTrial) -> Dict[str, Any]:
+        """
+        Submits the trial (which maps to an AppDef) as a job
+        onto the scheduler using ``torchx.runner``.
+
+        ..  note:: only supports `Trial` (not `BatchTrial`).
+        """
+
+        if not isinstance(trial, Trial):
+            raise ValueError(
+                f"{type(trial)} is not supported. Check your experiment setup"
+            )
+
+        # TODO add type + param check here
+        parameters = none_throws(trial.arm).parameters or {}
+        appdef = self._component(**parameters)
+
+        app_handle = self._torchx_runner.run(
+            appdef, self._scheduler, self._scheduler_args
+        )
+        return {_TORCHX_APP_HANDLE: app_handle, _TORCHX_RUNNER: self._torchx_runner}
+
+
+class TorchXScheduler(ax_Scheduler):
+    """
+    An implementation of an `Ax Scheduler<https://ax.dev/tutorials/scheduler.html>`_
+    that works with Experiments hooked up with the ``TorchXRunner``.
+
+    This scheduler is not a real scheduler but rather a facade scheduler
+    that delegates to scheduler clients for various remote/local schedulers.
+    For a list of supported schedulers please refer to TorchX
+    `scheduler docs<https://pytorch.org/torchx/latest/schedulers.html>`_.
+
+    """
+
+    def poll_trial_status(self) -> Dict[TrialStatus, Set[int]]:
+        trial_statuses: Dict[TrialStatus, Set[int]] = {}
+
+        for trial in self.running_trials:
+            app_handle: str = trial.run_metadata[_TORCHX_APP_HANDLE]
+            torchx_runner = trial.run_metadata[_TORCHX_RUNNER]
+            app_status: AppStatus = torchx_runner.status(app_handle)
+            trial_status = APP_STATE_TO_TRIAL_STATUS[app_status.state]
+
+            indices = trial_statuses.setdefault(trial_status, set())
+            indices.add(trial.index)
+
+        return trial_statuses
+
+    def poll_available_capacity(self) -> Optional[int]:
+        """
+        Used when ``run_trials_in_batches`` option is set.
+        Since this scheduler is a faux scheduler, this method
+        always returns the ``max_parallelism`` of the current
+        step of this scheduler's ``generation_strategy``.
+
+        .. note:: The trials (jobs) are simply submitted to the
+                  scheduler in parallel. Typically the trials will be
+                  queued in the scheduler's job queue (on the server-side)
+                  and executed according to the scheduler's job priority
+                  and scheduling policies.
+
+        """
+
+        return self.generation_strategy._curr.max_parallelism

--- a/torchx/apps/hpo/test/__init__.py
+++ b/torchx/apps/hpo/test/__init__.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.

--- a/torchx/apps/hpo/test/ax_test.py
+++ b/torchx/apps/hpo/test/ax_test.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import List, cast
+
+from ax.core import (
+    BatchTrial,
+    ChoiceParameter,
+    Experiment,
+    FixedParameter,
+    Objective,
+    OptimizationConfig,
+    Parameter,
+    ParameterType,
+    SearchSpace,
+    Trial,
+)
+from ax.modelbridge.dispatch_utils import choose_generation_strategy
+from ax.service.scheduler import SchedulerOptions
+from ax.service.utils.best_point import get_best_parameters
+from ax.service.utils.report_utils import exp_to_df
+from pyre_extensions import none_throws
+from torchx.apps.hpo.ax import AppMetric, TorchXRunner, TorchXScheduler
+from torchx.components import utils
+
+
+def is_ci() -> bool:
+    import os
+
+    return os.getenv("GITHUB_ACTIONS") is not None
+
+
+@unittest.skipIf(is_ci(), "re-enable when a new version of ax-platform releases")
+class TorchXSchedulerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._parameters: List[Parameter] = [
+            ChoiceParameter(
+                name="msg",
+                parameter_type=ParameterType.STRING,
+                # generate enough search dimensions for the # of trials
+                values=[f"hello_{i}" for i in range(30)],
+            ),
+            FixedParameter(
+                name="num_replicas",
+                parameter_type=ParameterType.INT,
+                value=1,
+            ),
+        ]
+
+        self._minimize = True
+        self._objective = Objective(
+            metric=AppMetric(name="foobar"), minimize=self._minimize
+        )
+
+        self._runner = TorchXRunner(component=utils.echo, scheduler="local")
+
+    def test_run_experiment_locally(self) -> None:
+        # runs optimization over n rounds of k sequential trials
+
+        experiment = Experiment(
+            name="torchx_echo_sequential_demo",
+            search_space=SearchSpace(parameters=self._parameters),
+            optimization_config=OptimizationConfig(objective=self._objective),
+            runner=self._runner,
+            is_test=True,
+        )
+
+        # maybe add-on RunConfig into SchedulerOption?
+        # so that we can pass it from one place
+        scheduler = TorchXScheduler(
+            experiment=experiment,
+            generation_strategy=(
+                choose_generation_strategy(
+                    search_space=experiment.search_space,
+                )
+            ),
+            options=SchedulerOptions(),
+        )
+
+        for i in range(2):
+            scheduler.run_n_trials(max_trials=3)
+
+        # print statement intentional for demo purposes
+        print(exp_to_df(experiment))
+
+        # AppMetrics always returns trial index; hence the best
+        # experiment for min objective will be the params for trial 0
+        best_param, _ = none_throws(get_best_parameters(experiment))
+
+        self.assertEqual(
+            none_throws(cast(Trial, experiment.trials[0]).arm).parameters, best_param
+        )
+
+    def test_run_experiment_locally_in_batches(self) -> None:
+        # runs optimization over k x n rounds of k parallel trials
+        # note:
+        #   1. setting max_parallelism_cap in generation_strategy
+        #   2. setting run_trials_in_batches in scheduler options
+        #   3. setting total_trials = parallelism * rounds
+        #
+        # this asks ax to run up to max_parallelism_cap trials
+        # in parallel by submitting them to the scheduler at the same time
+
+        parallelism = 3
+        rounds = 2
+
+        experiment = Experiment(
+            name="torchx_echo_parallel_demo",
+            search_space=SearchSpace(parameters=self._parameters),
+            optimization_config=OptimizationConfig(objective=self._objective),
+            runner=self._runner,
+            is_test=True,
+        )
+
+        # maybe add-on RunConfig into SchedulerOption?
+        # so that we can pass it from one place
+        scheduler = TorchXScheduler(
+            experiment=experiment,
+            generation_strategy=(
+                choose_generation_strategy(
+                    search_space=experiment.search_space,
+                    max_parallelism_cap=parallelism,
+                )
+            ),
+            options=SchedulerOptions(
+                run_trials_in_batches=True, total_trials=(parallelism * rounds)
+            ),
+        )
+
+        scheduler.run_all_trials()
+        # print statement intentional for demo purposes
+        print(exp_to_df(experiment))
+
+        # AppMetrics always returns trial index; hence the best
+        # experiment for min objective will be the params for trial 0
+        best_param, _ = none_throws(get_best_parameters(experiment))
+
+        self.assertEqual(
+            none_throws(cast(Trial, experiment.trials[0]).arm).parameters,
+            best_param,
+        )
+
+    def test_runner_no_batch_trials(self) -> None:
+        experiment = Experiment(
+            name="runner_test",
+            search_space=SearchSpace(parameters=self._parameters),
+            optimization_config=OptimizationConfig(objective=self._objective),
+            runner=self._runner,
+            is_test=True,
+        )
+
+        runner = TorchXRunner(component=utils.echo, scheduler="local")
+
+        with self.assertRaises(ValueError):
+            runner.run(trial=BatchTrial(experiment))


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebook/Ax/pull/683

Adds ax<>torchx plugin. Implements:

1. TorchXScheduler (ax scheduler that delegates to TorchXRunner)
2. TorchXRunner (TorchXRunner that delegates to the actual `torchx.runner`)
3. AppMetrics (WIP - pull metrics from a blob store uri)

NOTE: ~~still need to address the TODOs and FIXMEs. Publishing early for RFC.~~ In the interest of XFN I'd like to land this as is with a couple of fast followups (to be done within a week) to put this in a workable state:
1. Properly handle trial results (currently we return trial index as the metric, which is nonsense)
1. Move the TorchX-Ax-Scheduler, Metric, and Runner implementations to `torchx.runtime.hpo.ax` (since these are designed for programmatic usages by the end user).
1. Author a generic main method for the simplest hpo search (would serve as an expository example for users to follow).
1. Add all the above to the torchx hpo docs page.

Reviewed By: d4l3k

Differential Revision: D30320103

