### PR TITLE
Make docstring optional

### DIFF
--- a/docs/source/component_best_practices.rst
+++ b/docs/source/component_best_practices.rst
@@ -74,6 +74,14 @@ others to understand how to use it.
         return AppDef(roles=[Role(..., num_replicas=num_replicas)])
 
 
+Documentation
+^^^^^^^^^^^^^^^^^^^^^
+
+The documentation is optional, but it is the best practice to keep component functions documented,
+especially if you want to share your components. See :ref:Component Authoring<components/overview:Authoring>
+for more details.
+
+
 Named Resources
 -----------------
 


### PR DESCRIPTION
Summary:
The diff makes the docstring optional when defining the component function.
Use argparse formatter that also prints default values

Differential Revision: D31671125

