### PR TITLE
components/component_test_base: move component_test_base out of test package

### DIFF
--- a/docs/source/component_best_practices.rst
+++ b/docs/source/component_best_practices.rst
@@ -129,10 +129,10 @@ used with `pyre <https://pyre-check.org/>`__ or `mypy <http://mypy-lang.org/>`__
 Unit Tests
 --------------
 
-.. automodule:: torchx.components.test.component_test_base
-.. currentmodule:: torchx.components.test.component_test_base
+.. automodule:: torchx.components.component_test_base
+.. currentmodule:: torchx.components.component_test_base
 
-.. autoclass:: torchx.components.test.component_test_base.ComponentTestCase
+.. autoclass:: torchx.components.component_test_base.ComponentTestCase
    :members:
    :private-members: _validate
 

--- a/examples/apps/datapreproc/test/component_test.py
+++ b/examples/apps/datapreproc/test/component_test.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import examples.apps.datapreproc.component as datapreproc
-from torchx.components.test.component_test_base import ComponentTestCase
+from torchx.components.component_test_base import ComponentTestCase
 
 
 class DatapreprocComponentTest(ComponentTestCase):

--- a/examples/apps/dist_cifar/test/component_test.py
+++ b/examples/apps/dist_cifar/test/component_test.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import examples.apps.dist_cifar.component as dist_cifar
-from torchx.components.test.component_test_base import ComponentTestCase
+from torchx.components.component_test_base import ComponentTestCase
 
 
 class DistCifar10ComponentTest(ComponentTestCase):

--- a/examples/apps/lightning_classy_vision/test/component_test.py
+++ b/examples/apps/lightning_classy_vision/test/component_test.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import examples.apps.lightning_classy_vision.component as lightning_classy_vision
-from torchx.components.test.component_test_base import ComponentTestCase
+from torchx.components.component_test_base import ComponentTestCase
 
 
 class DistributedComponentTest(ComponentTestCase):

--- a/torchx/components/component_test_base.py
+++ b/torchx/components/component_test_base.py
@@ -27,7 +27,7 @@ class ComponentTestCase(unittest.TestCase):
     with testing component definitions.
 
     >>> import unittest
-    >>> from torchx.components.test.component_test_base import ComponentTestCase
+    >>> from torchx.components.component_test_base import ComponentTestCase
     >>> from torchx.components import utils
     >>> class MyComponentTest(ComponentTestCase):
     ...     def test_my_comp(self):

--- a/torchx/components/test/dist_test.py
+++ b/torchx/components/test/dist_test.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torchx.components.dist as dist
-from torchx.components.test.component_test_base import ComponentTestCase
+from torchx.components.component_test_base import ComponentTestCase
 
 
 class DistributedComponentTest(ComponentTestCase):

--- a/torchx/components/test/utils_test.py
+++ b/torchx/components/test/utils_test.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torchx.components.utils as utils
-from torchx.components.test.component_test_base import ComponentTestCase
+from torchx.components.component_test_base import ComponentTestCase
 
 
 class UtilsComponentTest(ComponentTestCase):


### PR DESCRIPTION
This allows external components to use component_test_base and allows
the doc generation to find the package when building from the wheel such
as in our doc_push.sh script.

<!-- Change Summary -->

Fixes https://github.com/pytorch/torchx/runs/3491657965

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ docs/doc_push.sh
```
