### PR TITLE
cli/run: show all scheduler names in run help

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -15,6 +15,7 @@ import torchx.specs as specs
 from pyre_extensions import none_throws
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import Runner, get_runner
+from torchx.schedulers import get_scheduler_factories
 from torchx.specs.finder import (
     _Component,
     get_components,
@@ -71,10 +72,11 @@ class CmdBuiltins(SubCommand):
 
 class CmdRun(SubCommand):
     def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        scheduler_names = get_scheduler_factories().keys()
         subparser.add_argument(
             "--scheduler",
             type=str,
-            help="Name of the scheduler to use",
+            help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]",
             default="default",
         )
         subparser.add_argument(

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -21,23 +21,33 @@ class SchedulerFactory(Protocol):
         ...
 
 
-def get_schedulers(
-    session_name: str, **scheduler_params: object
-) -> Dict[SchedulerBackend, Scheduler]:
+def get_scheduler_factories() -> Dict[str, SchedulerFactory]:
+    """
+    get_scheduler_factories returns all the available schedulers names and the
+    method to instantiate them.
+    """
     default_schedulers: Dict[str, SchedulerFactory] = {
+        "default": local_scheduler.create_scheduler,
         "local": local_scheduler.create_scheduler,
         "local_docker": local_scheduler.create_docker_scheduler,
-        "default": local_scheduler.create_scheduler,
         "slurm": slurm_scheduler.create_scheduler,
         "kubernetes": kubernetes_scheduler.create_scheduler,
     }
 
-    schedulers = load_group(
+    return load_group(
         "torchx.schedulers",
         default=default_schedulers,
         ignore_missing=True,
     )
 
+
+def get_schedulers(
+    session_name: str, **scheduler_params: object
+) -> Dict[SchedulerBackend, Scheduler]:
+    """
+    get_schedulers returns all available schedulers.
+    """
+    schedulers = get_scheduler_factories()
     return {
         scheduler_backend: scheduler_factory_method(session_name, **scheduler_params)
         for scheduler_backend, scheduler_factory_method in schedulers.items()


### PR DESCRIPTION
<!-- Change Summary -->

This shows the scheduler names in run help to make it easier for users to find new schedulers.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ torchx run --help
```