### PR TITLE
schedulers/local_scheduler: expose docker as local_docker instead of using image type

### DIFF
--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -15,7 +15,10 @@ from unittest.mock import MagicMock, patch
 from pyre_extensions import none_throws
 from torchx.runner import Runner, get_runner
 from torchx.schedulers.api import DescribeAppResponse
-from torchx.schedulers.local_scheduler import LocalScheduler
+from torchx.schedulers.local_scheduler import (
+    LocalScheduler,
+    LocalDirectoryImageProvider,
+)
 from torchx.schedulers.test.test_util import write_shell_script
 from torchx.specs.api import (
     AppDef,
@@ -52,7 +55,9 @@ class RunnerTest(unittest.TestCase):
         write_shell_script(self.test_dir, "fail.sh", ["exit 1"])
         write_shell_script(self.test_dir, "sleep.sh", ["sleep $1"])
 
-        self.scheduler = LocalScheduler(SESSION_NAME)
+        self.scheduler = LocalScheduler(
+            SESSION_NAME, image_provider_class=LocalDirectoryImageProvider
+        )
         self.cfg = RunConfig({"image_type": "dir"})
 
         # resource ignored for local scheduler; adding as an example
@@ -179,7 +184,9 @@ class RunnerTest(unittest.TestCase):
         # removed by the scheduler also get removed from the session after a status() API has been
         # called on the app
 
-        scheduler = LocalScheduler(session_name=SESSION_NAME, cache_size=1)
+        scheduler = LocalScheduler(
+            SESSION_NAME, cache_size=1, image_provider_class=LocalDirectoryImageProvider
+        )
         with Runner(
             name=SESSION_NAME,
             schedulers={"default": scheduler},

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -26,6 +26,7 @@ def get_schedulers(
 ) -> Dict[SchedulerBackend, Scheduler]:
     default_schedulers: Dict[str, SchedulerFactory] = {
         "local": local_scheduler.create_scheduler,
+        "local_docker": local_scheduler.create_docker_scheduler,
         "default": local_scheduler.create_scheduler,
         "slurm": slurm_scheduler.create_scheduler,
         "kubernetes": kubernetes_scheduler.create_scheduler,


### PR DESCRIPTION
<!-- Change Summary -->

This exposes running docker images via `local_docker` scheduler type ``--scheduler local_docker` instead of via `--scheduler local --scheduler_args image_type=docker`. This makes it easier to discover and use.

This is the first step in https://github.com/pytorch/torchx/issues/185. 

This is a breaking API change but not many users are using the local docker scheduler right now and it's easy to change.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ pytest -n 8
$ pyre
$ torchx runopts
```