### PR TITLE
components: switch all builtins to use docker images by default

### DIFF
--- a/scripts/slurmtest.sh
+++ b/scripts/slurmtest.sh
@@ -18,7 +18,7 @@ source "$VENV"/bin/activate
 python --version
 pip install "$REMOTE_WHEEL"
 
-APP_ID="$(torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10 utils.echo --num_replicas 3)"
+APP_ID="$(torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10 utils.echo --image /tmp --num_replicas 3)"
 torchx status "$APP_ID"
 torchx describe "$APP_ID"
 LOG_FILE="slurm-$(basename "$APP_ID").out"

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -113,6 +113,8 @@ class CmdRunTest(unittest.TestCase):
                 "--scheduler",
                 "local",
                 "utils.echo",
+                "--image",
+                "/tmp",
             ]
         )
         self.cmd_run.run(args)

--- a/torchx/components/serve.py
+++ b/torchx/components/serve.py
@@ -43,7 +43,8 @@ def torchserve(
     """
 
     args = [
-        "torchx/apps/serve/serve.py",
+        "-m",
+        "torchx.apps.serve.serve",
         "--model_path",
         model_path,
         "--management_api",
@@ -62,7 +63,7 @@ def torchserve(
             specs.Role(
                 name="torchx-serve-torchserve",
                 image=image,
-                entrypoint="python3",
+                entrypoint="python",
                 args=args,
                 port_map={"model-download": 8222},
             ),

--- a/torchx/components/test/serve_test.py
+++ b/torchx/components/test/serve_test.py
@@ -19,9 +19,10 @@ class ServeTest(unittest.TestCase):
                 specs.Role(
                     name="torchx-serve-torchserve",
                     image="torchx:latest",
-                    entrypoint="python3",
+                    entrypoint="python",
                     args=[
-                        "torchx/apps/serve/serve.py",
+                        "-m",
+                        "torchx.apps.serve.serve",
                         "--model_path",
                         "the_model_path",
                         "--management_api",

--- a/torchx/components/utils.py
+++ b/torchx/components/utils.py
@@ -18,7 +18,7 @@ from torchx.version import TORCHX_IMAGE
 
 
 def echo(
-    msg: str = "hello world", image: str = "/tmp", num_replicas: int = 1
+    msg: str = "hello world", image: str = TORCHX_IMAGE, num_replicas: int = 1
 ) -> specs.AppDef:
     """
     Echos a message to stdout (calls /bin/echo)
@@ -43,12 +43,13 @@ def echo(
     )
 
 
-def touch(file: str) -> specs.AppDef:
+def touch(file: str, image: str = TORCHX_IMAGE) -> specs.AppDef:
     """
     Touches a file (calls /bin/touch)
 
     Args:
         file: file to create
+        image: the image to use
 
     """
     return specs.AppDef(
@@ -56,7 +57,7 @@ def touch(file: str) -> specs.AppDef:
         roles=[
             specs.Role(
                 name="touch",
-                image="/tmp",
+                image=image,
                 entrypoint="/bin/touch",
                 args=[file],
                 num_replicas=1,
@@ -65,7 +66,7 @@ def touch(file: str) -> specs.AppDef:
     )
 
 
-def sh(*args: str, image: str = "/tmp", num_replicas: int = 1) -> specs.AppDef:
+def sh(*args: str, image: str = TORCHX_IMAGE, num_replicas: int = 1) -> specs.AppDef:
     """
     Runs the provided command via sh. Currently sh does not support
     environment variable substitution.
@@ -112,8 +113,10 @@ def copy(src: str, dst: str, image: str = TORCHX_IMAGE) -> specs.AppDef:
             specs.Role(
                 name="torchx-utils-copy",
                 image=image,
-                entrypoint="torchx/apps/utils/copy_main.py",
+                entrypoint="python",
                 args=[
+                    "-m",
+                    "torchx.apps.utils.copy_main",
                     "--src",
                     src,
                     "--dst",
@@ -148,8 +151,10 @@ def booth(
             specs.Role(
                 name="torchx-utils-booth",
                 image=image,
-                entrypoint="torchx/apps/utils/booth_main.py",
+                entrypoint="python",
                 args=[
+                    "-m",
+                    "torchx.apps.utils.booth_main",
                     "--x1",
                     str(x1),
                     "--x2",


### PR DESCRIPTION
<!-- Change Summary -->

This switches all builtin components to use docker images (instead of paths) and use `python -m` for module resolution instead of the absolute path.

https://github.com/pytorch/torchx/issues/184 

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ pytest
```
CI
