### PR TITLE
examples/lightning_classy_vision: switch model architecture to resnet so it actually converges

### DIFF
--- a/torchx/examples/apps/lightning_classy_vision/component.py
+++ b/torchx/examples/apps/lightning_classy_vision/component.py
@@ -11,7 +11,7 @@ Trainer Component Example
 This is a component definition that runs the example lightning_classy_vision app.
 """
 
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 
 import torchx.specs.api as torchx
 from torchx.specs import named_resources
@@ -27,6 +27,9 @@ def trainer(
     env: Optional[Dict[str, str]] = None,
     skip_export: bool = False,
     epochs: int = 1,
+    layers: Optional[List[int]] = None,
+    learning_rate: Optional[float] = None,
+    num_samples: int = 200,
 ) -> torchx.AppDef:
     """Runs the example lightning_classy_vision app.
 
@@ -41,6 +44,9 @@ def trainer(
         env: env variables for the app
         skip_export: disable model export
         epochs: number of epochs to run
+        layers: the number of convolutional layers and their number of channels
+        learning_rate: the learning rate to use for training
+        num_samples: the number of images to run per batch, use 0 to run on all
     """
     env = env or {}
     args = [
@@ -55,6 +61,12 @@ def trainer(
         "--epochs",
         str(epochs),
     ]
+    if layers:
+        args += ["--layers"] + [str(layer) for layer in layers]
+    if learning_rate:
+        args += ["--lr", str(learning_rate)]
+    if num_samples and num_samples > 0:
+        args += ["--num_samples", str(num_samples)]
     if data_path:
         args += ["--data_path", data_path]
     else:

--- a/torchx/examples/apps/lightning_classy_vision/data.py
+++ b/torchx/examples/apps/lightning_classy_vision/data.py
@@ -41,7 +41,7 @@ class TinyImageNetDataset(ClassyDataset):
         self,
         data_path: str,
         transform: Callable[[object], object],
-        num_samples: int = 1000,
+        num_samples: Optional[int] = None,
     ) -> None:
         batchsize_per_replica = 16
         shuffle = False
@@ -74,7 +74,7 @@ class TinyImageNetDataModule(pl.LightningDataModule):
     test_ds: TinyImageNetDataset
 
     def __init__(
-        self, data_dir: str, batch_size: int = 16, num_samples: int = 1000
+        self, data_dir: str, batch_size: int = 16, num_samples: Optional[int] = None
     ) -> None:
         super().__init__()
         self.data_dir = data_dir
@@ -85,7 +85,6 @@ class TinyImageNetDataModule(pl.LightningDataModule):
         # Setup data loader and transforms
         img_transform = transforms.Compose(
             [
-                transforms.Grayscale(),
                 transforms.ToTensor(),
             ]
         )
@@ -131,6 +130,10 @@ def download_data(remote_path: str, tmpdir: str) -> str:
     download_data downloads the training data from the specified remote path via
     fsspec and places it in the tmpdir unextracted.
     """
+    if os.path.isdir(remote_path):
+        print("dataset path is a directory, using as is")
+        return remote_path
+
     tar_path = os.path.join(tmpdir, "data.tar.gz")
     print(f"downloading dataset from {remote_path} to {tar_path}...")
     fs, _, rpaths = fsspec.get_fs_token_paths(remote_path)

--- a/torchx/examples/apps/lightning_classy_vision/interpret.py
+++ b/torchx/examples/apps/lightning_classy_vision/interpret.py
@@ -75,10 +75,9 @@ def convert_to_rgb(arr: torch.Tensor) -> np.ndarray:  # pyre-ignore[24]
     This converts the image from a torch tensor with size (1, 1, 64, 64) to
     numpy array with size (64, 64, 3).
     """
-    squeezed = arr.squeeze()
-    stacked = torch.stack([squeezed, squeezed, squeezed], dim=2)
-    print("img stats: ", stacked.count_nonzero(), stacked.mean())
-    return stacked.numpy()
+    out = arr.squeeze().swapaxes(0, 2)
+    assert out.shape == (64, 64, 3), "invalid shape produced"
+    return out.numpy()
 
 
 def main(argv: List[str]) -> None:
@@ -106,6 +105,7 @@ def main(argv: List[str]) -> None:
         # process first 5 images
         for i, (input, label) in enumerate(itertools.islice(dataloader, 5)):
             print(f"analyzing example {i}")
+            # input = input.unsqueeze(dim=0)
             model.zero_grad()
             attr_ig, delta = ig.attribute(
                 input,

--- a/torchx/examples/apps/lightning_classy_vision/test/model_test.py
+++ b/torchx/examples/apps/lightning_classy_vision/test/model_test.py
@@ -13,19 +13,18 @@ from torchx.examples.apps.lightning_classy_vision.model import (
 
 
 class ModelTest(unittest.TestCase):
-    def test_basic(self) -> None:
-        model = TinyImageNetModel()
-        self.assertEqual(len(model.seq), 1)
-        out = model(torch.zeros((1, 64, 64)))
-        self.assertIsNotNone(out)
+    def test_lr(self) -> None:
+        model = TinyImageNetModel(lr=0.1234)
+        self.assertEqual(model.configure_optimizers().defaults["lr"], 0.1234)
 
     def test_layer_sizes(self) -> None:
         model = TinyImageNetModel(
             layer_sizes=[
-                10,
-                15,
+                1,
+                2,
+                1,
+                1,
             ],
         )
-        self.assertEqual(len(model.seq), 5)
-        out = model(torch.zeros((1, 64, 64)))
+        out = model(torch.zeros((1, 3, 64, 64)))
         self.assertIsNotNone(out)

--- a/torchx/examples/apps/lightning_classy_vision/train.py
+++ b/torchx/examples/apps/lightning_classy_vision/train.py
@@ -51,9 +51,11 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--epochs", type=int, default=3, help="number of epochs to train"
     )
+    parser.add_argument("--lr", type=float, help="learning rate")
     parser.add_argument(
         "--batch_size", type=int, default=32, help="batch size to use for training"
     )
+    parser.add_argument("--num_samples", type=int, default=None, help="num_samples")
     parser.add_argument(
         "--test",
         help="Sets to test mode, training on a much smaller set of randomly generated images",
@@ -93,6 +95,7 @@ def main(argv: List[str]) -> None:
 
         # Init our model
         model = TinyImageNetModel(args.layers)
+        print(model)
 
         # Download and setup the data module
         if args.test:
@@ -110,7 +113,7 @@ def main(argv: List[str]) -> None:
         data = TinyImageNetDataModule(
             data_dir=data_path,
             batch_size=args.batch_size,
-            num_samples=5 if args.test else 1000,
+            num_samples=5 if args.test else args.num_samples,
         )
 
         # Setup model checkpointing
@@ -138,6 +141,9 @@ def main(argv: List[str]) -> None:
 
         # Train the model ⚡
         trainer.fit(model, data)
+        print(
+            f"train acc: {model.train_acc.compute()}, val acc: {model.val_acc.compute()}"
+        )
 
         if not args.skip_export:
             # Export the inference model


### PR DESCRIPTION
<!-- Change Summary -->

This switches the TinyImageNetModel to use resnet with variable block sizes. To adjust model complexity the user can set `--layers` with basically any set of 4 ints in the ranges specified at:

https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py#L299

the example defaults to [1,1,1,1]
resnet18 is [2,2,2,2]
resnet34 is [3, 4, 6, 3]

This also adds learning rate to allow testing with that.

To get the model to converge you should run it with `--epochs 10 --num_samples 0` to do the full dataset with 10 passes. The whole dataset is quite large so running this on a GPU is ideal.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
torchx run --scheduler local_cwd torchx/examples/apps/lightning_classy_vision/component.py:trainer --image ""
--data_path ~/Developer/tiny-imagenet-200/ --output /tmp/cv/ --log_path /tmp/logs --epochs 10 --num_samples 0
```

CI
