### PR TITLE
Add `metadata` field to Role

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -200,7 +200,8 @@ class Role:
                     args = ["--arg", "foo", ENV_VAR="FOOBAR"],
                     num_replicas = 4,
                     resource = Resource(cpu=1, gpu=1, memMB=500),
-                    port_map={"tcp_store":8080, "tensorboard": 8081})
+                    port_map={"tcp_store":8080, "tensorboard": 8081},
+                    metadata={"local_cwd.property", value})
 
     Args:
             name: name of the role
@@ -216,6 +217,8 @@ class Role:
                 least ``resource`` guarantees.
             port_map: Port mapping for the role. The key is the unique identifier of the port
                 e.g. "tensorboard": 9090
+            metadata: Free form information that is associated with the role, for example
+                scheduler specific data. The key should follow the pattern: ``$scheduler.$key``
     """
 
     name: str
@@ -229,6 +232,7 @@ class Role:
     retry_policy: RetryPolicy = RetryPolicy.APPLICATION
     resource: Resource = NULL_RESOURCE
     port_map: Dict[str, int] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def pre_proc(
         self,

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -137,6 +137,7 @@ class RoleBuilderTest(unittest.TestCase):
         self.assertEqual(1, default.num_replicas)
         self.assertEqual(0, default.max_retries)
         self.assertEqual(RetryPolicy.APPLICATION, default.retry_policy)
+        self.assertEqual({}, default.metadata)
 
     def test_build_role(self) -> None:
         # runs: ENV_VAR_1=FOOBAR /bin/echo hello world
@@ -152,6 +153,7 @@ class RoleBuilderTest(unittest.TestCase):
             max_retries=5,
             resource=resource,
             port_map={"foo": 8080},
+            metadata={"foo": "bar"},
         )
 
         self.assertEqual("trainer", trainer.name)
@@ -159,6 +161,7 @@ class RoleBuilderTest(unittest.TestCase):
         self.assertEqual("/bin/echo", trainer.entrypoint)
         self.assertEqual({"ENV_VAR_1": "FOOBAR"}, trainer.env)
         self.assertEqual(["hello", "world"], trainer.args)
+        self.assertDictEqual({"foo": "bar"}, trainer.metadata)
         self.assertDictEqual({"foo": 8080}, trainer.port_map)
         self.assertEqual(resource, trainer.resource)
         self.assertEqual(2, trainer.num_replicas)


### PR DESCRIPTION
Summary:
The diff introduces `metadata` field for torchx.specs.api.Role. The metadata field is an arbitrary dict that contains role-specific data that can be interpreted by different schedulers.

Expected usage:

```
role = Role(metadata = {"kubernetest.field":  "foo"})
```

Differential Revision: D31944144

