### PR TITLE
(torchx/docs) fix invalid references to docker when running with local_cwd in the components.dist docstring

### DIFF
--- a/torchx/components/train.py
+++ b/torchx/components/train.py
@@ -14,11 +14,7 @@ generic components you can use to run your custom training app.
 1. :ref:`examples_apps/lightning_classy_vision/train:Trainer App Example`
 2. :ref:`examples_apps/lightning_classy_vision/component:Trainer Component`
 3. :ref:`component_best_practices:Component Best Practices`
-
-
-You can learn more about authoring your own components: :py:mod:`torchx.components`
-
-Torchx has great support for simplifying execution of distributed jobs, that you can learn more
-:py:mod:`torchx.components.dist`
+4. See :py:mod:`torchx.components` to learn more about authoring components
+5. For more information on distributed training see :py:mod:`torchx.components.dist`.
 
 """


### PR DESCRIPTION
Summary:
Fixes incorrect docs that claim to run on docker containers when the command is `-s local_cwd` (see screenshot below)

{F672188530}

Differential Revision: D31828767

