### PR TITLE
(torchx/specs) temporarily add back base_image to Role to keep backward compatibility with older fbpkgs in workflows

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -221,6 +221,7 @@ class Role:
 
     name: str
     image: str
+    base_image: Optional[str] = None  # DEPRECATED DO NOT SET, WILL BE REMOVED SOON
     entrypoint: str = MISSING
     args: List[str] = field(default_factory=list)
     env: Dict[str, str] = field(default_factory=dict)


### PR DESCRIPTION
Summary:
makes torchx_run_gang workflow backward compatible with workflows that still have base_image

Solves: https://fb.workplace.com/groups/140700188041197/permalink/203080498469832/

Reviewed By: kiukchung

Differential Revision: D31513305

