### PR TITLE
schedulers/slurm_scheduler: add time and partition fields

### DIFF
--- a/scripts/slurmtest.sh
+++ b/scripts/slurmtest.sh
@@ -18,7 +18,7 @@ source "$VENV"/bin/activate
 python --version
 pip install "$REMOTE_WHEEL"
 
-APP_ID="$(torchx run --wait --scheduler slurm utils.echo --num_replicas 3)"
+APP_ID="$(torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10 utils.echo --num_replicas 3)"
 torchx status "$APP_ID"
 torchx describe "$APP_ID"
 LOG_FILE="slurm-$(basename "$APP_ID").out"

--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -73,6 +73,8 @@ class SlurmSchedulerTest(unittest.TestCase):
         )
 
     def test_replica_request_run_config(self) -> None:
+        scheduler = create_scheduler("foo")
+
         role = specs.Role(
             name="foo",
             image="/some/path",
@@ -80,12 +82,18 @@ class SlurmSchedulerTest(unittest.TestCase):
             args=["hello"],
         )
         cfg = specs.RunConfig()
-        cfg.set("foo", "bar")
+        cfg.set("partition", "bubblegum")
+        cfg.set("time", "5:13")
         sbatch, _ = SlurmReplicaRequest.from_role("role-name", role, cfg).materialize()
-        self.assertIn(
-            "--foo=bar",
-            sbatch,
-        )
+
+        run_opts = scheduler.run_opts()
+
+        for k, v in cfg.cfgs.items():
+            self.assertIsNotNone(run_opts.get(k))
+            self.assertIn(
+                f"--{k}={v}",
+                sbatch,
+            )
 
     def test_dryrun_multi_role(self) -> None:
         scheduler = create_scheduler("foo")


### PR DESCRIPTION
<!-- Change Summary -->

This adds two new slurm scheduler_args:

* time -- controls the max time the job is allowed to run
* partition -- controls the "partition" / queue that the job should use

```
$ torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10 utils.echo --num_replicas 3
```

will have the job run in partition "compute" with a maximum of 10 minutes execution time.

https://slurm.schedmd.com/sbatch.html#SECTION_OPTIONS

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ pytest
$ scripts/slurmint.sh
$ pyre
$ scripts/lint.sh
```
