### PR TITLE
schedulers: improved ID generation to conform with k8s requirements

### DIFF
--- a/scripts/integ_test_utils.py
+++ b/scripts/integ_test_utils.py
@@ -5,11 +5,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import binascii
 import dataclasses
 import os
 import subprocess
 from getpass import getuser
+
+from torchx.schedulers.ids import random_id
 
 
 @dataclasses.dataclass
@@ -28,10 +29,6 @@ def getenv_asserts(env: str) -> str:
     if not v:
         raise MissingEnvError(f"must have {env} environment variable")
     return v
-
-
-def rand_id() -> str:
-    return binascii.b2a_hex(os.urandom(8)).decode("utf-8")
 
 
 def run(*args: str) -> None:
@@ -74,7 +71,7 @@ def examples_container_tag(id: str) -> str:
 
 
 def build_images() -> BuildInfo:
-    id = f"{getuser()}_{rand_id()}"
+    id = f"{getuser()}_{random_id()}"
     examples_image = build_examples_canary(id)
     torchx_image = build_torchx_canary(id)
     return BuildInfo(

--- a/torchx/schedulers/ids.py
+++ b/torchx/schedulers/ids.py
@@ -5,16 +5,45 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import binascii
 import os
+import struct
 
 
 def make_unique(name: str) -> str:
     """
-    Appends the unique 64-bit hex string to the input argument.
+    Appends a unique 64-bit string to the input argument.
 
     Returns:
-        string in format $name_$unique_suffix
+        string in format $name-$unique_suffix
     """
-    rand_suffix = binascii.b2a_hex(os.urandom(8)).decode("utf-8")
-    return f"{name}_{rand_suffix}"
+    rand_suffix = random_id()
+    return f"{name}-{rand_suffix}"
+
+
+def random_uint64() -> int:
+    """
+    random_uint64 returns an random unsigned 64 bit int.
+    """
+    return struct.unpack("!Q", os.urandom(8))[0]
+
+
+def random_id() -> str:
+    """
+    Generates an alphanumeric string ID that matches the requirements from
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+    """
+    START_CANDIDATES = "abcdefghijklmnopqrstuvwxyz"
+    END_CANDIDATES = START_CANDIDATES + "012345679"
+
+    out = ""
+    v = random_uint64()
+    while v > 0:
+        if out == "":
+            candidates = START_CANDIDATES
+        else:
+            candidates = END_CANDIDATES
+
+        char = v % len(candidates)
+        v = v // len(candidates)
+        out += candidates[char]
+    return out

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -16,7 +16,6 @@ import yaml
 
 if TYPE_CHECKING:
     from kubernetes.client import ApiClient, CustomObjectsApi
-    from kubernetes.client.exceptions import ApiException
     from kubernetes.client.models import (  # noqa: F401 imported but unused
         V1Pod,
         V1PodSpec,
@@ -25,6 +24,7 @@ if TYPE_CHECKING:
         V1ResourceRequirements,
         V1ContainerPort,
     )
+    from kubernetes.client.rest import ApiException
 
 import torchx
 from torchx.schedulers.api import (
@@ -324,7 +324,7 @@ class KubernetesScheduler(Scheduler):
             return None
 
     def schedule(self, dryrun_info: AppDryRunInfo[KubernetesJob]) -> str:
-        from kubernetes.client.exceptions import ApiException
+        from kubernetes.client.rest import ApiException
 
         cfg = dryrun_info._cfg
         assert cfg is not None, f"{dryrun_info} missing cfg"

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -12,7 +12,6 @@ from typing import Iterable, Optional, Union
 from unittest.mock import MagicMock, patch
 
 from torchx.schedulers.api import DescribeAppResponse, Scheduler
-from torchx.schedulers.ids import make_unique
 from torchx.specs.api import (
     NULL_RESOURCE,
     AppDef,
@@ -130,14 +129,3 @@ class SchedulerTest(unittest.TestCase):
         scheduler_mock.close()
         scheduler_mock.close()
         # nothing to validate explicitly, just that no errors are raised
-
-
-class TorchxIdsTest(unittest.TestCase):
-    def test_unique(self) -> None:
-        name = "test"
-        self.assertNotEqual(make_unique(name), make_unique(name))
-
-    def test_unique_min_len(self) -> None:
-        unique_name = make_unique("test")
-        # 16 chars in hex is 64 bits
-        self.assertTrue(len(unique_name) >= len("test") + 16)

--- a/torchx/schedulers/test/ids_test.py
+++ b/torchx/schedulers/test/ids_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from torchx.schedulers.ids import (
+    make_unique,
+    random_uint64,
+    random_id,
+)
+
+
+class TorchxIdsTest(unittest.TestCase):
+    def test_make_unique(self) -> None:
+        name = "test"
+        self.assertNotEqual(make_unique(name), make_unique(name))
+
+    def test_make_unique_min_len(self) -> None:
+        unique_name = make_unique("test")
+        # 16 chars in hex is 64 bits
+        self.assertTrue(len(unique_name) >= len("test") + 5)
+        self.assertTrue(unique_name.startswith("test-"))
+
+    def test_random_uint64(self) -> None:
+        self.assertGreater(random_uint64(), 0)
+        self.assertNotEqual(random_uint64(), random_uint64())
+
+    def test_random_id(self) -> None:
+        ALPHAS = "abcdefghijklmnopqrstuvwxyz"
+        v = random_id()
+        self.assertIn(v[0], ALPHAS)
+        self.assertGreater(len(v), 5)
+
+    @patch("os.urandom", return_value=bytes(range(8)))
+    def test_random_id_seed(self, urandom: MagicMock) -> None:
+        self.assertEqual(random_id(), "xfik3yru3e")
+
+    @patch("os.urandom", return_value=bytes(range(8)))
+    def test_make_unique_seed(self, urandom: MagicMock) -> None:
+        self.assertEqual(make_unique("test"), "test-xfik3yru3e")

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -220,7 +220,7 @@ spec:
     def test_submit_job_name_conflict(
         self, create_namespaced_custom_object: MagicMock
     ) -> None:
-        from kubernetes.client.exceptions import ApiException
+        from kubernetes.client.rest import ApiException
 
         api_exc = ApiException(status=409, reason="Conflict")
         api_exc.body = "{'details':{'name': 'test_job'}}"


### PR DESCRIPTION
<!-- Change Summary -->

* switches generated ids to be `[a-z][a-z0-9]*` to match valid k8s IDs -- not strictly needed since we currently only append the IDs but it's a bit shorter
* Fixes broken integration tests: https://github.com/pytorch/torchx/runs/3550036832
* cleans up some ID usage
* fixes kubernetes scheduler import path for ApiException to work with `kubernetes==11`

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

kfp + k8s CI

pyre