### PR TITLE
specs: support single dashes `-c` for single letter params

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -776,10 +776,12 @@ def _create_args_parser(app_fn: Callable[..., AppDef]) -> argparse.ArgumentParse
             arg_name = param_name
             remainder_arg = [arg_name, args]
         else:
-            arg_name = f"--{param_name}"
+            arg_names = [f"--{param_name}"]
+            if len(param_name) == 1:
+                arg_names = [f"-{param_name}"] + arg_names
             if "default" not in args:
                 args["required"] = True
-            script_parser.add_argument(arg_name, **args)
+            script_parser.add_argument(*arg_names, **args)
     if len(remainder_arg) > 0:
         script_parser.add_argument(remainder_arg[0], **remainder_arg[1])
     return script_parser

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -526,6 +526,15 @@ def _test_var_args_first(*args: str, bar: str = "asdf") -> AppDef:
     return AppDef(name="varargs")
 
 
+_TEST_SINGLE_LETTER: Optional[str] = None
+
+
+def _test_single_letter(c: str) -> AppDef:
+    global _TEST_SINGLE_LETTER
+    _TEST_SINGLE_LETTER = c
+    return AppDef(name="varargs")
+
+
 class AppDefLoadTest(unittest.TestCase):
     def assert_apps(self, expected_app: AppDef, actual_app: AppDef) -> None:
         self.assertDictEqual(asdict(expected_app), asdict(actual_app))
@@ -707,6 +716,31 @@ class AppDefLoadTest(unittest.TestCase):
         self.assertEqual(
             _TEST_VAR_ARGS_FIRST,
             (("fooval", "--foo", "barval", "arg1", "arg2"), "asdf"),
+        )
+
+    def test_single_letter(self) -> None:
+        from_function(
+            _test_single_letter,
+            [
+                "-c",
+                "arg1",
+            ],
+        )
+        self.assertEqual(
+            _TEST_SINGLE_LETTER,
+            "arg1",
+        )
+
+        from_function(
+            _test_single_letter,
+            [
+                "--c",
+                "arg2",
+            ],
+        )
+        self.assertEqual(
+            _TEST_SINGLE_LETTER,
+            "arg2",
         )
 
     # pyre-ignore[3]


### PR DESCRIPTION
<!-- Change Summary -->

This adds support for using just a single dash instead of multiple with single letter params. `-c` is now supported as well as the earlier `--c` which feels clunky for most unix style CLI commands.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
```
pytest torchx/specs/test/api_test.py
pyre
```
