### PR TITLE
scripts/slurmint.sh: add keep alives to avoid ssh connections dropping when waiting for workers to spin up

### DIFF
--- a/scripts/slurmint.sh
+++ b/scripts/slurmint.sh
@@ -25,7 +25,7 @@ VENV="$DIR/venv"
 
 function run_cmd {
     # shellcheck disable=SC2048,SC2086
-    ssh "$SLURM_MASTER" -i "$SLURM_IDENT" $*
+    ssh -o ServerAliveInterval=60 "$SLURM_MASTER" -i "$SLURM_IDENT" $*
 }
 
 function run_scp {


### PR DESCRIPTION
<!-- Change Summary -->

We've had a few slurm integration tests timeout and have connections drop.  This adds keep alives to keep the connection alive as well as fail earlier if the server goes unresponsive for some reason instead of waiting 2 hours.

https://github.com/pytorch/torchx/runs/3667434200?check_suite_focus=true

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ scripts/slurmint.sh
```
