### PR TITLE
workflows/nightly: add nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,23 +1,18 @@
-name: Python Unittests
+name: Push Nightly
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  # run every day at 11:15am
+  schedule:
+    - cron:  '15 11 * * *'
 
 jobs:
-  unittest:
+  nightly:
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
-      fail-fast: false
     steps:
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
           architecture: x64
       - name: Checkout TorchX
         uses: actions/checkout@v2
@@ -25,5 +20,10 @@ jobs:
         run: |
           set -eux
           pip install -e .[dev]
+          pip install twine
       - name: Run tests
         run: python -m unittest discover --verbose --start-directory . --pattern "*_test.py"
+      - name: Push nightly
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: scripts/push_nightly.sh

--- a/scripts/push_nightly.sh
+++ b/scripts/push_nightly.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+rm -r dist || true
+
+
+python setup.py --override-name torchx-nightly bdist_wheel
+
+if [ -z "$PYPI_TOKEN" ]; then
+    echo "must specify PYPI_TOKEN"
+    exit 1
+fi
+
+python3 -m twine upload \
+    --username __token__ \
+    --password "$PYPI_TOKEN" \
+    dist/torchx_nightly-*

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@
 import os
 import re
 import sys
+from datetime import date
 
 from setuptools import find_packages, setup
 
@@ -22,9 +23,22 @@ def get_version():
         return version
 
 
+def get_nightly_version():
+    today = date.today()
+    return f"{today.year}.{today.month}.{today.day}"
+
+
 if __name__ == "__main__":
     if sys.version_info < (3, 7):
         sys.exit("python >= 3.7 required for torchx-sdk")
+
+    name = "torchx"
+    NAME_ARG = "--override-name"
+    if NAME_ARG in sys.argv:
+        idx = sys.argv.index(NAME_ARG)
+        name = sys.argv.pop(idx + 1)
+        sys.argv.pop(idx)
+    is_nightly = "nightly" in name
 
     with open("README.md", encoding="utf8") as f:
         readme = f.read()
@@ -35,12 +49,12 @@ if __name__ == "__main__":
     with open("dev-requirements.txt") as f:
         dev_reqs = f.read()
 
-    version = get_version()
-    print("-- Building version: " + version)
+    version = get_nightly_version() if is_nightly else get_version()
+    print(f"-- {name} building version: {version}")
 
     setup(
         # Metadata
-        name="torchx",
+        name=name,
         version=version,
         author="TorchX Devs",
         author_email="torchx@fb.com",


### PR DESCRIPTION
<!-- Change Summary -->

This adds a new workflow action that pushes nightly images under https://pypi.org/project/torchx-nightly/.

It runs the unit tests, builds the image and then pushes it to torchx-nightly with version `<year>.<month>.<date>`. I.e. 2021.09.15. If unit tests fail it won't push to minimize breaking changes being released.

This may run into issues eventually if we use up the full 10gb allocated per torchx project but currently torchx-nightly is 120KB so it's gonna be 228 years before we have issues at the current size.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ scripts/push_nightly.sh
```

CI 

https://github.com/pytorch/torchx/runs/3615556170?check_suite_focus=true (this fails since the package has already been pushed today)