### PR TITLE
ci: fix pyre with latest pyre version

### DIFF
--- a/.github/workflows/pyre.yaml
+++ b/.github/workflows/pyre.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pyre:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,6 +1,5 @@
 {
   "source_directories": [
-    "examples/apps/lightning_classy_vision",
     "."
   ],
   "strict": true,

--- a/examples/apps/Dockerfile
+++ b/examples/apps/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install classy_vision pytorch-lightning fsspec[s3] torch-model-archiver 
 
 WORKDIR /app
 
-COPY . /app
+COPY . /app/examples/apps

--- a/examples/apps/dist_cifar/component.py
+++ b/examples/apps/dist_cifar/component.py
@@ -55,7 +55,7 @@ def trainer(
     """
     return ddp(
         image,
-        "dist_cifar/train.py",
+        "examples/apps/dist_cifar/train.py",
         rdzv_backend,
         rdzv_endpoint,
         resource,

--- a/examples/apps/lightning_classy_vision/component.py
+++ b/examples/apps/lightning_classy_vision/component.py
@@ -22,7 +22,7 @@ def trainer(
     image: str,
     output_path: str,
     data_path: str,
-    entrypoint: str = "lightning_classy_vision/train.py",
+    entrypoint: str = "examples/apps/lightning_classy_vision/train.py",
     load_path: str = "",
     log_path: str = "/logs",
     resource: Optional[str] = None,
@@ -90,7 +90,7 @@ def interpret(
     """
     return binary_component(
         name="examples-lightning_classy_vision-interpret",
-        entrypoint="lightning_classy_vision/interpret.py",
+        entrypoint="examples/apps/lightning_classy_vision/interpret.py",
         args=[
             "--load_path",
             load_path,

--- a/examples/apps/lightning_classy_vision/interpret.py
+++ b/examples/apps/lightning_classy_vision/interpret.py
@@ -30,10 +30,13 @@ import fsspec
 import torch
 
 # ensure data and module are on the path
-sys.path.append("examples/apps/lightning_classy_vision")
+sys.path.append(".")
 
-from data import TinyImageNetDataModule, download_data
-from model import TinyImageNetModel
+from examples.apps.lightning_classy_vision.data import (
+    TinyImageNetDataModule,
+    download_data,
+)
+from examples.apps.lightning_classy_vision.model import TinyImageNetModel
 
 
 # FIXME: captum must be imported after torch otherwise it causes python to crash

--- a/examples/apps/lightning_classy_vision/model.py
+++ b/examples/apps/lightning_classy_vision/model.py
@@ -98,7 +98,7 @@ def export_inference_model(
             "--model-name",
             "tiny_image_net",
             "--handler",
-            "lightning_classy_vision/handler/handler.py",
+            "examples/apps/lightning_classy_vision/handler/handler.py",
             "--version",
             "1",
             "--serialized-file",

--- a/examples/apps/lightning_classy_vision/train.py
+++ b/examples/apps/lightning_classy_vision/train.py
@@ -28,9 +28,17 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
 
 # ensure data and module are on the path
-sys.path.append("examples/apps/lightning_classy_vision")
-from data import TinyImageNetDataModule, download_data, create_random_data
-from model import TinyImageNetModel, export_inference_model
+sys.path.append(".")
+
+from examples.apps.lightning_classy_vision.data import (
+    TinyImageNetDataModule,
+    download_data,
+    create_random_data,
+)
+from examples.apps.lightning_classy_vision.model import (
+    TinyImageNetModel,
+    export_inference_model,
+)
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:

--- a/examples/pipelines/kfp/advanced_pipeline.py
+++ b/examples/pipelines/kfp/advanced_pipeline.py
@@ -128,7 +128,7 @@ from torchx.components.base.binary_component import binary_component
 processed_data_path: str = os.path.join(args.output_path, "processed")
 datapreproc_app: specs.AppDef = binary_component(
     name="examples-datapreproc",
-    entrypoint="datapreproc/datapreproc.py",
+    entrypoint="examples/apps/datapreproc/datapreproc.py",
     args=["--input_path", data_path, "--output_path", processed_data_path],
     image=args.image,
 )


### PR DESCRIPTION
<!-- Change Summary -->

* This bumps the ubuntu version for pyre to avoid a glibc issue. Keeping the rest on 18.04 since that's what pytorch is currently on.

* It also changes the example container to match the same folder layout as the main repo. This makes pyre happy as well as makes it easier to reason about since everything is in the same location whether you're local or in the container. 

Fixes https://github.com/pytorch/torchx/actions/runs/1255259648

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI
