### PR TITLE
Add proper separator in `make_unique` function

### DIFF
--- a/torchx/schedulers/ids.py
+++ b/torchx/schedulers/ids.py
@@ -17,4 +17,4 @@ def make_unique(name: str) -> str:
         string in format $name_$unique_suffix
     """
     rand_suffix = binascii.b2a_hex(os.urandom(8)).decode("utf-8")
-    return f"{name}_{rand_suffix}"
+    return f"{name}-{rand_suffix}"


### PR DESCRIPTION
Summary: Some schedulers, e.g. kubernetes do not support `_` in the job name, change the separator to `-`

Differential Revision: D30848515

