### PR TITLE
Add dist train integ tests

### DIFF
--- a/.github/workflows/kubernetes-dist-train-integration-tests.yaml
+++ b/.github/workflows/kubernetes-dist-train-integration-tests.yaml
@@ -1,0 +1,55 @@
+name: Kubernetes Dist Train Integration Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  kubernetes-launch:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout TorchX
+        uses: actions/checkout@v2
+      - name: Configure Kube Config
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -eux
+          if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+            aws eks update-kubeconfig --region=us-west-2 --name=${{ secrets.EKS_CLUSTER_NAME }}
+          fi
+      - name: Configure Docker
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -eux
+          if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+            aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 495572122715.dkr.ecr.us-west-2.amazonaws.com
+          fi
+      - name: Install dependencies
+        run: |
+          set -eux
+          pip install -e .[kubernetes]
+      - name: Run Kubernetes Integration Tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
+          CONTAINER_REPO: ${{ secrets.CONTAINER_REPO }}
+        run: |
+          if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+            # only dryrun if no secrets
+            ARGS="--dryrun"
+          else
+            ARGS=
+          fi
+          scripts/kube_dist_trainer.py $ARGS

--- a/scripts/integ_test_utils.py
+++ b/scripts/integ_test_utils.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import binascii
+import dataclasses
+import os
+import subprocess
+from getpass import getuser
+
+
+@dataclasses.dataclass
+class BuildInfo:
+    id: str
+    torchx_image: str
+    examples_image: str
+
+
+class MissingEnvError(AssertionError):
+    pass
+
+
+def getenv_asserts(env: str) -> str:
+    v = os.getenv(env)
+    if not v:
+        raise MissingEnvError(f"must have {env} environment variable")
+    return v
+
+
+def rand_id() -> str:
+    return binascii.b2a_hex(os.urandom(8)).decode("utf-8")
+
+
+def run(*args: str) -> None:
+    print(f"run {args}")
+    subprocess.run(args, check=True)
+
+
+def run_in_bg(*args: str) -> "subprocess.Popen[str]":
+    print(f"run {args}")
+    return subprocess.Popen(args)
+
+
+def build_examples_canary(id: str) -> str:
+    examples_tag = "torchx_examples_canary"
+
+    print(f"building {examples_tag}")
+    run("docker", "build", "-t", examples_tag, "examples/apps/")
+
+    return examples_tag
+
+
+def build_torchx_canary(id: str) -> str:
+    torchx_tag = "torchx_canary"
+
+    print(f"building {torchx_tag}")
+    run("./torchx/runtime/container/build.sh")
+    run("docker", "tag", "torchx", torchx_tag)
+
+    return torchx_tag
+
+
+def torchx_container_tag(id: str) -> str:
+    CONTAINER_REPO = getenv_asserts("CONTAINER_REPO")
+    return f"{CONTAINER_REPO}:canary_{id}_torchx"
+
+
+def examples_container_tag(id: str) -> str:
+    CONTAINER_REPO = getenv_asserts("CONTAINER_REPO")
+    return f"{CONTAINER_REPO}:canary_{id}_examples"
+
+
+def build_images() -> BuildInfo:
+    id = f"{getuser()}_{rand_id()}"
+    examples_image = build_examples_canary(id)
+    torchx_image = build_torchx_canary(id)
+    return BuildInfo(
+        id=id,
+        torchx_image=torchx_image,
+        examples_image=examples_image,
+    )
+
+
+def push_images(build: BuildInfo) -> None:
+    examples_tag = examples_container_tag(build.id)
+    run("docker", "tag", build.examples_image, examples_tag)
+    build.examples_image = examples_tag
+
+    torchx_tag = torchx_container_tag(build.id)
+    run("docker", "tag", build.torchx_image, torchx_tag)
+    build.torchx_image = torchx_tag
+
+    run("docker", "push", examples_tag)
+    run("docker", "push", torchx_tag)

--- a/scripts/kube_dist_trainer.py
+++ b/scripts/kube_dist_trainer.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Kubernetes integration tests.
+"""
+
+import argparse
+import os
+
+from examples.apps.dist_cifar.component import trainer
+
+# pyre-ignore-all-errors[21] # Cannot find module utils
+# pyre-ignore-all-errors[11]
+from integ_test_utils import (
+    MissingEnvError,
+    build_images,
+    push_images,
+    BuildInfo,
+)
+from pyre_extensions import none_throws
+from torchx.runner import get_runner
+from torchx.specs import Resource, named_resources, RunConfig, AppState
+
+GiB: int = 1024
+
+
+def register_gpu_resource() -> None:
+    res = Resource(
+        cpu=2,
+        gpu=1,
+        memMB=4 * GiB,
+    )
+    print(f"Registering resource: {res}")
+    named_resources["GPU_X1"] = res
+
+
+def build_and_push_image() -> BuildInfo:
+    build = build_images()
+    push_images(build)
+    return build
+
+
+def run_job(dryrun: bool = False) -> None:
+    register_gpu_resource()
+    build = build_and_push_image()
+    image = build.examples_image
+    runner = get_runner("kubeflow-dist-runner")
+
+    storage_path = os.getenv("INTEGRATION_TEST_STORAGE", "/tmp/storage")
+    root = os.path.join(storage_path, build.id)
+    output_path = os.path.join(root, "output")
+
+    args = ("--output_path", output_path)
+    train_app = trainer(
+        *args,
+        image=image,
+        resource="GPU_X1",
+        nnodes=2,
+        rdzv_backend="etcd-v2",
+        rdzv_endpoint="etcd-server:2379",
+    )
+    print(f"Starting Trainer with args: {args}")
+    cfg = RunConfig()
+    cfg.set("namespace", "default")
+    cfg.set("queue", "default")
+    print("Submitting pods")
+    if dryrun:
+        dryrun_info = runner.dryrun(train_app, "kubernetes", cfg)
+        print(f"Dryrun info: {dryrun_info}")
+    else:
+        app_handle = runner.run(train_app, "kubernetes", cfg)
+        print(app_handle)
+        runner.wait(app_handle)
+        final_status = runner.status(app_handle)
+        print(f"Final status: {final_status}")
+        if none_throws(final_status).state != AppState.SUCCEEDED:
+            raise Exception(f"Dist app failed with status: {final_status}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="kubernetes dist trainer integration test runner"
+    )
+    parser.add_argument(
+        "--dryrun",
+        action="store_true",
+        help="Does not actually submit the app," " just prints the scheduler request",
+    )
+    args = parser.parse_args()
+
+    try:
+        run_job(args.dryrun)
+    except MissingEnvError:
+        print("Skip runnig tests, executed only docker buid step")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
The diff adds github workflow that runs cifar10 distributed train on 2 GPU instances.

The github workflow is similar to `kfp_integ_tests` workflow. Maybe it makes sense in future to merge them, to avoid duplication on building and pushing the same docker images.

The diff extracts common functionality between kfp workflow and dist trainer workflow into `utils` module.

Add `dryrun` to `runner.run` method to be consistent with `run_component` method

Differential Revision: D30654498

