### PR TITLE
(torchx-fb/penv)(bugfix) handle sys.argv[0] relpaths correctly when finding penv.par, add a CWD/penv.par search fallback to handle unittest @mode/opt

### DIFF
--- a/torchx/runtime/hpo/test/ax_test.py
+++ b/torchx/runtime/hpo/test/ax_test.py
@@ -66,7 +66,7 @@ class TorchXSchedulerTest(unittest.TestCase):
             tracker_base=self.test_dir,
             component=utils.booth,
             scheduler="local_cwd",
-            scheduler_args=RunConfig({"log_dir": self.test_dir, "prepend_cwd": True}),
+            scheduler_args=RunConfig({"prepend_cwd": True}),
         )
 
     def tearDown(self) -> None:


### PR DESCRIPTION
Summary:
Fixes the following two scenarios:

#1
```
~/bin
    - python
    - penv.par

$ cd ~/bin
$ ./python -m mo.du.le
```
Does not pick up `~/bin/penv.par` (as expected) because `sys.argv[0] = ./python`. Fix is to return `(Path(sys.argv[0])/"penv.par").absolute() `

#2
Using this interpreter as a unittest resource + torchx local_cwd scheduler does not resolve penv.par from the test source dir since the symlink is resolved by unix and `sys.argv[0]` is set to the actual interpreter (not the symlinked one)
```
python_unittest(
   name="foo_test",
   resource={
       "//torchx/fb:python": "python",
       "//torchx/apps:penv": "penv.par",
   }
   ...
)

# buck run mode/opt //foo_test
# outputs in build dir

~/fbcode/buck-out/opt/gen/foo_test#link-tree/
    - python -> buck-out/opt/gen/torchx/fb/python.par
    - penv.par
```
Hence with the current penv par lookup logic we end up looking for a penv.par in `buck-out/opt/gen/torchx/fb/penv.par` which does not exist and we just simply fall back to system python.

Reviewed By: aivanou

Differential Revision: D31402466

