### PR TITLE
CI: enable codecov coverage collection + cleanups

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source =
+    torchx
+
+omit =
+    *test*

--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -24,6 +24,16 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
+          pip install coverage codecov
           pip install -e .[dev]
       - name: Run tests
-        run: python -m unittest discover --verbose --start-directory . --pattern "*_test.py"
+        run: coverage run -m unittest discover --verbose --start-directory . --pattern "*_test.py"
+      - name: Coverage
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          set -eux
+          coverage report -m
+          coverage xml
+
+          codecov

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ cython_debug/
 
 wordlist.dic
 pipeline.yaml
+
+/codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![PyPI](https://img.shields.io/pypi/v/torchx)](https://pypi.org/project/torchx/) [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE) ![Tests](https://github.com/pytorch/torchx/actions/workflows/python-unittests.yaml/badge.svg) ![Lint](https://github.com/pytorch/torchx/actions/workflows/lint.yaml/badge.svg)
+[![PyPI](https://img.shields.io/pypi/v/torchx)](https://pypi.org/project/torchx/)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE)
+![Tests](https://github.com/pytorch/torchx/actions/workflows/python-unittests.yaml/badge.svg)
+![Lint](https://github.com/pytorch/torchx/actions/workflows/lint.yaml/badge.svg)
+[![codecov](https://codecov.io/gh/pytorch/torchx/branch/main/graph/badge.svg?token=ceHHIm0hXy)](https://codecov.io/gh/pytorch/torchx)
 
 
 # TorchX
@@ -24,8 +28,11 @@ TorchX Kubeflow Pipelines Support (torchx-kfp):
 ### Release
 
 ```bash
-# install torchx sdk and CLI
+# install torchx sdk and CLI -- minimum dependencies
 pip install torchx
+
+# install torchx sdk and CLI -- all dependencies
+pip install "torchx[dev]"
 
 # install torchx kubeflow pipelines (kfp) support
 pip install "torchx[kfp]"

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -24,7 +24,7 @@ from torchx.specs.finder import (
 )
 
 
-def test_component(name: str, role_name: str = "worker") -> AppDef:
+def _test_component(name: str, role_name: str = "worker") -> AppDef:
     """
     Test component
 
@@ -94,10 +94,10 @@ class DirComponentsFinderTest(unittest.TestCase):
         with patch("torchx.specs.finder.entrypoints") as entrypoints_mock:
             entrypoints_mock.load_group.return_value = test_torchx_group
             components = _load_components()
-        foobar_component = components["foobar.finder_test.test_component"]
-        self.assertEqual(test_component, foobar_component.fn)
-        self.assertEqual("test_component", foobar_component.fn_name)
-        self.assertEqual("foobar.finder_test.test_component", foobar_component.name)
+        foobar_component = components["foobar.finder_test._test_component"]
+        self.assertEqual(_test_component, foobar_component.fn)
+        self.assertEqual("_test_component", foobar_component.fn_name)
+        self.assertEqual("foobar.finder_test._test_component", foobar_component.name)
         self.assertEqual("Test component", foobar_component.description)
 
     def test_get_base_module_name(self) -> None:
@@ -142,20 +142,20 @@ def current_file_path() -> str:
 class CustomComponentsFinderTest(unittest.TestCase):
     def test_find_components(self) -> None:
         components = CustomComponentsFinder(
-            current_file_path(), "test_component"
+            current_file_path(), "_test_component"
         ).find()
         self.assertEqual(1, len(components))
         component = components[0]
-        self.assertEqual(f"{current_file_path()}:test_component", component.name)
+        self.assertEqual(f"{current_file_path()}:_test_component", component.name)
         self.assertEqual("Test component", component.description)
-        self.assertEqual("test_component", component.fn_name)
+        self.assertEqual("_test_component", component.fn_name)
         self.assertListEqual([], component.validation_errors)
 
     def test_get_component(self) -> None:
-        component = get_component(f"{current_file_path()}:test_component")
-        self.assertEqual(f"{current_file_path()}:test_component", component.name)
+        component = get_component(f"{current_file_path()}:_test_component")
+        self.assertEqual(f"{current_file_path()}:_test_component", component.name)
         self.assertEqual("Test component", component.description)
-        self.assertEqual("test_component", component.fn_name)
+        self.assertEqual("_test_component", component.fn_name)
         self.assertListEqual([], component.validation_errors)
 
     def test_get_components(self) -> None:


### PR DESCRIPTION
<!-- Change Summary -->

* enables coverage collection for python unit tests
* uploads coverage to codecov.io
* adds badge to README
* updates README with instructions on how to install all dependencies
* fixes finder_test compatibility with pytest

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI -- check coverage is correctly computed

![2021-09-30-165142_1227x768_scrot](https://user-images.githubusercontent.com/909104/135545453-4ade4e39-4f2d-4fa0-9a4b-b9e1e638bea2.png)
![2021-09-30-165129_1350x366_scrot](https://user-images.githubusercontent.com/909104/135545455-65ea8528-ce47-4e1b-a4b5-cd7cbdadb3a4.png)

