### PR TITLE
Improve key-value command parsing logic

### DIFF
--- a/torchx/util/test/types_test.py
+++ b/torchx/util/test/types_test.py
@@ -109,9 +109,33 @@ class TypesTest(unittest.TestCase):
     def test_to_dict_empty(self) -> None:
         self.assertDictEqual({}, to_dict(""))
 
+    def test_to_dict_simple(self) -> None:
+        enc = "foo=bar,key=value"
+        self.assertDictEqual({"foo": "bar", "key": "value"}, to_dict(enc))
+
+    def test_to_dict_one(self) -> None:
+        enc = "foo=bar"
+        self.assertDictEqual({"foo": "bar"}, to_dict(enc))
+
+    def test_to_dict_only_key(self) -> None:
+        enc = "foo"
+        with self.assertRaises(ValueError):
+            to_dict(enc)
+
+    def test_to_dict_complex_comma(self) -> None:
+        enc = "foo=bar1,bar2,bar3,my_key=my_value,new_foo=new_bar1,new_bar2"
+        self.assertDictEqual(
+            {
+                "foo": "bar1,bar2,bar3",
+                "my_key": "my_value",
+                "new_foo": "new_bar1,new_bar2",
+            },
+            to_dict(enc),
+        )
+
     def test_to_dict_doulbe_comma(self) -> None:
         enc = "key1=value1,,foo=bar"
-        self.assertDictEqual({"foo": "bar", "key1": "value1"}, to_dict(enc))
+        self.assertDictEqual({"foo": "bar", "key1": "value1,"}, to_dict(enc))
 
     def test_to_list_empty(self) -> None:
         self.assertListEqual([], to_list(""))

--- a/torchx/util/types.py
+++ b/torchx/util/types.py
@@ -10,15 +10,54 @@ import typing_inspect
 
 
 def to_dict(arg: str) -> Dict[str, str]:
-    conf = {}
-    if len(arg.strip()) == 0:
+    """
+    Parses the sting into the key-value pairs using `,` as delimiter.
+    The algorithm uses the last `,` between previous value and next key as delimiter, e.g.:
+
+    .. code-block:: python
+
+     arg="FOO=Value1,Value2,BAR=Value3"
+     conf = to_dict(arg)
+     print(conf) # {'FOO': 'Value1,Value2', 'BAR': 'Value3'}
+
+    """
+    conf: Dict[str, str] = {}
+    arg = arg.strip()
+    if len(arg) == 0:
         return {}
-    for kv in arg.split(","):
-        if kv == "":
-            continue
-        key, value = kv.split("=")
+
+    kv_delimiter: str = "="
+    pair_delimiter: str = ","
+
+    cpos: int = 0
+    while cpos < len(arg):
+        key = _get_key(arg, cpos, kv_delimiter)
+        cpos += len(key) + 1
+        value = _get_value(arg, cpos, kv_delimiter, pair_delimiter)
+        cpos += len(value) + 1
         conf[key] = value
     return conf
+
+
+def _get_key(arg: str, spos: int, kv_delimiter: str = "=") -> str:
+    epos: int = spos + 1
+    while epos < len(arg) and arg[epos] != kv_delimiter:
+        epos += 1
+    if epos == len(arg):
+        raise ValueError(
+            f"Argument `{arg}` does not follow the pattern: KEY1=VALUE1,KEY2=VALUE2"
+        )
+    return arg[spos:epos]
+
+
+def _get_value(arg: str, spos: int, kv_delimiter="=", pair_delimiter=",") -> str:
+    epos: int = spos + 1
+    while epos < len(arg) and arg[epos] != kv_delimiter:
+        epos += 1
+    if epos < len(arg) and arg[epos] == kv_delimiter:
+        while arg[epos] != pair_delimiter:
+            epos -= 1
+    return arg[spos:epos]
 
 
 def to_list(arg: str) -> List[str]:


### PR DESCRIPTION
Summary:
The diff adds support to specify `,` in the key of the key-value pairs provided to the components:

Only last `,` is treated as separator, all other `,` in between are treated as part of the value

Reviewed By: jspark1105

Differential Revision: D30811773

