### PR TITLE
Enable support for boolean flags in components definition

### DIFF
--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -401,6 +401,30 @@ def test_empty_fn() -> AppDef:
     return get_dummy_application("trainer")
 
 
+def test_fn_with_bool(flag: bool = False) -> AppDef:
+    """Dummy app with or without flag
+
+    Args:
+        flag: flag param
+    """
+    if flag:
+        return get_dummy_application("trainer-with-flag")
+    else:
+        return get_dummy_application("trainer-without-flag")
+
+
+def test_fn_with_bool_opional(flag: Optional[bool] = None) -> AppDef:
+    """Dummy app with or without flag
+
+    Args:
+        flag: flag param
+    """
+    if flag:
+        return get_dummy_application("trainer-with-flag")
+    else:
+        return get_dummy_application("trainer-without-flag")
+
+
 def test_empty_fn_no_docstring() -> AppDef:
     return get_dummy_application("trainer")
 
@@ -577,3 +601,46 @@ class AppDefLoadTest(unittest.TestCase):
             ],
         )
         self.assertEqual(_TEST_VAR_ARGS, ("fooval", ("arg1", "arg2"), "barval"))
+
+    def test_bool_true(self) -> None:
+        app_def = from_function(
+            test_fn_with_bool,
+            [
+                "--flag",
+                "True",
+            ],
+        )
+        self.assertEqual("trainer-with-flag", app_def.roles[0].name)
+        app_def = from_function(
+            test_fn_with_bool,
+            [
+                "--flag",
+                "true",
+            ],
+        )
+        self.assertEqual("trainer-with-flag", app_def.roles[0].name)
+
+    def test_bool_false(self) -> None:
+        app_def = from_function(
+            test_fn_with_bool,
+            [
+                "--flag",
+                "False",
+            ],
+        )
+        self.assertEqual("trainer-without-flag", app_def.roles[0].name)
+        app_def = from_function(
+            test_fn_with_bool,
+            [
+                "--flag",
+                "false",
+            ],
+        )
+        self.assertEqual("trainer-without-flag", app_def.roles[0].name)
+
+    def test_bool_none(self) -> None:
+        app_def = from_function(
+            test_fn_with_bool,
+            [],
+        )
+        self.assertEqual("trainer-without-flag", app_def.roles[0].name)

--- a/torchx/util/test/types_test.py
+++ b/torchx/util/test/types_test.py
@@ -13,6 +13,7 @@ from torchx.util.types import (
     decode_from_string,
     decode_optional,
     is_primitive,
+    is_bool,
     to_dict,
     to_list,
 )
@@ -66,6 +67,10 @@ class TypesTest(unittest.TestCase):
         arg2_parameter = parameters["arg2"]
         arg2_type = decode_optional(parameters["arg2"].annotation)
         self.assertFalse(is_primitive(arg2_parameter.annotation))
+
+    def test_is_bool(self) -> None:
+        self.assertTrue(is_bool(bool))
+        self.assertFalse(is_bool(int))
 
     def test_decode_from_string_dict(self) -> None:
         parameters = inspect.signature(_test_dict).parameters

--- a/torchx/util/types.py
+++ b/torchx/util/types.py
@@ -128,8 +128,14 @@ def decode_from_string(
         raise ValueError("Unknown")
 
 
+def is_bool(param_type: Any) -> bool:
+    """Check if the ``param_type`` is bool"""
+    return param_type == bool
+
+
 def is_primitive(param_type: Any) -> bool:
-    """Check if the ``param_type`` primitive or not
+    """Check if the ``param_type`` belongs to a list of
+    (int, str, float)
 
     Args:
         param_type: Parameter type


### PR DESCRIPTION
Summary: The diff enables `bool` parameter in the components definition function.

Differential Revision: D30973796

