### PR TITLE
Allow finding malformed components

### DIFF
--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -95,15 +95,14 @@ class CmdRunTest(unittest.TestCase):
             mock_scheduler_close.assert_called()
 
     def test_run_missing(self) -> None:
-        with self.assertRaises(ValueError):
-            args = self.parser.parse_args(
-                [
-                    "--scheduler",
-                    "local",
-                    "1234_does_not_exist.torchx",
-                ]
-            )
-            self.cmd_run.run(args)
+        args = self.parser.parse_args(
+            [
+                "--scheduler",
+                "local",
+                "1234_does_not_exist.torchx",
+            ]
+        )
+        self.cmd_run.run(args)
 
     @patch("torchx.runner.Runner.run")
     def test_run_dryrun(self, mock_runner_run: MagicMock) -> None:

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -25,7 +25,6 @@ from torchx.specs.api import (
     RunConfig,
     SchedulerBackend,
     UnknownAppException,
-    from_file,
     from_function,
     make_app_handle,
     parse_app_handle,
@@ -151,25 +150,11 @@ class Runner:
             if it dryrun specified.
 
         Raises:
-            ValueError: if the ``component_path`` is failed to resolve.
+            `ComponentValidationException`: if component is invalid.
+            `ComponentNotFoundException`: if the ``component_path`` is failed to resolve.
         """
         component_def = get_component(component_name)
-        if component_def:
-            app = from_function(component_def.fn, app_args)
-        elif ":" in component_name:
-            file_path, function_name = component_name.split(":")
-            if not function_name:
-                raise ValueError(
-                    f"Incorrect path: {component_name}. Missing function name after `:`"
-                )
-            app = from_file(file_path, function_name, app_args)
-        else:
-            raise ValueError(
-                f"Component `{component_name}` not found. Please make sure it is one of the "
-                "builtins: `torchx builtins`. Or registered via `[torchx.components]` "
-                "entry point (see: https://pytorch.org/torchx/latest/configure.html)"
-            )
-
+        app = from_function(component_def.fn, app_args)
         if dryrun:
             return self.dryrun(app, scheduler, cfg)
         else:

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -40,8 +40,6 @@ from .api import (  # noqa: F401 F403
     parse_app_handle,
     get_argparse_param_type,
     from_function,
-    from_file,
-    from_module,
 )
 
 GiB: int = 1024

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -5,8 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
-import pathlib
 import sys
 import unittest
 from dataclasses import asdict
@@ -27,9 +25,7 @@ from torchx.specs.api import (
     RetryPolicy,
     Role,
     RunConfig,
-    from_file,
     from_function,
-    from_module,
     get_type_name,
     macros,
     make_app_handle,
@@ -566,34 +562,6 @@ class AppDefLoadTest(unittest.TestCase):
         expected_app = self._get_expected_app_with_default()
         app_args = self._get_args_with_default()
         actual_app = from_function(_test_complex_fn, app_args)
-        self.assert_apps(expected_app, actual_app)
-
-    def test_load_from_module_complex_all_args(self) -> None:
-        expected_app = self._get_expected_app_with_all_args()
-        app_args = app_args = self._get_app_args()
-        curr_module = sys.modules[__name__]
-        actual_app = from_module(curr_module, "_test_complex_fn", app_args)
-        self.assert_apps(expected_app, actual_app)
-
-    def test_load_from_module_with_default(self) -> None:
-        expected_app = self._get_expected_app_with_default()
-        app_args = self._get_args_with_default()
-        curr_module = sys.modules[__name__]
-        actual_app = from_module(curr_module, "_test_complex_fn", app_args)
-        self.assert_apps(expected_app, actual_app)
-
-    def test_load_from_file_complex_all_args(self) -> None:
-        expected_app = self._get_expected_app_with_all_args()
-        app_args = app_args = self._get_app_args()
-        filepath = str(pathlib.Path(__file__))
-        actual_app = from_file(filepath, "_test_complex_fn", app_args)
-        self.assert_apps(expected_app, actual_app)
-
-    def test_load_from_file_with_default(self) -> None:
-        expected_app = self._get_expected_app_with_default()
-        app_args = self._get_args_with_default()
-        filepath = str(pathlib.Path(__file__))
-        actual_app = from_file(filepath, "_test_complex_fn", app_args)
         self.assert_apps(expected_app, actual_app)
 
     def test_varargs(self) -> None:


### PR DESCRIPTION
Summary:
https://github.com/pytorch/torchx/issues/129

* adds support of finding unknown and invalid components.
* resolves a bug where the varargs were missing form the linter procedure
* moves the logic of the custom components finder to the proper location(`finder` module)
* removes a bunch of code from the `torchx.specs.api` since it is not needed anymore

The new logic moves  functionality to corresponding places:

* Move builtin components and custom (filepath:fn_name) component retrieval to the `finder` module
* Make `runner` more lightweight by removing custom_component/builtin_component separation
* Make `torchx.specs.api`   only load from function

Reviewed By: d4l3k

Differential Revision: D30659872

