### PR TITLE
apps/utils/process_monitor: process manager for sidecar services

### DIFF
--- a/torchx/apps/utils/process_monitor.py
+++ b/torchx/apps/utils/process_monitor.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import subprocess
+import sys
+import time
+from typing import List
+
+import fsspec
+
+TIMEOUT_EXIT_CODE = 34
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="monitors a process and terminates it when a condition is met"
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        help="timeout in seconds to wait before killing the process",
+    )
+    parser.add_argument(
+        "--start_on_file",
+        type=str,
+        help="monitor specified fsspec path for existence and terminate process when the file is created",
+    )
+    parser.add_argument(
+        "--exit_on_file",
+        type=str,
+        help="monitor specified fsspec path for existence and terminate process when the file is created",
+    )
+    parser.add_argument(
+        "--poll_rate",
+        type=float,
+        default=5,
+        help="seconds between polling the process and file for termination",
+    )
+    parser.add_argument(
+        "--kill_timeout",
+        type=float,
+        default=60,
+        help="seconds to wait after terminating the process before calling kill",
+    )
+    parser.add_argument(
+        "entrypoint",
+        type=str,
+        help="program entrypoint",
+    )
+    parser.add_argument(
+        "args",
+        type=str,
+        help="program args",
+        nargs="+",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str]) -> None:
+    args = parse_args(argv)
+    start_time = time.time()
+
+    if args.start_on_file:
+        fs, path = fsspec.core.url_to_fs(args.start_on_file)
+        while True:
+            if fs.exists(path):
+                print(f"{args.start_on_file} exists, starting process...")
+                break
+            if args.timeout:
+                elapsed_time = time.time() - start_time
+                if elapsed_time > args.timeout:
+                    print("reached timeout before launching, terminating...")
+                    sys.exit(TIMEOUT_EXIT_CODE)
+
+            time.sleep(args.poll_rate)
+
+    p = subprocess.Popen([args.entrypoint] + args.args)
+    print(f"started process {p.pid}")
+
+    while True:
+        try:
+            p.wait(args.poll_rate)
+
+            print(f"process exited with exit code {p.returncode}")
+            sys.exit(p.returncode)
+        except subprocess.TimeoutExpired:
+            if args.timeout:
+                elapsed_time = time.time() - start_time
+                if elapsed_time > args.timeout:
+                    print("reached timeout, terminating...")
+                    break
+
+            if args.exit_on_file:
+                fs, path = fsspec.core.url_to_fs(args.exit_on_file)
+                if fs.exists(path):
+                    print(f"{args.exit_on_file} exists, terminating...")
+                    break
+
+    p.terminate()
+    print("issued terminate, waiting for exit...")
+    try:
+        p.wait(args.kill_timeout)
+    except subprocess.TimeoutExpired:
+        print("reached safe termination timeout, killing...")
+        p.kill()
+
+    p.wait()
+    print(f"process exited with exit code {p.returncode}")
+    sys.exit(p.returncode)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/torchx/apps/utils/test/process_monitor_test.py
+++ b/torchx/apps/utils/test/process_monitor_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import io
+import unittest
+from unittest.mock import MagicMock, patch
+
+import fsspec
+import psutil
+from torchx.apps.utils.process_monitor import main, TIMEOUT_EXIT_CODE
+
+
+class ProcessTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        current_process = psutil.Process()
+        self.assertEqual(
+            len(current_process.children()), 0, "zombie children processes!"
+        )
+
+    def test_returncode(self) -> None:
+        with self.assertRaisesRegex(SystemExit, r"^0$"):
+            main(
+                [
+                    "--timeout",
+                    "60",
+                    "echo",
+                    "hello",
+                ]
+            )
+
+        with self.assertRaisesRegex(SystemExit, r"^123$"):
+            main(["--timeout", "60", "--", "bash", "-c", "exit 123"])
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_timeout(self, stdout: MagicMock) -> None:
+        with self.assertRaisesRegex(SystemExit, r"^-15$"):
+            main(
+                [
+                    "--timeout",
+                    "0.0001",
+                    "--poll_rate",
+                    "0.0001",
+                    "sleep",
+                    "60",
+                ]
+            )
+        self.assertIn("reached timeout, terminating...", stdout.getvalue())
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_timeout_kill(self, stdout: MagicMock) -> None:
+        with self.assertRaisesRegex(SystemExit, r"^-9$"):
+            main(
+                [
+                    "--timeout",
+                    "0.1",
+                    "--poll_rate",
+                    "0.1",
+                    "--kill_timeout",
+                    "0.1",
+                    "--",
+                    "bash",
+                    "-c",
+                    "trap 'echo received term' TERM; sleep 10",
+                ]
+            )
+        self.assertIn("reached safe termination timeout, killing...", stdout.getvalue())
+
+    def test_start_on_file(self) -> None:
+        start_on_file = "memory://start"
+        fs, path = fsspec.core.url_to_fs(start_on_file)
+
+        args = [
+            "--timeout",
+            "0.001",
+            "--poll_rate",
+            "0.001",
+            "--start_on_file",
+            start_on_file,
+            "--",
+            "echo",
+            "banana",
+        ]
+
+        with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            with self.assertRaisesRegex(SystemExit, f"^{TIMEOUT_EXIT_CODE}$"):
+                main(args)
+            self.assertIn(
+                "reached timeout before launching, terminating...", stdout.getvalue()
+            )
+
+        fs.touch(path)
+
+        with self.assertRaisesRegex(SystemExit, r"^0$"):
+            main(args)
+
+    def test_exit_on_file(self) -> None:
+        start_on_file = "memory://end"
+        fs, path = fsspec.core.url_to_fs(start_on_file)
+        args = [
+            "--poll_rate",
+            "0.001",
+            "--exit_on_file",
+            start_on_file,
+            "--",
+            "sleep",
+            "60",
+        ]
+
+        with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            with self.assertRaisesRegex(SystemExit, r"^-15$"):
+                main(
+                    [
+                        "--timeout",
+                        "0.001",
+                    ]
+                    + args
+                )
+            self.assertIn("reached timeout, terminating", stdout.getvalue())
+
+        fs.touch(path)
+
+        with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            with self.assertRaisesRegex(SystemExit, r"^-15$"):
+                main(
+                    [
+                        "--timeout",
+                        "60",
+                    ]
+                    + args
+                )
+            self.assertIn("exists, terminating", stdout.getvalue())


### PR DESCRIPTION
<!-- Change Summary -->

This creates a new wrapper `torchx/apps/utils/process_monitor.py` that can be used to manage ancillary services to the main job. This is designed to allow using stock tensorboard during a distributed training job.

```
$ torchx/apps/utils/process_monitor.py --start_on_file s3://bucket/job1/logs --end_on_file s3://bucket/job1/checkpoint/final.ckpt  --timeout 28800  -- tensorboard --logdir s3://bucket/job1/logs
```

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ pytest torchx/apps/utils/test/process_monitor_test.py
$ pyre
```

CI
