### PR TITLE
(torchx-fb/scheduler) Add local_penv scheduler

### DIFF
--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -240,9 +240,9 @@ def apply(scheduler: str, cfg: RunConfig, dirs: Optional[List[str]] = None) -> N
     for d in dirs:
         configfile = Path(d) / ".torchxconfig"
         if configfile.exists():
-            log.info(f"loading configs from {configfile}")
             with open(str(configfile), "r") as f:
                 load(scheduler, f, cfg)
+                log.info(f"loaded configs from {configfile}")
 
 
 def load(scheduler: str, f: TextIO, cfg: RunConfig) -> None:

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -18,7 +18,7 @@ import unittest
 from contextlib import contextmanager
 from datetime import datetime
 from os.path import join
-from typing import Optional, Generator
+from typing import Generator, Optional
 from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
@@ -278,7 +278,7 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         )
 
     def tearDown(self) -> None:
-        shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.test_dir, ignore_errors=True)
 
     def test_submit(self) -> None:
         # make sure the macro substitution works


### PR DESCRIPTION
Summary:
Implement a `PenvImageProvider` that does what `CWDImageProvider` does except it additionally fetches the AppDef's image in the `fetch()` method (note it still returns CWD).

Register `local_penv` in entry_points.txt.

There are two additional things I'd like to do before landing this (publishing early for feedback):

1. If the image does not exist (no fbpkg), fall back to penv.par in buck-out with a warning.
2. ~~(maybe) make this the default scheduler for fb~~ (will do this separately)
3. add `fb.dist.ddp` builtin
4. delete local_scheduler base_logdir on exit
5. works with bento kernels (see test plan section)

Reviewed By: aivanou

Differential Revision: D31853855

