### PR TITLE
Do not delete `base_dir` for local scheduler

### DIFF
--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -11,7 +11,6 @@ import logging
 import os
 import pprint
 import re
-import shutil
 import signal
 import subprocess
 import sys
@@ -926,9 +925,6 @@ class LocalScheduler(Scheduler):
         for (app_id, app) in self._apps.items():
             log.debug(f"Terminating app: {app_id}")
             app.kill()
-        # delete logdir
-        if self._base_log_dir:
-            shutil.rmtree(self._base_log_dir, ignore_errors=True)
 
     def __del__(self) -> None:
         self.close()

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -318,6 +318,7 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         assert desc is not None
         self.assertEqual(f"{expected_app_id}", app_id)
         self.assertEqual(AppState.FAILED, desc.state)
+        self.assertTrue(os.path.exists(self.test_dir))
 
     def test_macros_env(self) -> None:
         # make sure the macro substitution works


### PR DESCRIPTION
Summary: Do not delete `base_dir` for local scheduler

Differential Revision: D31914905

