### PR TITLE
Change `lightning-cv` example to make it work for gpu training

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ kfp==1.6.2
 pyre-extensions>=0.0.21
 black>=21.5b1
 usort==0.6.4
-pytorch-lightning>=0.5.3
+pytorch-lightning>=1.4.9
 torch>=1.9.0
 torchvision>=0.10.0
 classy-vision>=0.6.0

--- a/scripts/kube_dist_trainer.py
+++ b/scripts/kube_dist_trainer.py
@@ -33,7 +33,7 @@ def register_gpu_resource() -> None:
     res = Resource(
         cpu=2,
         gpu=1,
-        memMB=4 * GiB,
+        memMB=8 * GiB,
     )
     print(f"Registering resource: {res}")
     named_resources["GPU_X1"] = res


### PR DESCRIPTION
Summary:
Change `lightning-cv` example to make it work for gpu training
It seems there are bugs with `ddp2` running on GPUs, so changing accelerator to `ddp`

Reviewed By: d4l3k

Differential Revision: D31818113

