### PR TITLE
schedulers/local_scheduler: silence docker version output

### DIFF
--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -230,7 +230,14 @@ class DockerImageProvider(ImageProvider):
     @staticmethod
     def has_docker() -> bool:
         try:
-            return subprocess.run(["docker", "version"]).returncode == 0
+            return (
+                subprocess.run(
+                    ["docker", "version"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                ).returncode
+                == 0
+            )
         except FileNotFoundError:
             return False
 


### PR DESCRIPTION
<!-- Change Summary -->

https://github.com/pytorch/torchx/commit/88a3f41d3fab5eb22d10b00ac3546c37dd20dd8e accidentally added some extra log spam from `docker version` this hides it.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
tristanr@tristanr-arch2 ~/D/torchx (dockerquiet)> torchx run  utils.echo
0.1.0rc2: Pulling from pytorch/torchx
Digest: sha256:f97df7bd3d2137b3dcb6b85e14f4eef9c1c7cdd826d12508cc7cafb08bb2f704
Status: Image is up to date for ghcr.io/pytorch/torchx:0.1.0rc2
ghcr.io/pytorch/torchx:0.1.0rc2
local_docker://torchx/echo_484dcf48
torchx 2021-10-20 14:23:25 INFO     Waiting for the app to finish...
WARNING: IPv4 forwarding is disabled. Networking will not work.
hello world
torchx 2021-10-20 14:23:27 INFO     Job finished: SUCCEEDED
```
