### PR TITLE
Correct kubernetes docs + other changes

### DIFF
--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -38,8 +38,6 @@ Try launching a single node, multiple trainers example on your desktop:
 
 .. code:: bash
 
-    cd torchx
-
     torchx run -s local_cwd \
 ./torchx/examples/apps/lightning_classy_vision/component.py:trainer_dist --skip-export\
 --nnodes 1 --nproc_per_node 2
@@ -81,7 +79,17 @@ It is simple to launch multiple nodes trainer in kubernetes:
 ./torchx/examples/apps/lightning_classy_vision/component.py:trainer_dist --skip-export\
 --nnodes 2 --nproc_per_node 2
 
+The command above will launch distributed train job on kubernetes `default` namespace using volcano
+`default` queue. It will use etcd service accessible on `etcd-server:2379` to perform
+`etcd rendezvous <https://pytorch.org/docs/stable/elastic/rendezvous.html>`_.
 
+You can overwrite rendezvous endpoint:
+
+.. code:: bash
+
+    torchx run -s kubernetes --scheduler_args namespace=default,queue=default\
+./torchx/examples/apps/lightning_classy_vision/component.py:trainer_dist --skip-export\
+--nnodes 2 --nproc_per_node 2 --rdzv_endpoint etcd-server.default.svc.cluster.local:2379
 
 Builtin distributed components
 ---------------------------------

--- a/torchx/components/train.py
+++ b/torchx/components/train.py
@@ -10,18 +10,19 @@ code. As such, we don't provide an out of the box training loop app. We do
 however have examples for how you can construct your training app as well as
 generic components you can use to run your custom training app.
 
+
+.. note::
+
+    Follow :ref:`examples_apps/lightning_classy_vision/component:Prerequisites of running examples`
+    before running the examples
+
+
 Check out the code for :ref:`examples_apps/lightning_classy_vision/train:Trainer App Example`.
 You can try it out by running a single trainer example on your desktop:
-
-.. note:
-
-    Follow :ref:`examples_apps/lightning_classy_vision/component:Prerequisites of running examples` to
-    before running the examples
 
 
 .. code:: bash
 
-    cd ~/torchx
     python torchx/examples/apps/lightning_classy_vision/train.py --skip_export
 
 
@@ -37,8 +38,6 @@ Try it out yourself:
 
 .. code:: bash
 
-    cd torchx
-
     torchx run -s local_cwd \
 ./torchx/examples/apps/lightning_classy_vision/component.py:trainer --skip-export
 
@@ -48,14 +47,13 @@ If you have docker installed on your laptop you can running the same single trai
 
 .. code:: bash
 
-    cd torchx
-
     torchx run -s local_docker \
 ./torchx/examples/apps/lightning_classy_vision/component.py:trainer --skip-export
 
 
-You can learn more about authoring your own components.
+You can learn more about authoring your own components: :py:mod:`torchx.components`
 
-Torchx has great support for simplifying execution of distributed jobs, that you can learn more here.
+Torchx has great support for simplifying execution of distributed jobs, that you can learn more
+:py:mod:`torchx.components.dist`
 
 """

--- a/torchx/examples/apps/lightning_classy_vision/component.py
+++ b/torchx/examples/apps/lightning_classy_vision/component.py
@@ -56,7 +56,7 @@ from torchx.version import TORCHX_IMAGE
 
 
 def trainer(
-    output_path: str,
+    output_path: Optional[str] = None,
     image: str = TORCHX_IMAGE,
     data_path: Optional[str] = None,
     load_path: str = "",
@@ -90,8 +90,6 @@ def trainer(
     args = [
         "-m",
         "torchx.examples.apps.lightning_classy_vision.train",
-        "--output_path",
-        output_path,
         "--load_path",
         load_path,
         "--log_path",
@@ -99,6 +97,8 @@ def trainer(
         "--epochs",
         str(epochs),
     ]
+    if output_path:
+        args += ["--output_path", output_path]
     if layers:
         args += ["--layers"] + [str(layer) for layer in layers]
     if learning_rate:
@@ -133,7 +133,7 @@ def trainer(
 
 
 def trainer_dist(
-    output_path: str,
+    output_path: Optional[str] = None,
     image: str = TORCHX_IMAGE,
     data_path: Optional[str] = None,
     load_path: str = "",
@@ -186,8 +186,6 @@ def trainer_dist(
         str(nproc_per_node),
         "-m",
         "torchx.examples.apps.lightning_classy_vision.train",
-        "--output_path",
-        output_path,
         "--load_path",
         load_path,
         "--log_path",
@@ -195,6 +193,8 @@ def trainer_dist(
         "--epochs",
         str(epochs),
     ]
+    if output_path:
+        args += ["--output_path", output_path]
     if data_path:
         args += ["--data_path", data_path]
     if skip_export:

--- a/torchx/examples/apps/lightning_classy_vision/train.py
+++ b/torchx/examples/apps/lightning_classy_vision/train.py
@@ -150,7 +150,7 @@ def main(argv: List[str]) -> None:
             f"train acc: {model.train_acc.compute()}, val acc: {model.val_acc.compute()}"
         )
 
-        if not args.skip_export:
+        if not args.skip_export and args.output_path:
             # Export the inference model
             export_inference_model(model, args.output_path, tmpdir)
 

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -15,13 +15,16 @@ Install volcano 1.4.0 version
 
     kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.4.0/installer/volcano-development.yaml
 
-Install etcd server on your kubernetes cluster:
+Torchx uses `torch.distributed.run <https://pytorch.org/docs/stable/elastic/run.html>`_ to run distributed training.
+This requires the installation of etcd service on your kubernetes cluster:
 
 .. code:: bash
 
     kubectl apply -f https://github.com/pytorch/torchx/blob/main/resources/etcd.yaml
 
-Install `python etcd library <https://pypi.org/project/python-etcd/>`_
+
+
+Learn more about running distributed trainers :py:mod:`torchx.components.dist`
 
 """
 


### PR DESCRIPTION
Summary:
* Correct kubernetes docs
* Make sure example components succeed if `output_path` is None
* Add proper links in `torch.components.distributed` page

Differential Revision: D31745235

