### PR TITLE
(torchx/component) give dist.ddp a facelift, don't use torch_dist_role in dist.ddp

### DIFF
--- a/torchx/components/integration_tests/component_provider.py
+++ b/torchx/components/integration_tests/component_provider.py
@@ -37,13 +37,11 @@ class ComponentProvider(ABC):
 class DDPComponentProvider(ComponentProvider):
     def get_app_def(self) -> AppDef:
         args = ["torchx.components.integration_tests.test.dummy_app"]
-        rdzv_backend: str = "c10d"
         rdzv_endpoint: str = "localhost:29400"
         return dist_components.ddp(
             *args,
-            entrypoint="-m",
+            script="-m",
             image=self._image,
-            rdzv_backend=rdzv_backend,
             rdzv_endpoint=rdzv_endpoint,
         )
 

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -16,8 +16,8 @@ from pyre_extensions import none_throws
 from torchx.runner import Runner, get_runner
 from torchx.schedulers.api import DescribeAppResponse
 from torchx.schedulers.local_scheduler import (
-    LocalScheduler,
     LocalDirectoryImageProvider,
+    LocalScheduler,
 )
 from torchx.schedulers.test.test_util import write_shell_script
 from torchx.specs.api import (
@@ -29,6 +29,7 @@ from torchx.specs.api import (
     UnknownAppException,
 )
 from torchx.specs.finder import ComponentNotFoundException
+
 
 GET_SCHEDULERS = "torchx.runner.api.get_schedulers"
 
@@ -375,15 +376,15 @@ class RunnerTest(unittest.TestCase):
         local_sched_mock = MagicMock()
         schedulers = {"local_dir": local_sched_mock, "local": local_sched_mock}
         with Runner(name="test_session", schedulers=schedulers) as runner:
-            app_args = ["--image", "dummy_image", "--entrypoint", "test.py"]
+            app_args = ["--image", "dummy_image", "--script", "test.py"]
             with patch.object(runner, "run") as run_mock:
-                app_handle = runner.run_component("dist.ddp", app_args, "local")
+                _ = runner.run_component("dist.ddp", app_args, "local")
                 args, kwargs = run_mock.call_args
                 actual_app = args[0]
 
-            self.assertEqual(actual_app.name, "test-name")
+            self.assertEqual(actual_app.name, "test")
             self.assertEqual(1, len(actual_app.roles))
-            self.assertEqual("worker", actual_app.roles[0].name)
+            self.assertEqual("test", actual_app.roles[0].name)
 
     def test_run_from_file_no_function_found(self, _) -> None:
         local_sched_mock = MagicMock()

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -30,6 +30,7 @@ import yaml
 from torchx.specs.file_linter import TorchXArgumentHelpFormatter, get_fn_docstring
 from torchx.util.types import decode_from_string, decode_optional, is_bool, is_primitive
 
+
 SchedulerBackend = str
 
 
@@ -753,9 +754,21 @@ def _create_args_parser(app_fn: Callable[..., AppDef]) -> argparse.ArgumentParse
     parameters = inspect.signature(app_fn).parameters
     function_desc, args_desc = get_fn_docstring(app_fn)
     script_parser = argparse.ArgumentParser(
-        prog=f"torchx run <<torchx_params>> {app_fn.__name__} ",
+        prog=f"torchx run <run args...> {app_fn.__name__} ",
         description=function_desc,
         formatter_class=TorchXArgumentHelpFormatter,
+        # enables components to have "h" as a parameter
+        # otherwise argparse by default adds -h/--help as the help argument
+        # we still add --help but reserve "-"h" to be used as a component argument
+        add_help=False,
+    )
+
+    # add help manually since we disabled auto help to allow "h" in component arg
+    script_parser.add_argument(
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help="show this help message and exit",
     )
 
     remainder_arg = []


### PR DESCRIPTION
Summary: Remove usage of `torch_dist_role()` (deprecated) in dist.ddp builtin. Also makes params of dist.ddp much more user friendly with better defaults. Updates docs accordingly

Differential Revision: D31946148

