### PR TITLE
local_scheduler: add local_cwd scheduler + improve default handling

### DIFF
--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -5,6 +5,11 @@ torchx.schedulers
 .. currentmodule:: torchx.schedulers
 
 .. autofunction:: get_schedulers
+.. autofunction:: get_scheduler_factories
+.. autofunction:: get_default_scheduler_name
 
 .. autoclass:: Scheduler
+   :members:
+
+.. autoclass:: SchedulerFactory
    :members:

--- a/docs/source/schedulers/local.rst
+++ b/docs/source/schedulers/local.rst
@@ -13,8 +13,8 @@ Image Providers
 .. autoclass:: ImageProvider
    :members:
 
-.. autoclass:: LocalDirectoryImageProvider
+.. autoclass:: DockerImageProvider
    :members:
 
-.. autoclass::DockerImageProvider
+.. autoclass:: CWDImageProvider
    :members:

--- a/torchx/cli/__init__.py
+++ b/torchx/cli/__init__.py
@@ -31,13 +31,23 @@ If so, no need to even author an app spec!
   3. touch
   ... <omitted for brevity>
 
-Listing the supported schedulers
-----------------------------------
+Listing the supported schedulers and arguments
+-------------------------------------------------
 To get a list of supported schedulers that you can launch your job into run:
 
 .. code-block:: shell-session
 
- $ torchx schedulers
+ $ torchx runopts
+ local_docker:
+ { 'log_dir': { 'default': 'None',
+                'help': 'dir to write stdout/stderr log files of replicas',
+                'type': 'str'}}
+ local_cwd:
+ ...
+ slurm:
+ ...
+ kubernetes:
+ ...
 
 Running a component as a job
 ---------------------------------
@@ -80,27 +90,24 @@ parameters:
 
 2. arguments to the scheduler (``--scheduler_args``, also known as ``run_options`` or ``run_configs``),
    each scheduler takes different args, to find out the args for a specific scheduler run (command for
-   ``local`` scheduler shown below:
+   ``local_cwd`` scheduler shown below:
 
    .. code-block:: shell-session
 
-    $ torchx runopts local
-    { 'image_fetcher': { 'default': 'dir',
-                     'help': 'image fetcher type',
-                     'type': 'str'},
-    'log_dir': { 'default': 'None',
+    $ torchx runopts local_cwd
+    { 'log_dir': { 'default': 'None',
                'help': 'dir to write stdout/stderr log files of replicas',
                'type': 'str'}}
 
     # pass run options as comma-delimited k=v pairs
-    $ torchx run --scheduler local --scheduler_args image_fetcher=dir,log_dir=/tmp ...
+    $ torchx run --scheduler local_cwd --scheduler_args log_dir=/tmp ...
 
 3. arguments to the component (the app args are included here), this also depends on the
    component and can be seen with the ``--help`` string on the component
 
    .. code-block:: shell-session
 
-    $ torchx run --scheduler local utils.echo --help
+    $ torchx run --scheduler local_cwd utils.echo --help
     usage: torchx run echo.torchx [-h] [--msg MSG]
 
     Echos a message
@@ -109,11 +116,11 @@ parameters:
     -h, --help  show this help message and exit
     --msg MSG   Message to echo
 
-Putting everything together, running ``echo`` with the ``local`` scheduler:
+Putting everything together, running ``echo`` with the ``local_cwd`` scheduler:
 
 .. code-block:: shell-session
 
- $ torchx run --scheduler local --scheduler_args image_fetcher=dir,log_dir=/tmp utils.echo --msg "hello $USER"
+ $ torchx run --scheduler local_cwd --scheduler_args log_dir=/tmp utils.echo --msg "hello $USER"
  === RUN RESULT ===
  Launched app: local://torchx_kiuk/echo_ecd30f74
 
@@ -137,7 +144,7 @@ use the ``--dryrun`` option to the ``run`` subcommand:
 
 .. code-block:: shell-session
 
- $ torchx run --dryrun utils.echo --msg  hello_world
+ $ torchx run --dryrun utils.echo --msg hello_world
  === APPLICATION ===
  { 'metadata': {},
    'name': 'echo',

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -15,7 +15,7 @@ import torchx.specs as specs
 from pyre_extensions import none_throws
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import Runner, get_runner
-from torchx.schedulers import get_scheduler_factories
+from torchx.schedulers import get_scheduler_factories, get_default_scheduler_name
 from torchx.specs.finder import (
     _Component,
     get_components,
@@ -77,7 +77,7 @@ class CmdRun(SubCommand):
             "--scheduler",
             type=str,
             help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]",
-            default="default",
+            default=get_default_scheduler_name(),
         )
         subparser.add_argument(
             "--scheduler_args",
@@ -140,7 +140,7 @@ class CmdRun(SubCommand):
             app_handle = cast(specs.AppHandle, result)
             print(app_handle)
 
-            if args.scheduler == "local":
+            if args.scheduler.startswith("local"):
                 self._wait_and_exit(runner, app_handle)
             else:
                 logger.info("=== RUN RESULT ===")

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -45,7 +45,7 @@ class CmdRunTest(unittest.TestCase):
         args = self.parser.parse_args(
             [
                 "--scheduler",
-                "local",
+                "local_cwd",
                 str(Path(__file__).parent / "components.py:touch"),
                 "--file",
                 str(self.tmpdir / "foobar.txt"),
@@ -60,7 +60,7 @@ class CmdRunTest(unittest.TestCase):
             args = self.parser.parse_args(
                 [
                     "--scheduler",
-                    "local",
+                    "local_cwd",
                     str(Path(__file__).parent / "components.py:touch_v2"),
                     "--file",
                     str(self.tmpdir / "foobar.txt"),
@@ -83,7 +83,7 @@ class CmdRunTest(unittest.TestCase):
             args = self.parser.parse_args(
                 [
                     "--scheduler",
-                    "local",
+                    "local_cwd",
                     str(Path(__file__).parent / "components.py:touch_v2"),
                     "--file",
                     str(self.tmpdir / "foobar.txt"),
@@ -99,7 +99,7 @@ class CmdRunTest(unittest.TestCase):
         args = self.parser.parse_args(
             [
                 "--scheduler",
-                "local",
+                "local_cwd",
                 "1234_does_not_exist.torchx",
             ]
         )
@@ -111,7 +111,7 @@ class CmdRunTest(unittest.TestCase):
             [
                 "--dryrun",
                 "--scheduler",
-                "local",
+                "local_cwd",
                 "utils.echo",
                 "--image",
                 "/tmp",

--- a/torchx/cli/test/main_test.py
+++ b/torchx/cli/test/main_test.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import unittest
 from pathlib import Path
 
@@ -17,17 +18,22 @@ _SIMPLE_CONF: str = str(Path(__file__).parent / "components.py:simple")
 
 
 class CLITest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.old_cwd = os.getcwd()
+        os.chdir(_root / "container")
+
+    def tearDown(self) -> None:
+        os.chdir(self.old_cwd)
+
     def test_run_abs_config_path(self) -> None:
         main(
             [
                 "run",
                 "--scheduler",
-                "local",
+                "local_cwd",
                 str(_root / "components.py:simple"),
                 "--num_trainers",
                 "2",
-                "--trainer_image",
-                str(_root / "container"),
             ]
         )
 
@@ -36,11 +42,9 @@ class CLITest(unittest.TestCase):
             [
                 "run",
                 "--scheduler",
-                "local",
+                "local_cwd",
                 _SIMPLE_CONF,
                 "--num_trainers",
                 "2",
-                "--trainer_image",
-                str(_root / "container"),
             ]
         )

--- a/torchx/components/__init__.py
+++ b/torchx/components/__init__.py
@@ -20,11 +20,11 @@ Components can be used out of the box by either torchx cli or torchx sdk.
 
   # using via sdk
   from torchx.runner import get_runner
-  get_runner().run_component("distributed.ddp", app_args=[], scheduler="local", ...)
+  get_runner().run_component("distributed.ddp", app_args=[], scheduler="local_cwd", ...)
 
   # using via torchx-cli
 
-  >> torchx run --scheduler local distributed.ddp --param1 --param2
+  >> torchx run --scheduler local_cwd distributed.ddp --param1 --param2
 
 
 Components development

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -65,10 +65,6 @@ class Runner:
                 inherit this name.
             schedulers: a list of schedulers the runner can use.
         """
-        if "default" not in schedulers:
-            raise ValueError(
-                f"A `default` scheduler is required. Provided schedulers: {schedulers.keys()}"
-            )
         self._name: str = name
         self._schedulers = schedulers
         self._apps: Dict[AppHandle, AppDef] = {}
@@ -107,7 +103,7 @@ class Runner:
         self,
         component_name: ComponentId,
         app_args: List[str],
-        scheduler: SchedulerBackend = "default",
+        scheduler: SchedulerBackend,
         cfg: Optional[RunConfig] = None,
         dryrun: bool = False,
         # pyre-ignore[24]: Allow generic AppDryRunInfo
@@ -163,7 +159,7 @@ class Runner:
     def run(
         self,
         app: AppDef,
-        scheduler: SchedulerBackend = "default",
+        scheduler: SchedulerBackend,
         cfg: Optional[RunConfig] = None,
     ) -> AppHandle:
         """
@@ -229,7 +225,7 @@ class Runner:
     def dryrun(
         self,
         app: AppDef,
-        scheduler: SchedulerBackend = "default",
+        scheduler: SchedulerBackend,
         cfg: Optional[RunConfig] = None,
         # pyre-fixme[24]: AppDryRunInfo was designed to work with Any request object
     ) -> AppDryRunInfo:
@@ -292,9 +288,6 @@ class Runner:
     def scheduler_backends(self) -> List[SchedulerBackend]:
         """
         Returns a list of all supported scheduler backends.
-        All session implementations must support a "default"
-        scheduler backend and document what the default
-        scheduler is.
         """
         return list(self._schedulers.keys())
 

--- a/torchx/runtime/hpo/test/ax_test.py
+++ b/torchx/runtime/hpo/test/ax_test.py
@@ -43,6 +43,9 @@ class TorchXSchedulerTest(unittest.TestCase):
     def setUp(self) -> None:
         self.test_dir = tempfile.mkdtemp("torchx_runtime_hpo_ax_test")
 
+        self.old_cwd = os.getcwd()
+        os.chdir(os.path.dirname(__file__))
+
         self._parameters: List[Parameter] = [
             RangeParameter(
                 name="x1",
@@ -69,15 +72,13 @@ class TorchXSchedulerTest(unittest.TestCase):
         self._runner = TorchXRunner(
             tracker_base=self.test_dir,
             component=utils.booth,
-            component_const_params={
-                "image": os.path.dirname(__file__),
-            },
-            scheduler="local",
+            scheduler="local_cwd",
             scheduler_args=RunConfig({"log_dir": self.test_dir}),
         )
 
     def tearDown(self) -> None:
         shutil.rmtree(self.test_dir)
+        os.chdir(self.old_cwd)
 
     def test_run_experiment_locally(self) -> None:
         # runs optimization over n rounds of k sequential trials

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -25,11 +25,12 @@ def get_scheduler_factories() -> Dict[str, SchedulerFactory]:
     """
     get_scheduler_factories returns all the available schedulers names and the
     method to instantiate them.
+
+    The first scheduler in the dictionary is used as the default scheduler.
     """
     default_schedulers: Dict[str, SchedulerFactory] = {
-        "default": local_scheduler.create_scheduler,
-        "local": local_scheduler.create_scheduler,
         "local_docker": local_scheduler.create_docker_scheduler,
+        "local_cwd": local_scheduler.create_cwd_scheduler,
         "slurm": slurm_scheduler.create_scheduler,
         "kubernetes": kubernetes_scheduler.create_scheduler,
     }
@@ -39,6 +40,14 @@ def get_scheduler_factories() -> Dict[str, SchedulerFactory]:
         default=default_schedulers,
         ignore_missing=True,
     )
+
+
+def get_default_scheduler_name() -> str:
+    """
+    default_scheduler_name returns the first scheduler defined in
+    get_scheduler_factories.
+    """
+    return next(iter(get_scheduler_factories().keys()))
 
 
 def get_schedulers(

--- a/torchx/schedulers/test/registry_test.py
+++ b/torchx/schedulers/test/registry_test.py
@@ -9,7 +9,7 @@ import unittest
 from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
-from torchx.schedulers import get_schedulers
+from torchx.schedulers import get_schedulers, get_default_scheduler_name
 from torchx.schedulers.local_scheduler import LocalScheduler
 
 
@@ -27,8 +27,10 @@ class SchedulersTest(unittest.TestCase):
     @patch("torchx.schedulers.load_group", new_callable=spy_load_group)
     def test_get_local_schedulers(self, mock_load_group: MagicMock) -> None:
         schedulers = get_schedulers(session_name="test_session")
-        self.assertTrue(isinstance(schedulers["local"], LocalScheduler))
-        self.assertTrue(isinstance(schedulers["default"], LocalScheduler))
+        self.assertTrue(isinstance(schedulers["local_cwd"], LocalScheduler))
+        self.assertTrue(isinstance(schedulers["local_docker"], LocalScheduler))
 
-        self.assertEquals("test_session", schedulers["local"].session_name)
-        self.assertEquals("test_session", schedulers["default"].session_name)
+        self.assertEqual(get_default_scheduler_name(), "local_docker")
+
+        for scheduler in schedulers.values():
+            self.assertEqual("test_session", scheduler.session_name)


### PR DESCRIPTION
<!-- Change Summary -->

* `local_cwd`: This adds a new scheduler/image provider that overrides the image with the current working directory. This is intended to be a better approach for local launching since it doesn't require interacting with the images.
* This removes `local_dir` scheduler in favor of `local_cwd`. 
* Changes how the default scheduler is specified since it's unclear what `default` even means without looking at the code and instead the CLI specifies the default via argparse default.
* Updates the documentation to use local_cwd and local_docker instead.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ pytest
$ pyre
$ env O="--port 4444" make clean livehtml
```

Go to quickstart page and ensure command run without any changes.

CI
