### PR TITLE
docs: add Google Analytics ID

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -141,6 +141,7 @@ html_theme_options = {
     "collapse_navigation": False,
     "display_version": True,
     "logo_only": True,
+    "analytics_id": "UA-117752657-2",
 }
 
 html_logo = "_static/img/pytorch-logo-dark.svg"


### PR DESCRIPTION
<!-- Change Summary -->

This adds the same analytics ID all other pytorch projects have https://github.com/pytorch/audio/blob/8a347b62cf5c907d2676bdc983354834e500a282/docs/source/conf.py#L130

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ env O="--port 4444" make clean livehtml
```
![2021-08-31-111012_695x187_scrot](https://user-images.githubusercontent.com/909104/131554349-e4e256d5-bcb3-4119-b10f-e358d8204aab.png)

