### PR TITLE
(torchx/runner) Implement scheduler runopt dumping and loading to/from .INI file

### DIFF
--- a/torchx/cli/cmd_configure.py
+++ b/torchx/cli/cmd_configure.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import logging
+import sys
+
+from torchx.cli.cmd_base import SubCommand
+from torchx.runner.config import dump
+from torchx.schedulers import get_schedulers
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class CmdConfigure(SubCommand):
+    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "-s",
+            "--schedulers",
+            type=str,
+            help="comma delimited list of schedulers to dump runopts for, if not specified, dumps for all schedulers",
+        )
+        subparser.add_argument(
+            "--print",
+            action="store_true",
+            help="if specified, prints the config file to stdout instead of saving it to a file",
+        )
+        subparser.add_argument(
+            "-a",
+            "--all",
+            action="store_true",
+            help="if specified, includes required and optional runopts (default only dumps required)",
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+
+        if args.schedulers:
+            schedulers = args.schedulers.split(",")
+        else:
+            schedulers = get_schedulers(session_name="_").keys()
+
+        required_only = not args.all
+
+        if args.print:
+            dump(f=sys.stdout, schedulers=schedulers, required_only=required_only)
+        else:
+            with open(".torchxconfig", "w") as f:
+                dump(f=f, schedulers=schedulers, required_only=required_only)

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -79,12 +79,14 @@ class CmdRun(SubCommand):
         scheduler_names = get_scheduler_factories().keys()
         self._subparser = subparser
         subparser.add_argument(
+            "-s",
             "--scheduler",
             type=str,
             help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]",
             default=get_default_scheduler_name(),
         )
         subparser.add_argument(
+            "-a",
             "--scheduler_args",
             type=str,
             help="Arguments to pass to the scheduler (Ex:`cluster=foo,user=bar`)."

--- a/torchx/cli/main.py
+++ b/torchx/cli/main.py
@@ -7,16 +7,18 @@
 import logging
 import sys
 from argparse import ArgumentParser
-from typing import List, Dict
+from typing import Dict, List
 
 from torchx.cli.cmd_base import SubCommand
+from torchx.cli.cmd_configure import CmdConfigure
 from torchx.cli.cmd_describe import CmdDescribe
 from torchx.cli.cmd_log import CmdLog
 from torchx.cli.cmd_run import CmdBuiltins, CmdRun
 from torchx.cli.cmd_runopts import CmdRunopts
 from torchx.cli.cmd_status import CmdStatus
-from torchx.cli.colors import ORANGE, GRAY, ENDC
+from torchx.cli.colors import ENDC, GRAY, ORANGE
 from torchx.util.entrypoints import load_group
+
 
 sub_parser_description = """Use the following commands to run operations, e.g.:
 torchx run ${JOB_NAME}
@@ -31,6 +33,7 @@ def get_default_sub_cmds() -> Dict[str, SubCommand]:
         "builtins": CmdBuiltins(),
         "runopts": CmdRunopts(),
         "status": CmdStatus(),
+        "configure": CmdConfigure(),
     }
 
 

--- a/torchx/cli/test/cmd_configure_test.py
+++ b/torchx/cli/test/cmd_configure_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import List
+
+from torchx.cli.cmd_configure import CmdConfigure
+
+
+class CmdConfigureTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parser = argparse.ArgumentParser()
+        self.cmd_configure = CmdConfigure()
+        self.cmd_configure.add_arguments(self.parser)
+
+        self.test_dir = tempfile.mkdtemp(prefix="torchx_cmd_configure_test")
+        self._old_cwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self) -> None:
+        os.chdir(self._old_cwd)
+        shutil.rmtree(self.test_dir)
+
+    def _args(self, sys_args: List[str]) -> argparse.Namespace:
+        return self.parser.parse_args(sys_args)
+
+    def test_configure_print(self) -> None:
+        # nothing to assert, just make sure the cmd runs
+        self.cmd_configure.run(self._args(["--print"]))
+        self.cmd_configure.run(self._args(["--print", "--all"]))
+
+    def test_configure(self) -> None:
+        os.chdir(self.test_dir)
+        self.cmd_configure.run(self._args([]))
+
+        self.assertTrue((Path(self.test_dir) / ".torchxconfig").exists())
+
+    def test_configure_all(self) -> None:
+        self.cmd_configure.run(self._args(["--all"]))
+        self.assertTrue((Path(self.test_dir) / ".torchxconfig").exists())
+
+    def test_configure_local_cwd(self) -> None:
+        self.cmd_configure.run(self._args(["--schedulers", "local_cwd"]))
+        self.assertTrue((Path(self.test_dir) / ".torchxconfig").exists())

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -13,6 +13,7 @@ from types import TracebackType
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 from pyre_extensions import none_throws
+from torchx.runner import config
 from torchx.runner.events import log_event
 from torchx.schedulers import get_schedulers
 from torchx.schedulers.api import Scheduler
@@ -259,9 +260,14 @@ class Runner:
                     f"Non-positive replicas for role: {role.name}."
                     f" Did you forget to set role.num_replicas?"
                 )
+
+        cfg = cfg or RunConfig()
+        # TODO enable profiles - https://github.com/pytorch/torchx/issues/248
+        config.apply(profile="default", scheduler=scheduler, runcfg=cfg)
+
         sched = self._scheduler(scheduler)
         sched._validate(app, scheduler)
-        dryrun_info = sched.submit_dryrun(app, cfg or RunConfig())
+        dryrun_info = sched.submit_dryrun(app, cfg)
         dryrun_info._scheduler = scheduler
         return dryrun_info
 

--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import configparser as configparser
+import logging
+from pathlib import Path
+from typing import List, Optional, TextIO
+
+from torchx.schedulers import Scheduler, get_schedulers
+from torchx.specs import RunConfig, get_type_name
+
+
+_NONE = "None"
+
+log: logging.Logger = logging.getLogger(__name__)
+
+
+def _configparser() -> configparser.ConfigParser:
+    """
+    Sets up the configparser and returns it. The same config parser
+    should be used between dumps() and loads() methods for ser/de compatibility
+    """
+
+    config = configparser.ConfigParser()
+    # if optionxform is not overridden, configparser will by default lowercase
+    # the option keys because it is compatible with Windows INI files
+    # which are expected to be parsed case insensitive.
+    # override since torchx's runopts are case-sensitive
+    # see: https://stackoverflow.com/questions/19359556/configparser-reads-capital-keys-and-make-them-lower-case
+    # pyre-ignore[8]
+    config.optionxform = lambda option: option
+
+    return config
+
+
+def _get_scheduler(name: str) -> Scheduler:
+    schedulers = get_schedulers(session_name="_")
+    sched = schedulers.get(name)
+    if not sched:
+        raise ValueError(
+            f"`{name}` is not a registered scheduler. Valid scheduler names: {schedulers.keys()}"
+        )
+    return sched
+
+
+def dump(
+    f: TextIO, schedulers: Optional[List[str]] = None, required_only: bool = False
+) -> None:
+    """
+    Dumps a default INI-style config template containing the runopts for the
+    given scheduler names into ``f``. If no ``schedulers`` are specified
+    dumps all known registered schedulers.
+
+    Optional runopts are pre-filled  with their default values.
+    Required runopts are set with a ``<FIXME_...>`` placeholder.
+    Each scheduler's runopts are written in the section called
+    ``[default.scheduler_args.{scheduler_name}]`` (e.g. ``[default.scheduler_args.kubernetes]``)
+
+    To only dump required runopts pass ``required_only=True``.
+
+    Raises a ``ValueError`` if given a scheduler name that is not known
+    """
+
+    if schedulers:
+        scheds = schedulers
+    else:
+        scheds = get_schedulers(session_name="_").keys()
+
+    config = _configparser()
+    for sched_name in scheds:
+        sched = _get_scheduler(sched_name)
+
+        section = f"default.scheduler_args.{sched_name}"
+        config.add_section(section)
+
+        for opt_name, opt in sched.run_opts():
+            if opt.is_required:
+                val = f"<FIXME_WITH_A_{get_type_name(opt.opt_type)}_VALUE>"
+            else:  # not required runopts MUST have a default
+                if required_only:
+                    continue
+
+                # serialize list elements with `;` delimiter (consistent with torchx cli)
+                if opt.opt_type == List[str]:
+                    # deal with empty or None default lists
+                    if opt.default:
+                        # pyre-ignore[6] opt.default type checked already as List[str]
+                        val = ";".join(opt.default)
+                    else:
+                        val = _NONE
+                else:
+                    val = f"{opt.default}"
+
+            config.set(section, opt_name, val)
+
+    config.write(f, space_around_delimiters=True)
+
+
+def apply(profile: str, scheduler: str, runcfg: RunConfig) -> None:
+    """
+    Loads .torchxconfig files from predefined locations according
+    to a load hierarchy and applies the loaded configs into the
+    given ``runcfg``. The load hierarchy is as follows (in order of precedence):
+
+    #. ``runcfg`` given to this function
+    #. configs loaded from ``$HOME/.torchxconfig``
+    #. configs loaded from ``$CWD/.torchxconfig``
+
+    Note that load hierarchy does NOT overwrite, but rather adds.
+    That is, the configs already present in ``runcfg`` are not
+    overridden during the load.
+    """
+    lookup_dirs = [Path.home(), Path.cwd()]
+
+    for d in lookup_dirs:
+        configfile = d / ".torchxconfig"
+        if configfile.exists():
+            log.info(f"loading configs from {configfile}")
+            with open(str(configfile), "r") as f:
+                load(profile, scheduler, f, runcfg)
+
+
+def load(profile: str, scheduler: str, f: TextIO, runcfg: RunConfig) -> None:
+    """
+    loads the section ``[{profile}.scheduler_args.{scheduler}]`` from the given
+    configfile ``f`` (in .INI format) into the provided ``runcfg``, only adding
+    configs that are NOT currently in the given ``runcfg`` (e.g. does not
+    override existing values in ``runcfg``). If no section is found, does nothing.
+    """
+
+    config = _configparser()
+    config.read_file(f)
+
+    runopts = _get_scheduler(scheduler).run_opts()
+
+    section = f"{profile}.scheduler_args.{scheduler}"
+    if config.has_section(section):
+        for name, value in config.items(section):
+            if name in runcfg.cfgs:
+                # DO NOT OVERRIDE existing configs
+                continue
+
+            if value == _NONE:
+                # should map to None (not str 'None')
+                # this also handles empty or None lists
+                runcfg.set(name, None)
+            else:
+                runopt = runopts.get(name)
+
+                if runopt is None:
+                    log.warning(
+                        f"`{name} = {value}` was declared in the [{section}] section "
+                        f" of the config file but is not a runopt of `{scheduler}` scheduler."
+                        f" Remove the entry from the config file to no longer see this warning"
+                    )
+                else:
+                    if runopt.opt_type is bool:
+                        # need to handle bool specially since str -> bool is based on
+                        # str emptiness not value (e.g. bool("False") == True)
+                        runcfg.set(name, config.getboolean(section, name))
+                    elif runopt.opt_type is List[str]:
+                        runcfg.set(name, value.split(";"))
+                    else:
+                        # pyre-ignore[29]
+                        runcfg.set(name, runopt.opt_type(value))

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime
+from io import StringIO
+from pathlib import Path
+from typing import Iterable, List, Optional
+from unittest.mock import patch
+
+from torchx.runner.config import apply, dump, load
+from torchx.schedulers import Scheduler, get_schedulers
+from torchx.schedulers.api import DescribeAppResponse
+from torchx.specs import AppDef, AppDryRunInfo, RunConfig, runopts
+
+
+class TestScheduler(Scheduler):
+    def __init__(self) -> None:
+        super().__init__("_", "_")
+
+    def schedule(self, dryrun_info: AppDryRunInfo) -> str:
+        raise NotImplementedError()
+
+    def _submit_dryrun(self, app: AppDef, cfg: RunConfig) -> AppDryRunInfo:
+        raise NotImplementedError()
+
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        raise NotImplementedError()
+
+    def _cancel_existing(self, app_id: str) -> None:
+        raise NotImplementedError()
+
+    def log_iter(
+        self,
+        app_id: str,
+        role_name: str,
+        k: int = 0,
+        regex: Optional[str] = None,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+        should_tail: bool = False,
+    ) -> Iterable[str]:
+        raise NotImplementedError()
+
+    def run_opts(self) -> runopts:
+        opts = runopts()
+        opts.add(
+            "i",
+            type_=int,
+            default=1,
+            help="an int option",
+        )
+        opts.add(
+            "f",
+            type_=float,
+            default=1.2,
+            help="a float option",
+        )
+        opts.add(
+            "s",
+            type_=str,
+            default="foobar",
+            help="an str option",
+        )
+        opts.add(
+            "bTrue",
+            type_=bool,
+            default=True,
+            help="an bool_true option",
+        )
+        opts.add(
+            "bFalse",
+            type_=bool,
+            default=False,
+            help="an bool_false option",
+        )
+        opts.add(
+            "l",
+            type_=List[str],
+            default=["a", "b", "c"],
+            help="a list option",
+        )
+        opts.add(
+            "l_none",
+            type_=List[str],
+            default=None,
+            help="a None list option",
+        )
+        opts.add(
+            "empty",
+            type_=str,
+            default=None,
+            help="an empty option",
+        )
+        return opts
+
+
+_CONFIG = """[default.scheduler_args.local_cwd]
+log_dir = /home/bob/logs
+prepend_cwd = True
+
+[test.scheduler_args.local_cwd]
+log_dir = None
+prepend_cwd = False
+
+[alpha.scheduler_args.local_cwd]
+log_dir = /tmp/logs
+"""
+
+_CONFIG_INVALID = """[default.scheduler_args.test]
+a_run_opt_that = does_not_exist
+s = option_that_exists
+"""
+
+_TEAM_CONFIG = """[default.scheduler_args.test]
+s = team_default
+i = 50
+f = 1.2
+"""
+
+_MY_CONFIG = """[default.scheduler_args.test]
+s = my_default
+i = 100
+"""
+
+PATH_HOME = "torchx.runner.config.Path.home"
+PATH_CWD = "torchx.runner.config.Path.cwd"
+TORCHX_GET_SCHEDULERS = "torchx.runner.config.get_schedulers"
+
+
+class ConfigTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = tempfile.mkdtemp(prefix="torchx_runner_config_test")
+        self._write(
+            ".torchxconfig",
+            _TEAM_CONFIG,
+        )
+        self._write(
+            os.path.join("home", "bob", ".torchxconfig"),
+            _MY_CONFIG,
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def _write(self, filename: str, content: str) -> Path:
+        f = Path(self.test_dir) / filename
+        f.parent.mkdir(parents=True, exist_ok=True)
+        with open(f, "w") as fp:
+            fp.write(content)
+        return f
+
+    def test_load(self) -> None:
+        runcfg = RunConfig()
+        load(
+            profile="default", scheduler="local_cwd", f=StringIO(_CONFIG), runcfg=runcfg
+        )
+        self.assertEqual("/home/bob/logs", runcfg.get("log_dir"))
+        self.assertEqual(True, runcfg.get("prepend_cwd"))
+
+        runcfg = RunConfig()
+        load(profile="test", scheduler="local_cwd", f=StringIO(_CONFIG), runcfg=runcfg)
+        self.assertEqual(None, runcfg.get("log_dir"))
+        self.assertEqual(False, runcfg.get("prepend_cwd"))
+
+        runcfg = RunConfig()
+        load(profile="alpha", scheduler="local_cwd", f=StringIO(_CONFIG), runcfg=runcfg)
+        self.assertEqual("/tmp/logs", runcfg.get("log_dir"))
+        self.assertEqual(None, runcfg.get("prepend_cwd"))
+
+    def test_no_override_load(self) -> None:
+        runcfg = RunConfig()
+        runcfg.set("log_dir", "/foo/bar")
+        runcfg.set("debug", 1)
+
+        load(profile="test", scheduler="local_cwd", f=StringIO(_CONFIG), runcfg=runcfg)
+        self.assertEqual("/foo/bar", runcfg.get("log_dir"))
+        self.assertEqual(1, runcfg.get("debug"))
+        self.assertEqual(False, runcfg.get("prepend_cwd"))
+
+    @patch(
+        TORCHX_GET_SCHEDULERS,
+        return_value={"test": TestScheduler()},
+    )
+    def test_apply(self, _) -> None:
+        with patch(PATH_CWD, return_value=Path(self.test_dir)):
+            with patch(PATH_HOME, return_value=Path(self.test_dir) / "home" / "bob"):
+                runcfg = RunConfig()
+                runcfg.set("s", "runtime_value")
+
+                apply(profile="default", scheduler="test", runcfg=runcfg)
+
+                self.assertEqual("runtime_value", runcfg.get("s"))
+                self.assertEqual(100, runcfg.get("i"))
+                self.assertEqual(1.2, runcfg.get("f"))
+
+    def test_dump_invalid_scheduler(self) -> None:
+        with self.assertRaises(ValueError):
+            dump(f=StringIO(), schedulers=["does-not-exist"])
+
+    @patch(
+        TORCHX_GET_SCHEDULERS,
+        return_value={"test": TestScheduler()},
+    )
+    def test_dump_only_required(self, _) -> None:
+        sfile = StringIO()
+
+        # test scheduler has no required options hence expect empty string
+        dump(f=sfile, required_only=True)
+
+        runcfg = RunConfig()
+        sfile.seek(0)
+        load(profile="default", scheduler="test", f=sfile, runcfg=runcfg)
+
+        self.assertFalse(runcfg.cfgs)
+
+    @patch(
+        TORCHX_GET_SCHEDULERS,
+        return_value={"test": TestScheduler()},
+    )
+    def test_load_invalid_runopt(self, _) -> None:
+        runcfg = RunConfig()
+        load(
+            profile="default",
+            scheduler="test",
+            f=StringIO(_CONFIG_INVALID),
+            runcfg=runcfg,
+        )
+        # options in the config file but not in runopts
+        # should be ignored (we shouldn't throw an error since
+        # this makes things super hard to guarantee BC - stale config file will fail
+        # to run, we don't want that)
+
+        self.assertEquals("option_that_exists", runcfg.get("s"))
+
+    def test_load_no_section(self) -> None:
+        runcfg = RunConfig()
+        load(
+            profile="default",
+            scheduler="local_cwd",
+            f=StringIO(),
+            runcfg=runcfg,
+        )
+        # is empty
+        self.assertFalse(runcfg.cfgs)
+
+        load(
+            profile="default",
+            scheduler="local_cwd",
+            f=StringIO("[default.scheduler_args.local_cwd]\n"),
+            runcfg=runcfg,
+        )
+        # still empty
+        self.assertFalse(runcfg.cfgs)
+
+    @patch(
+        TORCHX_GET_SCHEDULERS,
+        return_value={"test": TestScheduler()},
+    )
+    def test_dump_and_load_all_runopt_types(self, _) -> None:
+        sfile = StringIO()
+        dump(sfile)
+
+        sfile.seek(0)
+
+        runcfg = RunConfig()
+        load(profile="default", scheduler="test", f=sfile, runcfg=runcfg)
+
+        # all runopts in the TestScheduler have defaults, just check against those
+        for opt_name, opt in TestScheduler().run_opts():
+            self.assertEqual(runcfg.get(opt_name), opt.default)
+
+    def test_dump_and_load_all_registered_schedulers(self) -> None:
+        # dump all the runopts for all registered schedulers
+        # load them back as RunConfig()
+        # checks that all scheduler run options are accounted for
+
+        sfile = StringIO()
+        dump(sfile)
+
+        for sched_name, sched in get_schedulers(session_name="_").items():
+            sfile.seek(0)  # reset the file pos
+            runcfg = RunConfig()
+            load(profile="default", scheduler=sched_name, f=sfile, runcfg=runcfg)
+
+            for opt_name, _ in sched.run_opts():
+                self.assertTrue(opt_name in runcfg.cfgs)

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# TODO(aivanou): Update documentation
 import argparse
 import copy
 import inspect
@@ -18,6 +17,7 @@ from typing import (
     Callable,
     Dict,
     Generic,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -556,6 +556,9 @@ class runopts:
     def __init__(self) -> None:
         self._opts: Dict[str, Runopt] = {}
 
+    def __iter__(self) -> Iterator[Tuple[str, Runopt]]:
+        return self._opts.items().__iter__()
+
     @staticmethod
     def is_type(obj: ConfigValue, tp: Type[ConfigValue]) -> bool:
         """
@@ -572,7 +575,7 @@ class runopts:
 
     def get(self, name: str) -> Optional[Runopt]:
         """
-        Returns option if any was registerred, or None otherwise
+        Returns option if any was registered, or None otherwise
         """
         return self._opts.get(name, None)
 

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -353,6 +353,11 @@ class RunConfigTest(unittest.TestCase):
         self.assertTrue(runopts.is_type([], List[str]))
         self.assertTrue(runopts.is_type(["a", "b"], List[str]))
 
+    def test_runopts_iter(self) -> None:
+        runopts = self.get_runopts()
+        for name, opt in runopts:
+            self.assertEqual(opt, runopts.get(name))
+
 
 class GetTypeNameTest(unittest.TestCase):
     def test_get_type_name(self) -> None:


### PR DESCRIPTION
Summary:
Implements `dumps` and `loads` functions that dumps and loads INI file containing the runopts for all registered schedulers.

Here's a sample config file dumped by calling `torchx.runner.config.dumps(std.out)`

```
[default.local]
log_dir = None
prepend_cwd = False
image_type = dir
root_dir = /var/cache/fbpkg

[default.local_cwd]
log_dir = None
prepend_cwd = False

[default.local_par]
log_dir = None
prepend_cwd = False

[default.local_fbpkg]
log_dir = None
prepend_cwd = False

[default.mast]
hpcClusterUuid = TSCTestCluster
hpcEntitlementName = None
runningTimeoutSec = None
hpcIdentity = <FIXME_WITH_A_str_VALUE>
hpcJobOncall = pyper_training
useStrictName = False
mounts = None
localityConstraints = None
enableGracefulPreemption = False

[default.flow]
secure_group = <FIXME_WITH_A_str_VALUE>
entitlement = default
proxy_workflow_image = None

[default.quickflow]
entitlement = default
runningTimeoutSec = None
identity = <FIXME_WITH_A_str_VALUE>
oncall = None
useStrictName = False
mounts = None
localityConstraints = None
enableGracefulPreemption = False
perpetualRun = False

[default.slurm]
partition = None
time = None

[default.kubernetes]
namespace = default
queue = <FIXME_WITH_A_str_VALUE>
```

Added a `//torchx/fb/example/.torchxconfig` .

Next steps: document all this (will do this in a separate diff since its somewhat urgent we ship the functionality first)

Differential Revision: D31601700

