### PR TITLE
Add NotFoundRunoptException

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -25,7 +25,6 @@ from torchx.specs.finder import (
 )
 from torchx.util.types import to_dict
 
-
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -137,7 +136,18 @@ class CmdRun(SubCommand):
             )
         except (ComponentValidationException, ComponentNotFoundException) as e:
             error_msg = f"\nFailed to run component `{conf_file}` got errors: \n {e}"
-            print(error_msg)
+            logger.error(error_msg)
+            sys.exit(1)
+            return
+        except specs.InvalidRunConfigException as e:
+            error_msg = (
+                f"Scheduler arg is incorrect or missing required option: `{e.cfg_key}`\n"
+                f"Run `torchx runopts` to check configuration for `{args.scheduler}` scheduler\n"
+                f"Use `-cfg` to specify run cfg as `key1=value1,key2=value2` pair\n"
+                "of setup `.torchxconfig` file, see: https://pytorch.org/torchx/main/experimental/runner.config.html"
+            )
+            logger.error(error_msg)
+            sys.exit(1)
             return
 
         if args.dryrun:

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -30,8 +30,8 @@ import yaml
 from torchx.specs.file_linter import TorchXArgumentHelpFormatter, get_fn_docstring
 from torchx.util.types import decode_from_string, decode_optional, is_bool, is_primitive
 
-
 SchedulerBackend = str
+
 
 # ========================================
 # ==== Distributed AppDef API =======
@@ -622,6 +622,7 @@ class runopts:
             if runopt.is_required and val is None:
                 raise InvalidRunConfigException(
                     f"Required run option: {cfg_key}, must be provided and not `None`",
+                    cfg_key,
                     config,
                 )
 
@@ -630,6 +631,7 @@ class runopts:
                 raise InvalidRunConfigException(
                     f"Run option: {cfg_key}, must be of type: {get_type_name(runopt.opt_type)},"
                     f" but was: {val} ({type(val).__name__})",
+                    cfg_key,
                     config,
                 )
 
@@ -674,9 +676,10 @@ class InvalidRunConfigException(Exception):
     type mismatch.
     """
 
-    def __init__(self, invalid_reason: str, cfg: RunConfig) -> None:
+    def __init__(self, invalid_reason: str, cfg_key: str, cfg: RunConfig) -> None:
         given = str(cfg) if cfg.cfgs else "<EMPTY>"
         super().__init__(f"{invalid_reason}. Given: {given}")
+        self.cfg_key = cfg_key
 
 
 class MalformedAppHandleException(Exception):


### PR DESCRIPTION
Summary: Add high-level message when running `torchx run` without `-cfg`

Differential Revision: D31736580

