### PR TITLE
docs: add component and app best practices documentation

### DIFF
--- a/docs/source/app_best_practices.rst
+++ b/docs/source/app_best_practices.rst
@@ -1,0 +1,183 @@
+App Best Practices
+====================
+
+TorchX apps can be written using any language as well as with any set of
+libraries to allow for maximum flexibility. However, we do have a standard set
+of recommended libraries and practices to have a starting point for users and to
+provide consistency across the built in components and applications.
+
+See :ref:`component_best_practices:Component Best Practices` for information how to handle component
+management and AppDefs.
+
+Data Passing and Storage
+--------------------------
+
+We recommend
+`fsspec <https://filesystem-spec.readthedocs.io/en/latest/index.html>`__. fsspec
+allows pluggable filesystems so apps can be written once and run on most
+infrastructures just by changing the input and output paths.
+
+TorchX builtin components use fsspec for all storage access to make it possible
+to run in new environments by using a different fsspec backend or by adding a
+new one.
+
+Pytorch Lightning supports fsspec out of the box so using fsspec elsewhere makes
+it seamless to integrate in with your trainer.
+
+Using remote storage also makes it easier to transition your apps to running
+with distributed support via libraries such as
+`torch.distributed.elastic <https://pytorch.org/docs/stable/distributed.elastic.html>`__.
+
+Train Loops
+-------------
+
+There are lots of ways to structure a training loop and it depends a lot on your
+model type and architecture which is why we don't provide one out of the box.
+
+Some common choices are:
+
+* Pure Pytorch
+* Use a managed train loop
+    * `Pytorch Lighting <https://pytorch-lightning.readthedocs.io/en/latest/>`__
+    * `Pytorch Ignite <https://github.com/pytorch/ignite>`__
+
+See :ref:`components/train:Train` for more information.
+
+
+Metrics
+----------------
+
+For logging metrics and monitoring your job we recommend using standalone
+Tensorboard since it's supported natively by
+`Pytorch tensorboard integrations <https://pytorch.org/tutorials/intermediate/tensorboard_tutorial.html>`__
+and
+`Pytorch Lightning logging <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html>`__.
+
+Since Tensorboard can log to remote storage like s3 or gcs you can view complex
+information about your model while it's training.
+
+See :ref:`components/metrics:Metrics` for more information on metric handling
+within TorchX.
+
+Checkpointing
+----------------
+
+Periodic checkpoints allow your application to recover from failures and in some
+cases allow you to restart your trainer with different parameters without losing
+training progress.
+
+`Pytorch Lighting <https://pytorch-lightning.readthedocs.io/en/latest/common/weights_loading.html#checkpoint-saving>`__
+provides a standardized way to checkpoint your models to an fsspec remote path.
+
+Fine Tuning
+-------------
+
+To support things like transfer learning, fine tuning and resuming from
+checkpoints we recommend having a command line argument to your app that will
+resume from a checkpoint file.
+
+This will allow you to recover from transient errors, continue train on new
+data, or later adjust the learning rate without losing training progress.
+
+Having load support allows for less code and better maintainability since you
+can have one app doing a number of similar tasks.
+
+Interpretability
+----------------
+
+We recommend `captum <https://captum.ai/>`__ for model interpretability and
+analysing model results. This can be used interactively from a Jupyter notebook
+or from a component.
+
+See :ref:`components/interpret:Interpret` for more information.
+
+Hyper Parameter Optimization
+------------------------------
+
+See :ref:`components/hpo:Hyperparameter Optimization` for more information.
+
+
+Model Packaging
+-----------------
+
+The pytorch community hasn't standardized on one package format. Here's a couple
+of options and when you might need to use them.
+
+Python + Saved Weights
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is the most common format for packaging models. To use you'll load your
+model definition from a python file and then you'll load the weights and state
+dict from a `.ckpt` or `.pt` file.
+
+This is how Pytorch Lightning's
+`ModelCheckpoint <https://pytorch-lightning.readthedocs.io/en/latest/extensions/generated/pytorch_lightning.callbacks.ModelCheckpoint.html>`__ hook works.
+
+This is generally the most common but makes it harder to make a reusable app
+since your trainer app needs to include the model definition code.
+
+TorchScript Models
+^^^^^^^^^^^^^^^^^^^^^^
+
+TorchScript is a way to create serializable and optimized Pytorch models that
+can be executed without Python. This can be used for inference or training in a
+performant way without relying on Python's GIL.
+
+These model files are completely self described but not all pytorch models can
+be automatically converted to TorchScript.
+
+See the `TorchScript documentation <https://pytorch.org/docs/stable/jit.html>`__.
+
+TorchServe Model Archiver (`.mar`)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want to use TorchServe for inference you'll need to export your model to
+this format. For inference you'll generally use a quantized version of the model
+so it's best to have your trainer export both a full precision model for fine
+tuning as well as a quantized `.mar` file for TorchServe to consume.
+
+See the
+`Model Archiver documentation <https://github.com/pytorch/serve/blob/master/model-archiver/README.md>`_.
+
+torch.package
+^^^^^^^^^^^^^^^^^^
+
+This is a new format as of pytorch 1.9.0 and can be used to save and load model
+definitions and their weights so you don't need to manage the model definition
+separately.
+
+See the `torch.package documentation <https://pytorch.org/docs/stable/package.html>`__.
+
+It's quite new and doesn't have widespread adoption or support.
+
+
+Serving / Inference
+---------------------
+
+For serving and inference we recommend using
+`TorchServe <https://github.com/pytorch/serve>`_
+for common use cases.
+We provide a component that allows you to upload your model to TorchServe via
+the management API.
+
+See the :ref:`components/serve:Serve` built in components for more information.
+
+For more complex serving and performance reasons you may need to write your own
+custom inference logic. Torchscript and torch::deploy are some standard
+utilities you can use to build your own inference server.
+
+Testing
+---------
+
+Since TorchX apps are typically standard python you can write unit tests for
+them like you would with any other Python code.
+
+.. code-block:: python
+
+    import unittest
+    from your.custom.app import main
+
+    class CustomAppTest(unittest.TestCase):
+        def test_main(self) -> None:
+            main(["--src", "src", "--dst", "dst"])
+            self.assertTrue(...)

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -197,8 +197,8 @@ For example the following application is **NOT** infra agnostic
 The binary above makes an implicit assumption that the ``input_path``
 is an AWS S3 path. One way to make this trainer storage agnostic is to introduce
 a ``FileSystem`` abstraction layer. For file systems, frameworks like
-`PyTorch Lightning <https://www.pytorchlightning.ai/>`_  already define ``io``
-layers (lightning uses `fsspec <https://filesystem-spec.readthedocs.io/en/latest/index.html>`_
+`PyTorch Lightning <https://www.pytorchlightning.ai/>`__  already define ``io``
+layers (lightning uses `fsspec <https://filesystem-spec.readthedocs.io/en/latest/index.html>`__
 under the hood). The binary above can be rewritten to be storage agnostic with
 lightning.
 

--- a/docs/source/component_best_practices.rst
+++ b/docs/source/component_best_practices.rst
@@ -1,0 +1,146 @@
+Component Best Practices
+==========================
+
+This has a list of common things you might want to do with a component and best
+practices for them. Components are designed to be flexible so you can deviate
+from these practices if necessary however these are the best practices we use
+for the builtin TorchX components.
+
+See :ref:`app_best_practices:App Best Practices` for information how to write
+apps using TorchX.
+
+Simplify
+-------------------
+
+When writing a component generally you want to keep it as simple as possible and
+make it so it just passes the arguments around.
+
+Avoiding complex processing makes it easier to use the component in different
+environments and easier for others to understand what the component does.
+
+Argument Processing
+^^^^^^^^^^^^^^^^^^^^^
+
+Argument processing makes it hard to use the component in other environments. In
+this example we concatenate the image name which makes it impossible to use in
+other environments which have a different format for images.
+
+.. code-block:: python
+
+   # avoid
+   def trainer(img_name: str, img_version: str) -> AppDef:
+       """
+       ...
+       """
+       return AppDef(roles=[Role(image=f"{img_name}:{img_version}")...)
+
+   # recommended
+   def trainer(image: str):
+       """
+       ...
+       """
+       return AppDef(roles=[Role(image=image)...)
+
+Branching Logic
+^^^^^^^^^^^^^^^^^
+
+If the component has lots of branching logic it can make it hard for others to
+understand how the component maps to the underlying app and how they should
+configure the arguments.
+
+.. code-block:: python
+
+   # avoid
+   def trainer(stage: str):
+       """
+       ...
+       """
+       if stage == "test":
+           num_replicas=1
+       elif stage == "prod":
+           num_replicas=10
+       return AppDef(roles=[Role(..., num_replicas=num_replicas)])
+
+   # recommended
+   def trainer_test():
+       """
+       ...
+       """
+       return trainer(num_replicas=1)
+
+   def trainer_prod() -> AppDef:
+       """
+       ...
+       """
+       return trainer(num_replicas=10)
+
+   # not a component just a function
+   def trainer(num_replicas: int) -> AppDef:
+        return AppDef(roles=[Role(..., num_replicas=num_replicas)])
+
+
+
+Named Resources
+-----------------
+
+Generally when writing components it's best to use TorchX's named resources
+support instead of manually specifying cpu and memory allocations. Named
+resources allow your component to be environment independent and allow for
+better scheduling behavior by using t-shirt sizes.
+
+See :py:meth:`torchx.specs.get_named_resources` for more info.
+
+Composing Components
+----------------------
+
+For common component styles we provide base component definitions. These can be
+called from your custom component definition and are generally easier to use
+than creating a full AppDef from scratch.
+
+See:
+
+* :py:mod:`torchx.components.base` for simple single node components.
+* :py:meth:`torchx.components.dist.ddp` for distributed components.
+
+For even more complex components it's possible to merge multiple existing
+components into a single one. For instance you could use a metrics UI component
+and merge the roles from it into training component roles to have a sidecar
+service to your main training job.
+
+Distributed Components
+------------------------
+
+If you're writing a component for distributed training or other similar
+distributed computation, we recommend using the
+:py:meth:`torchx.components.dist.ddp` component since it provides out of the box
+support for `torch.distributed.elastic` jobs.
+
+You can extend the `ddp` component by writing a custom component that simple
+imports the `ddp` component and calls it with your app configuration.
+
+Define All Arguments
+----------------------
+
+It's generally preferable to define all component arguments as function
+arguments instead of consuming a dictionary of arguments. This makes it easier
+for users to figure out the options as well as can provide static typing when
+used with `pyre <https://pyre-check.org/>`__ or `mypy <http://mypy-lang.org/>`__.
+
+Unit Tests
+--------------
+
+.. automodule:: torchx.components.test.component_test_base
+.. currentmodule:: torchx.components.test.component_test_base
+
+.. autoclass:: torchx.components.test.component_test_base.ComponentTestCase
+   :members:
+   :private-members: _validate
+
+Integration Tests
+-------------------
+
+You can setup integration tests with your components by either using the
+programmatic runner API or write a bash script to call the CLI.
+
+You can see both styles in use in the core
+`TorchX scheduler integration tests <https://github.com/pytorch/torchx/tree/main/.github/workflows>`__.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,8 @@ Documentation
    quickstart
    cli
    configure
+   app_best_practices
+   component_best_practices
 
 
 .. toctree::

--- a/torchx/components/test/component_test_base.py
+++ b/torchx/components/test/component_test_base.py
@@ -4,6 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""
+You can unit test the component definitions as you would normal Python code
+since they are valid Python definitions.
+
+We do recommend using :py:class:`ComponentTestCase` to ensure that your
+component can be parsed by the TorchX CLI. The CLI requires stricter formatting
+on the doc string than pure Python as the doc string is used for parsing CLI
+args.
+"""
+
 import os
 import unittest
 from types import ModuleType
@@ -12,7 +22,26 @@ from torchx.specs.file_linter import validate
 
 
 class ComponentTestCase(unittest.TestCase):
+    """
+    ComponentTestCase is an extension of TestCase with helper methods for use
+    with testing component definitions.
+
+    >>> import unittest
+    >>> from torchx.components.test.component_test_base import ComponentTestCase
+    >>> from torchx.components import utils
+    >>> class MyComponentTest(ComponentTestCase):
+    ...     def test_my_comp(self):
+    ...         self._validate(utils, "copy")
+    >>> MyComponentTest("test_my_comp").run()
+    <unittest.result.TestResult run=1 errors=0 failures=0>
+    """
+
     def _validate(self, module: ModuleType, function_name: str) -> None:
+        """
+        _validate takes in a module and the name of a component function
+        definition defined in that module and validates that it is a valid
+        component def.
+        """
         file_path = path = os.path.abspath(module.__file__)
         with open(file_path, "r") as fp:
             file_content = fp.read()


### PR DESCRIPTION
<!-- Change Summary -->

This adds a brain dump of app best practices and component best practices. The component side is a bit sparse since the definitions are pretty short, hard to do much bad with them. Feedback welcome :)

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ env O="--port 4444" make clean livehtml
$ make doctest
```

CI