### PR TITLE
(torchx/config) remove profiles from .torchxconfig, remove hierarchical loading, and move config loading to cli from runner

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -13,7 +13,6 @@ from types import TracebackType
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 from pyre_extensions import none_throws
-from torchx.runner import config
 from torchx.runner.events import log_event
 from torchx.schedulers import get_schedulers
 from torchx.schedulers.api import Scheduler
@@ -262,9 +261,6 @@ class Runner:
                 )
 
         cfg = cfg or RunConfig()
-        # TODO enable profiles - https://github.com/pytorch/torchx/issues/248
-        config.apply(scheduler=scheduler, cfg=cfg, profile="default")
-
         sched = self._scheduler(scheduler)
         sched._validate(app, scheduler)
         dryrun_info = sched.submit_dryrun(app, cfg)

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -102,35 +102,27 @@ class TestScheduler(Scheduler):
         return opts
 
 
-_CONFIG = """[default.local_cwd.cfg]
+_CONFIG = """[local_cwd]
 log_dir = /home/bob/logs
 prepend_cwd = True
-
-[test.local_cwd.cfg]
-log_dir = None
-prepend_cwd = False
-
-[alpha.local_cwd.cfg]
-log_dir = /tmp/logs
 """
 
-_CONFIG_INVALID = """[default.test.cfg]
+_CONFIG_INVALID = """[test]
 a_run_opt_that = does_not_exist
 s = option_that_exists
 """
 
-_TEAM_CONFIG = """[default.test.cfg]
+_TEAM_CONFIG = """[test]
 s = team_default
 i = 50
 f = 1.2
 """
 
-_MY_CONFIG = """[default.test.cfg]
+_MY_CONFIG = """[test]
 s = my_default
 i = 100
 """
 
-PATH_HOME = "torchx.runner.config.Path.home"
 PATH_CWD = "torchx.runner.config.Path.cwd"
 TORCHX_GET_SCHEDULERS = "torchx.runner.config.get_schedulers"
 
@@ -159,45 +151,50 @@ class ConfigTest(unittest.TestCase):
 
     def test_load(self) -> None:
         cfg = RunConfig()
-        load(profile="default", scheduler="local_cwd", f=StringIO(_CONFIG), cfg=cfg)
+        load(scheduler="local_cwd", f=StringIO(_CONFIG), cfg=cfg)
         self.assertEqual("/home/bob/logs", cfg.get("log_dir"))
         self.assertEqual(True, cfg.get("prepend_cwd"))
-
-        cfg = RunConfig()
-        load(profile="test", scheduler="local_cwd", f=StringIO(_CONFIG), cfg=cfg)
-        self.assertEqual(None, cfg.get("log_dir"))
-        self.assertEqual(False, cfg.get("prepend_cwd"))
-
-        cfg = RunConfig()
-        load(profile="alpha", scheduler="local_cwd", f=StringIO(_CONFIG), cfg=cfg)
-        self.assertEqual("/tmp/logs", cfg.get("log_dir"))
-        self.assertEqual(None, cfg.get("prepend_cwd"))
 
     def test_no_override_load(self) -> None:
         cfg = RunConfig()
         cfg.set("log_dir", "/foo/bar")
         cfg.set("debug", 1)
 
-        load(profile="test", scheduler="local_cwd", f=StringIO(_CONFIG), cfg=cfg)
+        load(scheduler="local_cwd", f=StringIO(_CONFIG), cfg=cfg)
         self.assertEqual("/foo/bar", cfg.get("log_dir"))
         self.assertEqual(1, cfg.get("debug"))
-        self.assertEqual(False, cfg.get("prepend_cwd"))
+        self.assertEqual(True, cfg.get("prepend_cwd"))
 
     @patch(
         TORCHX_GET_SCHEDULERS,
         return_value={"test": TestScheduler()},
     )
-    def test_apply(self, _) -> None:
+    def test_apply_default(self, _) -> None:
         with patch(PATH_CWD, return_value=Path(self.test_dir)):
-            with patch(PATH_HOME, return_value=Path(self.test_dir) / "home" / "bob"):
-                cfg = RunConfig()
-                cfg.set("s", "runtime_value")
+            cfg = RunConfig()
+            cfg.set("s", "runtime_value")
 
-                apply(profile="default", scheduler="test", cfg=cfg)
+            apply(scheduler="test", cfg=cfg)
 
-                self.assertEqual("runtime_value", cfg.get("s"))
-                self.assertEqual(100, cfg.get("i"))
-                self.assertEqual(1.2, cfg.get("f"))
+            self.assertEqual("runtime_value", cfg.get("s"))
+            self.assertEqual(50, cfg.get("i"))
+            self.assertEqual(1.2, cfg.get("f"))
+
+    @patch(
+        TORCHX_GET_SCHEDULERS,
+        return_value={"test": TestScheduler()},
+    )
+    def test_apply_dirs(self, _) -> None:
+        cfg = RunConfig()
+        cfg.set("s", "runtime_value")
+        apply(
+            scheduler="test",
+            cfg=cfg,
+            dirs=[str(Path(self.test_dir) / "home" / "bob"), self.test_dir],
+        )
+        self.assertEqual("runtime_value", cfg.get("s"))
+        self.assertEqual(100, cfg.get("i"))
+        self.assertEqual(1.2, cfg.get("f"))
 
     def test_dump_invalid_scheduler(self) -> None:
         with self.assertRaises(ValueError):
@@ -215,7 +212,7 @@ class ConfigTest(unittest.TestCase):
 
         cfg = RunConfig()
         sfile.seek(0)
-        load(profile="default", scheduler="test", f=sfile, cfg=cfg)
+        load(scheduler="test", f=sfile, cfg=cfg)
 
         self.assertFalse(cfg.cfgs)
 
@@ -226,7 +223,6 @@ class ConfigTest(unittest.TestCase):
     def test_load_invalid_runopt(self, _) -> None:
         cfg = RunConfig()
         load(
-            profile="default",
             scheduler="test",
             f=StringIO(_CONFIG_INVALID),
             cfg=cfg,
@@ -241,7 +237,6 @@ class ConfigTest(unittest.TestCase):
     def test_load_no_section(self) -> None:
         cfg = RunConfig()
         load(
-            profile="default",
             scheduler="local_cwd",
             f=StringIO(),
             cfg=cfg,
@@ -250,9 +245,8 @@ class ConfigTest(unittest.TestCase):
         self.assertFalse(cfg.cfgs)
 
         load(
-            profile="default",
             scheduler="local_cwd",
-            f=StringIO("[default.scheduler_args.local_cwd]\n"),
+            f=StringIO("[scheduler_args.local_cwd]\n"),
             cfg=cfg,
         )
         # still empty
@@ -269,7 +263,7 @@ class ConfigTest(unittest.TestCase):
         sfile.seek(0)
 
         cfg = RunConfig()
-        load(profile="default", scheduler="test", f=sfile, cfg=cfg)
+        load(scheduler="test", f=sfile, cfg=cfg)
 
         # all runopts in the TestScheduler have defaults, just check against those
         for opt_name, opt in TestScheduler().run_opts():
@@ -282,11 +276,11 @@ class ConfigTest(unittest.TestCase):
 
         sfile = StringIO()
         dump(sfile)
-        print(sfile.getvalue())
+
         for sched_name, sched in get_schedulers(session_name="_").items():
             sfile.seek(0)  # reset the file pos
             cfg = RunConfig()
-            load(profile="default", scheduler=sched_name, f=sfile, cfg=cfg)
+            load(scheduler=sched_name, f=sfile, cfg=cfg)
 
             for opt_name, _ in sched.run_opts():
                 self.assertTrue(opt_name in cfg.cfgs)


### PR DESCRIPTION
Summary:
1. Removes profiles from .torchxconfig (also removes .cfg suffix from section)
2. Removes hierarchical loading (only picks up .torchxconfig from CWD - project dir)
3. Removes config application from runner and moves it to CLI only

Differential Revision: D31674537

