### PR TITLE
schedulers/images: add image type detection and warning

### DIFF
--- a/torchx/schedulers/images.py
+++ b/torchx/schedulers/images.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import posixpath
+from enum import Enum
+
+
+class ImageType(str, Enum):
+    UNKNOWN = "unknown"
+    DIR = "dir"
+    DOCKER = "docker"
+
+
+def image_type(image: str) -> ImageType:
+    if not image:
+        return ImageType.UNKNOWN
+    if posixpath.isabs(image):
+        return ImageType.DIR
+    return ImageType.DOCKER
+
+
+def assert_image_type(image: str, expected: ImageType) -> None:
+    actual = image_type(image)
+    if expected != actual:
+        raise TypeError(
+            f"expected image of type {repr(expected)} not {repr(actual)}: {repr(image)}",
+        )

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -34,6 +34,7 @@ from torchx.schedulers.api import (
     filter_regex,
 )
 from torchx.schedulers.ids import make_unique
+from torchx.schedulers.images import ImageType, assert_image_type
 from torchx.specs.api import (
     AppState,
     ReplicaState,
@@ -153,6 +154,8 @@ def role_to_pod(name: str, role: Role) -> "V1Pod":
         limits=requests,
         requests=requests,
     )
+
+    assert_image_type(role.image, ImageType.DOCKER)
 
     container = V1Container(
         command=[role.entrypoint] + role.args,

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from torchx.schedulers.api import AppDryRunInfo, DescribeAppResponse, Scheduler
+from torchx.schedulers.images import ImageType, assert_image_type
 from torchx.specs.api import (
     NONE,
     AppDef,
@@ -82,6 +83,8 @@ class SlurmReplicaRequest:
                 sbatch_opts.setdefault("mem", str(resource.memMB))
             if resource.gpu > 0:
                 sbatch_opts.setdefault("gpus-per-task", str(resource.gpu))
+
+        assert_image_type(role.image, ImageType.DIR)
 
         return cls(
             name=name,

--- a/torchx/schedulers/test/images_test.py
+++ b/torchx/schedulers/test/images_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+from torchx.schedulers.images import (
+    image_type,
+    assert_image_type,
+    ImageType,
+)
+
+
+class TorchxImageTypeTest(unittest.TestCase):
+    def test_image_type(self) -> None:
+        self.assertEqual(image_type("foo"), ImageType.DOCKER)
+        self.assertEqual(image_type("foo:bar"), ImageType.DOCKER)
+        self.assertEqual(image_type("abc/foo-bar:v1.0.0"), ImageType.DOCKER)
+        self.assertEqual(image_type("pytorch.com/abc/foo-bar:v1.0.0"), ImageType.DOCKER)
+        self.assertEqual(image_type("foo/bar"), ImageType.DOCKER)
+
+        self.assertEqual(image_type("/tmp"), ImageType.DIR)
+        self.assertEqual(image_type("/home/test"), ImageType.DIR)
+        self.assertEqual(image_type("/"), ImageType.DIR)
+
+        self.assertEqual(image_type(""), ImageType.UNKNOWN)
+
+    def test_assert_image_type(self) -> None:
+        with self.assertRaisesRegex(
+            TypeError, "expected image of type.*DIR.*not.*DOCKER"
+        ):
+            assert_image_type("foo/bar", ImageType.DIR)
+
+        with self.assertRaisesRegex(
+            TypeError, "expected image of type.*DIR.*not.*UNKNOWN"
+        ):
+            assert_image_type("", ImageType.DIR)
+
+        with self.assertRaisesRegex(
+            TypeError, "expected image of type.*DOCKER.*not.*DIR"
+        ):
+            assert_image_type("/", ImageType.DOCKER)

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -116,6 +116,15 @@ class KubernetesSchedulerTest(unittest.TestCase):
             want,
         )
 
+    def test_bad_image(self) -> None:
+        app = _test_app()
+        role = app.roles[0]
+        role.image = "/tmp"
+        with self.assertRaisesRegex(
+            TypeError, "expected image of type.*DOCKER.*not.*DIR"
+        ):
+            role_to_pod("name", role)
+
     def test_validate(self) -> None:
         scheduler = create_scheduler("test")
         app = _test_app()

--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -72,6 +72,17 @@ class SlurmSchedulerTest(unittest.TestCase):
             " ".join(srun),
         )
 
+    def test_replica_request_bad_image(self) -> None:
+        role = specs.Role(
+            name="foo",
+            image="alpine:latest",
+            entrypoint="echo",
+        )
+        with self.assertRaisesRegex(
+            TypeError, "expected image of type.*DIR.*not.*DOCKER"
+        ):
+            SlurmReplicaRequest.from_role("role-name", role, specs.RunConfig())
+
     def test_replica_request_run_config(self) -> None:
         role = specs.Role(
             name="foo",


### PR DESCRIPTION
<!-- Change Summary -->

Adds code for detecting image times and warning upfront when trying to schedule a job with an invalid image type.

This changes the local scheduler to detect if the image is a path or a docker image and use the corresponding scheduler. This requires all paths to have a `/` prefix to distinguish them from docker images. This is a bit hacky since it requires the local images to be in a certain format.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ pytest
$ pyre
$ scripts/lint.sh
```

CI