### PR TITLE
Remove `path` from file-linter

### DIFF
--- a/torchx/components/component_test_base.py
+++ b/torchx/components/component_test_base.py
@@ -38,9 +38,7 @@ class ComponentUtils:
     def get_linter_errors(
         cls, file_path: str, function_name: str
     ) -> List[LinterMessage]:
-        with open(file_path, "r") as fp:
-            file_content = fp.read()
-        linter_errors = validate(file_content, file_path, function_name)
+        linter_errors = validate(file_path, function_name)
         if len(linter_errors) != 0:
             error_msg = ""
             for linter_error in linter_errors:


### PR DESCRIPTION
Summary: The diff removes path parameter from file linter, since it is not necessary

Differential Revision: D31560686

