### PR TITLE
docs/configure: update entry_points docs + doctest

### DIFF
--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -3,44 +3,73 @@ Configuring
 
 TorchX defines plugin points for you to configure TorchX to best support
 your infrastructure setup. Most of the configuration is done through
-Python's `entry points<https://packaging.python.org/specifications/entry-points/>`.
+Python's `entry points <https://packaging.python.org/specifications/entry-points/>`__.
+
+.. note::
+
+  Entry points requires a python package containing them be installed.
+  If you don't have a python package we recommend you make one so you can share
+  your resource definitions, schedulers and components across your team and org.
 
 The entry points described below can be specified in your project's `setup.py`
 file as
 
-.. code-block:: python
+.. testsetup:: setup
+
+   import sys
+   sys.argv = ["setup.py", "--version"]
+
+.. testcode:: setup
 
  from setuptools import setup
 
  setup(
-    name="project foobar",
-    entry_points={
-        "$ep_group_name" : [
-            "$ep_name = $module:$function"
-        ],
-    }
+     name="project foobar",
+     entry_points={
+         "torchx.schedulers": [
+             "my_scheduler = my.custom.scheduler:create_scheduler",
+         ],
+         "torchx.named_resources": [
+             "gpu_x2 = my_module.resources:gpu_x2",
+         ],
+     }
  )
+
+.. testoutput:: setup
+   :hide:
+
+   0.0.0
+
 
 
 Registering Custom Schedulers
 --------------------------------
 You may implement a custom scheduler by implementing the
-.. py::class torchx.schedulers.Scheduler interface. Once you do you can
-register this custom scheduler with the following entrypoint
-
-::
-
- [torchx.schedulers]
- $sched_name = my.custom.scheduler:create_scheduler
+.. py::class torchx.schedulers.Scheduler interface.
 
 The ``create_scheduler`` function should have the following function signature:
 
-.. code-block:: python
+.. testcode::
 
  from torchx.schedulers import Scheduler
 
- def create_scheduler(session_name: str, **kwargs: Any) -> Scheduler:
+ def create_scheduler(session_name: str, **kwargs: object) -> Scheduler:
      return MyScheduler(session_name, **kwargs)
+
+You can then register this custom scheduler by adding an entry_points definition
+to your python project.
+
+
+.. testcode::
+
+   # setup.py
+   ...
+   entry_points={
+       "torchx.schedulers": [
+           "my_scheduler = my.custom.scheduler:create_schedule",
+       ],
+   }
+
 
 
 Registering Named Resources
@@ -53,46 +82,76 @@ deep learning training kubernetes cluster on AWS is
 comprised only of p3.16xlarge (64 vcpu, 8 gpu, 488GB), then you may want to
 enumerate t-shirt sized resource specs for the containers as:
 
-.. code-block:: python
+.. testcode:: python
 
- {
-    "gpu_x_1" : "Resource(cpu=8,  gpu=1, memMB=61*GB),
-    "gpu_x_2" : "Resource(cpu=16, gpu=2, memMB=122*GB),
-    "gpu_x_4" : "Resource(cpu=32, gpu=4, memMB=244*GB),
-    "gpu_x_8" : "Resource(cpu=64, gpu=8, memMB=488*GB),
- }
+ from torchx.specs import Resource
+
+ def gpu_x1() -> Resource:
+     return Resource(cpu=8,  gpu=1, memMB=61_000)
+
+ def gpu_x2() -> Resource:
+     return Resource(cpu=16, gpu=2, memMB=122_000)
+
+ def gpu_x3() -> Resource:
+     return Resource(cpu=32, gpu=4, memMB=244_000)
+
+ def gpu_x4() -> Resource:
+     return Resource(cpu=64, gpu=8, memMB=488_000)
+
+.. testcode:: python
+ :hide:
+
+ gpu_x1()
+ gpu_x2()
+ gpu_x3()
+ gpu_x4()
+
+To make these resource definitions available you then need to register them via
+entry_points:
+
+.. testcode::
+
+   # setup.py
+   ...
+   entry_points={
+       "torchx.named_resources": [
+           "gpu_x2 = my_module.resources:gpu_x2",
+       ],
+   }
 
 
-And refer to the resources by their string names.
+Once you install the package with the entry_points definitions, the named
+resource can then be used in the following manner:
 
-Torchx supports custom resource definition and reference by string
-representation:
+.. testsetup:: role
 
-::
+   from torchx.specs import named_resources, Resource
 
- [torchx.named_resources]
- gpu_x_2 = my_module.resources:gpu_x_2
+   named_resources["gpu_x2"] = Resource(cpu=16, gpu=2, memMB=122_000)
 
 
-The named resource after that can be used in the following manner:
+.. doctest:: role
 
-.. code-block:: python
+   >>> from torchx.specs import get_named_resources
+   >>> get_named_resources("gpu_x2")
+   Resource(cpu=16, gpu=2, memMB=122000, ...)
+
+
+.. testcode:: role
 
   # my_module.component
-  from torchx.specs import AppDef, Role, named_resources
-  from torchx.components.base import torch_dist_role
+  from torchx.specs import AppDef, Role, get_named_resources
 
-  app = AppDef(name="test_app", roles=[Role(.., resource=named_resources("gpu_x_2"))])
+  def test_app(resource: str) -> AppDef:
+      return AppDef(name="test_app", roles=[
+          Role(
+              name="...",
+              image="...",
+              resource=get_named_resources(resource),
+          )
+      ])
 
-or using ``torch.distributed.run``:
-
-.. code-block:: python
-
-  # my_module.component
-  from torchx.specs import AppDef, Role
-  from torchx.components.base import torch_dist_role
-
-  app = AppDef(name="test_app", roles=[torch_dist_role(.., resource="gpu_x_2", ...)])
+  test_app("gpu_x2")
 
 
 Registering Custom Components
@@ -107,12 +166,18 @@ when they run
 
  $ torchx builtins
 
-Custom components can be registered via the following modification of the ``entry_points.txt``:
+Custom components can be registered via the following modification of the ``entry_points``:
 
-::
 
- [torchx.components]
- foo = my_project.bar
+.. testcode::
+
+   # setup.py
+   ...
+   entry_points={
+       "torchx.components": [
+           "foo = my_project.bar",
+       ],
+   }
 
 The line above registers a group ``foo`` that is associated with the module ``my_project.bar``.
 Torchx will recursively traverse lowest level dir associated with the ``my_project.bar`` and will find


### PR DESCRIPTION
<!-- Change Summary -->

The documentation for TorchX entry_points support was a bit outdated (as pointed out in T102501232). This updates it as well as switches it to use doctests to ensure that there's no regressions in the future.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
make -C docs doctest
make -C docs livehtml
```
![Screenshot 2021-10-06 at 16-31-25 Configuring — PyTorch TorchX main documentation](https://user-images.githubusercontent.com/909104/136297399-9e072258-da7a-4658-9711-336201f21bd2.png)



