### PR TITLE
Add missing `AWS_ROLE_ARN` env variable to the integ tests workflows

### DIFF
--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -35,12 +35,16 @@ jobs:
             curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
           fi
       - name: Configure Kube Config
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           set -eux
           if [ -n "$AWS_ROLE_ARN" ]; then
             aws eks update-kubeconfig --region=us-west-2 --name=${{ secrets.EKS_CLUSTER_NAME }}
           fi
       - name: Configure Docker
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           set -eux
           if [ -n "$AWS_ROLE_ARN" ]; then

--- a/.github/workflows/kfp-integration-tests.yaml
+++ b/.github/workflows/kfp-integration-tests.yaml
@@ -36,6 +36,8 @@ jobs:
             curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
           fi
       - name: Configure Kube Config
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           set -eux
           if [ -n "$AWS_ROLE_ARN" ]; then
@@ -49,6 +51,8 @@ jobs:
       - name: Checkout TorchX
         uses: actions/checkout@v2
       - name: Configure Docker
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           set -eux
           if [ -n "$AWS_ROLE_ARN" ]; then

--- a/.github/workflows/kubernetes-dist-train-integration-tests.yaml
+++ b/.github/workflows/kubernetes-dist-train-integration-tests.yaml
@@ -35,12 +35,16 @@ jobs:
             curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
           fi
       - name: Configure Kube Config
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           set -eux
           if [ -n "$AWS_ROLE_ARN" ]; then
             aws eks update-kubeconfig --region=us-west-2 --name=${{ secrets.EKS_CLUSTER_NAME }}
           fi
       - name: Configure Docker
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           set -eux
           if [ -n "$AWS_ROLE_ARN" ]; then
@@ -54,6 +58,7 @@ jobs:
         env:
           INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
           CONTAINER_REPO: ${{ secrets.CONTAINER_REPO }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           if [ -z "$AWS_ROLE_ARN" ]; then
             # only dryrun if no secrets


### PR DESCRIPTION
Summary: Add missing `AWS_ROLE_ARN` env variable to the integ tests workflows

Differential Revision: D31739619

