### PR TITLE
Make `nnodes` have priority over `num_replicas`

### DIFF
--- a/torchx/components/base/__init__.py
+++ b/torchx/components/base/__init__.py
@@ -60,8 +60,9 @@ def torch_dist_role(
      trainer = torch_dist_role("trainer",container, entrypoint="trainer.py",.., nproc_per_node=4)
 
 
-    .. warning:: ``torch.distributed.run`` parameter ``nnodes`` will be set to the ``num_replicas``.
-                  The ``nnodes`` parameter will be ignored if provided.
+    .. warning:: Users can provide ``nnodes`` parameter, that is used by the ``torch.distibuted.run``
+                  If users do not provide ``nnodes`` parameter, the ``nnodes`` will be automatically set
+                  to ``num_replicas``.
 
 
     Args:

--- a/torchx/components/base/roles.py
+++ b/torchx/components/base/roles.py
@@ -91,12 +91,8 @@ def create_torch_dist_role(
     launch_kwargs.setdefault("rdzv_id", macros.app_id)
     launch_kwargs.setdefault("role", name)
 
-    if "nnodes" in launch_kwargs:
-        logger.warning(
-            "Parameter ``nnodes`` will be overridden by the ``num_replicas``"
-            "You can safely omit it and use ``num_replicas``"
-        )
-    launch_kwargs["nnodes"] = num_replicas
+    if "nnodes" not in launch_kwargs:
+        launch_kwargs["nnodes"] = num_replicas
 
     for (arg, val) in launch_kwargs.items():
         if isinstance(val, bool):

--- a/torchx/components/base/test/lib_test.py
+++ b/torchx/components/base/test/lib_test.py
@@ -84,7 +84,7 @@ class TorchxBaseLibTest(unittest.TestCase):
             "-m",
             "torch.distributed.run",
             "--nnodes",
-            "2",
+            "10",
             "--rdzv_backend",
             "etcd",
             "--rdzv_id",


### PR DESCRIPTION
Summary:
The diff makes sure that `nnodes` has priority over `num_replicas`, when launching via torchx. This will support a use case, where the compute cluster needs to be established among different roles.

The diff D31099295 (https://github.com/pytorch/torchx/commit/febf9fcdd107c08c199f9c5bbf99381005700138) made a change where `num_replicas` always override `nnodes`. But this change does not work for use-case where node cluster is established among different roles. This diff fixes the issue.

Differential Revision: D31118956

