### PR TITLE
(torchx/hpo) move ax to torchx.runtime.hpo, implement fsspec tracker, make ax example run with booth function not echo

### DIFF
--- a/torchx/apps/utils/booth_main.py
+++ b/torchx/apps/utils/booth_main.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import sys
+from typing import List
+
+from torchx.runtime.tracking import FsspecResultTracker
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="evaluates the booth function at (x1, x2)"
+    )
+    parser.add_argument(
+        "--x1",
+        type=float,
+        help="x1",
+        required=True,
+    )
+    parser.add_argument(
+        "--x2",
+        type=float,
+        help="x2",
+        required=True,
+    )
+    parser.add_argument(
+        "--tracker_base",
+        type=str,
+        help="URI of output directory to use as the tracker's base dir",
+        default="/tmp/torchx-utils-booth",
+    )
+    parser.add_argument(
+        "--trial_idx",
+        type=int,
+        help="trial index (ignore if not running hpo)",
+        default=0,
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str]) -> None:
+    args = parse_args(argv)
+
+    x1 = args.x1
+    x2 = args.x2
+
+    eval = (x1 + 2 * x2 - 7) ** 2 + (2 * x1 + x2 - 5) ** 2
+
+    tracker = FsspecResultTracker(args.tracker_base)
+    tracker[args.trial_idx] = {"booth_eval": eval}
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/torchx/apps/utils/test/booth_test.py
+++ b/torchx/apps/utils/test/booth_test.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import shutil
+import tempfile
+import unittest
+
+import torchx.apps.utils.booth_main as booth
+from torchx.runtime.tracking import FsspecResultTracker
+
+
+class BoothTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = tempfile.mkdtemp("torchx_apps_utils_booth_test")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_booth(self) -> None:
+        # evaluate booth function at (1,3) - which is its global minimum (0)
+        booth.main(["--x1", "1", "--x2", "3", "--tracker_base", self.test_dir])
+
+        tracker = FsspecResultTracker(self.test_dir)
+        self.assertEqual(0.0, tracker[0]["booth_eval"])

--- a/torchx/components/test/utils_test.py
+++ b/torchx/components/test/utils_test.py
@@ -20,3 +20,6 @@ class UtilsComponentTest(ComponentTestCase):
 
     def test_copy(self) -> None:
         self._validate(utils, "copy")
+
+    def test_booth(self) -> None:
+        self._validate(utils, "booth")

--- a/torchx/components/utils.py
+++ b/torchx/components/utils.py
@@ -112,14 +112,53 @@ def copy(src: str, dst: str, image: str = TORCHX_IMAGE) -> specs.AppDef:
             specs.Role(
                 name="torchx-utils-copy",
                 image=image,
-                entrypoint="python3",
+                entrypoint="torchx/apps/utils/copy_main.py",
                 args=[
-                    "torchx/apps/utils/copy_main.py",
                     "--src",
                     src,
                     "--dst",
                     dst,
                 ],
             ),
+        ],
+    )
+
+
+def booth(
+    x1: float,
+    x2: float,
+    trial_idx: int = 0,
+    tracker_base: str = "/tmp/torchx-util-booth",
+    image: str = TORCHX_IMAGE,
+) -> specs.AppDef:
+    """
+    Evaluates the booth function, ``f(x1, x2) = (x1 + 2*x2 - 7)^2 + (2*x1 + x2 - 5)^2``.
+    Output result is accessible via ``FsspecResultTracker(outdir)[trial_idx]``
+
+    Args:
+        x1: x1
+        x2: x2
+        trial_idx: ignore if not running hpo
+        tracker_base: URI of the tracker's base output directory (e.g. s3://foo/bar)
+        image: the image that contains the booth app
+    """
+    return specs.AppDef(
+        name="torchx-utils-booth",
+        roles=[
+            specs.Role(
+                name="torchx-utils-booth",
+                image=image,
+                entrypoint="torchx/apps/utils/booth_main.py",
+                args=[
+                    "--x1",
+                    str(x1),
+                    "--x2",
+                    str(x2),
+                    "--trial_idx",
+                    str(trial_idx),
+                    "--tracker_base",
+                    tracker_base,
+                ],
+            )
         ],
     )

--- a/torchx/runtime/hpo/__init__.py
+++ b/torchx/runtime/hpo/__init__.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+The ``torchx.runtime.hpo`` module contains modules and functions that you
+can use to build a Hyperparameter Optimization (HPO) application. Note
+that an HPO application is the entity that is coordinating the HPO search
+and is not to be confused with the application that runs for each "trial"
+of the search. Typically a "trial" in an HPO job is the trainer app that
+trains an ML model given a set of parameters as dictated by the HPO job.
+
+For grid-search, the HPO job may be as simple as a for-parallel loop that
+exhaustively runs through all the combinations of parameters in the user-defined
+search space. On the other hand, bayesian optimization requires the optimizer
+state to be preserved between trials, which leads a more non-trivial implementation
+of an HPO app.
+
+Currently this module uses `Ax <https://ax.dev>`_ as the underlying brains of HPO
+and offers a few extension points to integrate Ax with TorchX runners.
+
+Quick Usage:
+
+.. code-block:: python
+
+ from ax.modelbridge.dispatch_utils import choose_generation_strategy
+ from ax.service.scheduler import SchedulerOptions
+ from ax.service.utils.best_point import get_best_parameters
+ from ax.service.utils.report_utils import exp_to_df
+ from torchx.runtime.hpo.ax import AppMetric, TorchXRunner, TorchXScheduler
+
+
+"""

--- a/torchx/runtime/hpo/test/__init__.py
+++ b/torchx/runtime/hpo/test/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchx/runtime/tracking/__init__.py
+++ b/torchx/runtime/tracking/__init__.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+.. note:: EXPERIMENTAL, USE AT YOUR OWN RISK, APIs SUBJECT TO CHANGE
+
+In TorchX applications are binaries (executables),
+hence there is no built-in way to "return" results from applications.
+The ``torchx.runtime.tracking`` module allows applications
+to return simple results (note the keyword "simple"). The return types
+that the tracker module supports are intentionally constrained. For instance,
+attempting to return the trained model weights, which can be hundreds of GB in size,
+is not allowed. This module is NOT intended nor tuned to pass around large
+quantities of data or binary blobs.
+
+When apps are launched as part of a higher level coordinated effort
+(e.g. workflow, pipeline, hyper-parameter optimization) often times,
+the result of the app needs to be accessible to the coordinator or
+other apps in the workflow.
+
+Suppose App1 and App2 are launched sequentially with the output of App1
+feeding as input of App2. Since these are binaries the typical way to
+chain input/outputs between apps is by passing the output file path
+of App1 as the input file path of App2:
+
+.. code-block:: shell-session
+
+ $ app1 --output-file s3://foo/out/app1.out
+ $ app2 --input-file s3://foo/out/app1.out
+
+As easy as this may seem, there are a few things one needs to worry about:
+
+1. The format of the file ``app1.out`` (app1 needs to write it in the format app2 understands)
+2. Actually parsing the url and writing/reading the output file
+
+So the application's main ends up looking like this (pseudo-code for demonstrative purposes):
+
+.. code-block:: python
+
+ # in app1.py
+ if __name__ == "__main__":
+    accuracy = do_something()
+    s3client = ...
+    out = {"accuracy": accuracy}
+
+    with open("/tmp/out", "w") as f:
+        f = json.dumps(out).encode("utf-8")
+
+    s3client.put(args.output_file, f)
+
+ # in app2.py
+ if __name__ == "__main__":
+    s3client = ...
+    with open("/tmp/out", "w") as f:
+        s3client.get(args.input_file, f)
+
+    with open("/tmp/out", "r") as f:
+        in = json.loads(f.read().decode("utf-8"))
+
+    do_something_else(in["accuracy"])
+
+
+Instead with the tracker a tracker with the same ``tracker_base``
+can be used across apps to make the return values of one app
+available to another without the need to chain output file paths of
+one app with the input file path of another and deal with custom
+serialization and file writing.
+
+.. code-block:: python
+
+ # in app1.py
+ if __name__ == "__main__":
+    accuracy = do_something()
+    tracker = FsspecResultTracker(args.tracker_base)
+    tracker["app1_out"] = {"accuracy": accuracy}
+
+ # in app2.py
+ if __name__ == "__main__":
+    tracker = FsspecResultTracker(args.tracker_base)
+    app1_accuracy = tracker["app1_out"]
+    do_something_else(app1_accuracy)
+
+"""
+
+from .api import FsspecResultTracker, ResultTracker  # noqa: F401

--- a/torchx/runtime/tracking/api.py
+++ b/torchx/runtime/tracking/api.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+import json
+from typing import Dict, Union
+
+import fsspec
+
+
+KeyType = Union[int, str]
+ResultType = Union[int, float, str]
+
+
+class ResultTracker(abc.ABC):
+    """
+    Base result tracker, which should be sub-classed to implement trackers.
+    Typically there exists a tracker implementation per backing store.
+
+    Usage:
+
+    .. code-block:: python
+
+     # get and put APIs can be used directly or in map-like API
+     # the following are equivalent
+     tracker.put("foo", l2norm=1.2)
+     tracker["foo"] = {"l2norm": 1.2}
+
+     # so are these
+     tracker.get("foo")["l2norm"] == 1.2
+     tracker["foo"]["l2norm"] == 1.2
+
+    Valid ``result`` types are:
+
+    1. numeric: int, float
+    2. literal:str (1kb size limit when utf-8 encoded)
+
+    Valid ``key`` types are:
+
+    1. ``int``
+    2. ``str``
+
+    As a convention, "slashes" can be used in the key to store results that
+    are statistical. For instance, to store the mean and sem of l2norm:
+
+    .. code-block:: python
+
+     tracker[key] = {"l2norm/mean" : 1.2, "l2norm/sem": 3.4}
+     tracker[key]["l2norm/mean"] # returns 1.2
+     tracker[key]["l2norm/sem"] # returns 3.4
+
+    Keys are assumed to be unique within the scope of the tracker's backing
+    store. For example, if a tracker is backed by a local directory and the
+    ``key`` is the file within directory where the results are saved, then
+
+    .. code-block:: python
+
+      # same key, different backing directory -> results are not overwritten
+      FsspecResultTracker("/tmp/foo")["1"] = {"l2norm":1.2}
+      FsspecResultTracker("/tmp/bar")["1"] = {"l2norm":3.4}
+
+    The tracker is NOT a central entity hence no strong consistency guarantees
+    (beyond what the backing store provides) are made between ``put`` and ``get``
+    operations on the same key. Similarly no strong consistency guarantees are
+    made between two consecutive ``put`` or ``get`` operations on the same key.
+
+    For example:
+
+    .. code-block:: python
+      tracker[1] = {"l2norm":1.2}
+      tracker[1] = {"l2norm":3.4}
+      tracker[1] # NOT GUARANTEED TO BE 3.4!
+
+      sleep(1*MIN)
+      tracker[1] # more likely to be 3.4 but still not guaranteed!
+
+    It is STRONGLY advised that a unique id is used as the key. This id is
+    often the job id for simple jobs or can be a concatenation of
+    (experiment_id, trial_number) or (job id, replica/worker rank)
+    for iterative applications like hyper-parameter optimization.
+
+    """
+
+    def __getitem__(self, key: KeyType) -> Dict[str, ResultType]:
+        return self.get(key)
+
+    def __setitem__(self, key: KeyType, results: Dict[str, ResultType]) -> None:
+        self.put(key, **results)
+
+    @abc.abstractmethod
+    def put(self, key: KeyType, **results: ResultType) -> None:
+        """
+        Records the given results by associating them with the provided key.
+        The key is implicitly converted to a string by calling ``str(key)``.
+
+        Calling this API on the same key multiple times overwrites
+        the results BUT not necessarily with the last call's results.
+        The exact semantics of consistency depends on the backing store.
+
+        .. note:: It is recommended this API is only called once per unique key
+
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get(self, key: KeyType) -> Dict[str, ResultType]:
+        """
+        Returns the results that have been recorded (put) with the key or
+        an empty map if no such key exists.
+        The key is implicitly converted to a string by calling ``str(key)``.
+
+        Note that if the backing store is not strongly consistent, there may be
+        a delay in the presence of the key after the ``put`` API has been called.
+        In this case, this method DOES NOT block until the key becomes available.
+        To account for this, the caller may chose to retry-get-with-timeout.
+        """
+        raise NotImplementedError()
+
+
+class FsspecResultTracker(ResultTracker):
+    """
+    Tracker that uses fsspec under the hood to save results.
+
+    Usage:
+
+    .. testcode::
+
+     # PUT: in trainer.py
+     tracker_base = "/tmp/foobar" # also supports URIs (e.g. "s3://bucket/trainer/123")
+     tracker = FsspecResultTracker(tracker_base)
+     tracker["attempt_1/out"] = {"accuracy": 0.233}
+
+     # GET: anywhere outside trainer.py
+     tracker = FsspecResultTracker(tracker_base)
+     print(tracker["attempt_1/out"]["accuracy"])
+
+     .. testoutput::
+
+      0.233
+
+    """
+
+    def __init__(self, tracker_base: str) -> None:
+        self._tracker_base = tracker_base
+
+    def put(self, key: KeyType, **results: ResultType) -> None:
+        mapper = fsspec.get_mapper(self._tracker_base, create=True)
+        # save results in pretty-print format so that the file is human readable
+        mapper[key] = json.dumps(results, indent=2).encode("utf-8")
+
+    def get(self, key: KeyType) -> Dict[str, ResultType]:
+        mapper = fsspec.get_mapper(self._tracker_base)
+        try:
+            results = mapper[key]
+            return json.loads(results.decode("utf-8"))
+        except KeyError:
+            return {}

--- a/torchx/runtime/tracking/test/__init__.py
+++ b/torchx/runtime/tracking/test/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchx/runtime/tracking/test/api_test.py
+++ b/torchx/runtime/tracking/test/api_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import shutil
+import tempfile
+import unittest
+
+from torchx.runtime.tracking.api import FsspecResultTracker
+
+
+class ApiTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = tempfile.mkdtemp("torchx_runtime_tracking_test")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_put_get(self) -> None:
+        tracker = FsspecResultTracker(self.test_dir)
+        tracker["a/b"] = {
+            "hartmann6": 1,
+            "model_name": "foobar",
+            "l2norm/mean": 3.4,
+            "l2norm/sem": 5.6,
+        }
+
+        self.assertEqual(1, tracker["a/b"]["hartmann6"])
+        self.assertEqual("foobar", tracker["a/b"]["model_name"])
+        self.assertEqual(3.4, tracker["a/b"]["l2norm/mean"])
+        self.assertEqual(5.6, tracker["a/b"]["l2norm/sem"])
+
+    def test_get_missing_key(self) -> None:
+        tracker = FsspecResultTracker(self.test_dir)
+        res = tracker[1]
+        self.assertFalse(res)
+
+    def test_put_get_x2(self) -> None:
+        tracker = FsspecResultTracker(self.test_dir)
+        tracker[1] = {"l2norm": 1}
+        tracker[1] = {"l2norm": 2}
+
+        self.assertEqual(2, tracker["1"]["l2norm"])
+        self.assertEqual(2, tracker["1"]["l2norm"])

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -30,7 +30,7 @@ from typing import (
 import yaml
 from pyre_extensions import none_throws
 from torchx.specs.file_linter import parse_fn_docstring
-from torchx.util.types import decode_from_string, is_primitive, decode_optional
+from torchx.util.types import decode_from_string, decode_optional, is_primitive
 
 
 SchedulerBackend = str
@@ -136,6 +136,7 @@ class macros:
             """
             apply applies the values to a copy the specified role and returns it.
             """
+
             role = copy.deepcopy(role)
             role.args = [self.substitute(arg) for arg in role.args]
             role.env = {key: self.substitute(arg) for key, arg in role.env.items()}


### PR DESCRIPTION
Summary:
Follow up to D30320103 (https://github.com/pytorch/torchx/commit/a879d63e545a9dd36f02d2e33462d2e2497d016b). Does the following:

1. Moves TorchXRunner, TorchXScheduler, AppMetrics to `torchx.runtime.hpo.ax` (from `torchx.apps.hpo.ax`)

2. Implements a simple `FsspecResultTracker` - used to return objective values from the trials (aka apps - see `booth_main.py`)

3. Modifies `ax_test.py` to actually run an hpo on `booth_main.py` (rather than echo), which evaluates booth function at `(x1, x2)` and writes the eval value with the fsspec tracker.

Reviewed By: aivanou

Differential Revision: D30797078

