### PR TITLE
schedulers/docker_scheduler: uses docker python library + supports full TorchX spec

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,3 +17,4 @@ importlib-metadata
 ax-platform[mysql]>=0.2.2
 fsspec[s3]>=2021.09.0
 torch-model-archiver>=0.4.2
+filelock

--- a/docs/source/schedulers/local.rst
+++ b/docs/source/schedulers/local.rst
@@ -7,13 +7,18 @@ Local
 .. autoclass:: LocalScheduler
    :members:
 
+.. automodule:: torchx.schedulers.docker_scheduler
+.. currentmodule:: torchx.schedulers.docker_scheduler
+
+.. autoclass:: DockerScheduler
+   :members:
+
 Image Providers
 ~~~~~~~~~~~~~~~~~
 
-.. autoclass:: ImageProvider
-   :members:
+.. currentmodule:: torchx.schedulers.local_scheduler
 
-.. autoclass:: DockerImageProvider
+.. autoclass:: ImageProvider
    :members:
 
 .. autoclass:: CWDImageProvider

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyre-extensions
 docstring-parser==0.8.1
 pyyaml
+docker

--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -12,7 +12,6 @@ import sys
 import threading
 from queue import Queue
 from typing import Optional, List, Tuple
-from urllib.parse import urlparse
 
 from pyre_extensions import none_throws
 from torchx import specs
@@ -55,12 +54,11 @@ def print_log_lines(
 
 def get_logs(identifier: str, regex: Optional[str], should_tail: bool = False) -> None:
     validate(identifier)
-    url = urlparse(identifier)
-    scheduler_backend = url.scheme
-    session_name = url.netloc or "default"
+    scheduler_backend, _, path_str = identifier.partition("://")
 
     # path is of the form ["", "app_id", "master", "0"]
-    path = url.path.split("/")
+    path = path_str.split("/")
+    session_name = path[0] or "default"
     app_id = path[1]
     role_name = path[2] if len(path) > 2 else None
 

--- a/torchx/cli/test/cmd_log_test.py
+++ b/torchx/cli/test/cmd_log_test.py
@@ -72,7 +72,7 @@ class CmdLogTest(unittest.TestCase):
     ) -> None:
         with self.assertRaises(SentinelError):
             get_logs(
-                "local://default/SparseNNAppDef/unknown_role",
+                "local_docker://default/SparseNNAppDef/unknown_role",
                 regex=None,
             )
 
@@ -83,7 +83,7 @@ class CmdLogTest(unittest.TestCase):
     def test_cmd_log_all_roles(
         self, stdout_mock: MagicMock, mock_runner: MagicMock
     ) -> None:
-        get_logs("local://test-session/SparseNNAppDef", regex="INFO")
+        get_logs("local_docker://test-session/SparseNNAppDef", regex="INFO")
         self.assertSetEqual(
             {
                 f"{GREEN}master/0{ENDC} INFO foo",
@@ -102,7 +102,7 @@ class CmdLogTest(unittest.TestCase):
     def test_cmd_log_all_replicas(
         self, stdout_mock: MagicMock, mock_runner: MagicMock
     ) -> None:
-        get_logs("local://test-session/SparseNNAppDef/trainer", regex="INFO")
+        get_logs("local_docker://test-session/SparseNNAppDef/trainer", regex="INFO")
         self.assertSetEqual(
             {
                 f"{GREEN}trainer/0{ENDC} INFO foo",
@@ -120,7 +120,7 @@ class CmdLogTest(unittest.TestCase):
     def test_cmd_log_one_replica(
         self, stdout_mock: MagicMock, mock_runner: MagicMock
     ) -> None:
-        get_logs("local://test-session/SparseNNAppDef/trainer/0", regex=None)
+        get_logs("local_docker://test-session/SparseNNAppDef/trainer/0", regex=None)
         self.assertSetEqual(
             {
                 f"{GREEN}trainer/0{ENDC} INFO foo",
@@ -138,7 +138,7 @@ class CmdLogTest(unittest.TestCase):
     def test_cmd_log_some_replicas(
         self, stdout_mock: MagicMock, mock_runner: MagicMock
     ) -> None:
-        get_logs("local://test-session/SparseNNAppDef/trainer/0,2", regex="WARN")
+        get_logs("local_docker://test-session/SparseNNAppDef/trainer/0,2", regex="WARN")
         self.assertSetEqual(
             {
                 f"{GREEN}trainer/0{ENDC} WARN baz",
@@ -164,6 +164,7 @@ class CmdLogTest(unittest.TestCase):
         validate("kubernetes://session/queue:name-1234/role")
         validate("kubernetes://session/queue:name-1234/role/1")
         validate("kubernetes://session/queue:name-1234/role/1,2,3")
+        validate("two_part://session/queue:name-1234/role/1,2,3")
 
         with self.assertRaisesRegex(SystemExit, "1"):
             validate("kubernetes://session")

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -7,6 +7,7 @@
 
 from typing import Dict
 
+import torchx.schedulers.docker_scheduler as docker_scheduler
 import torchx.schedulers.kubernetes_scheduler as kubernetes_scheduler
 import torchx.schedulers.local_scheduler as local_scheduler
 import torchx.schedulers.slurm_scheduler as slurm_scheduler
@@ -29,7 +30,7 @@ def get_scheduler_factories() -> Dict[str, SchedulerFactory]:
     The first scheduler in the dictionary is used as the default scheduler.
     """
     default_schedulers: Dict[str, SchedulerFactory] = {
-        "local_docker": local_scheduler.create_docker_scheduler,
+        "local_docker": docker_scheduler.create_scheduler,
         "local_cwd": local_scheduler.create_cwd_scheduler,
         "slurm": slurm_scheduler.create_scheduler,
         "kubernetes": kubernetes_scheduler.create_scheduler,

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -1,0 +1,361 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os.path
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, List
+
+import torchx
+import yaml
+from torchx.schedulers.api import (
+    AppDryRunInfo,
+    DescribeAppResponse,
+    Scheduler,
+    filter_regex,
+)
+from torchx.schedulers.ids import make_unique
+from torchx.specs.api import (
+    AppDef,
+    AppState,
+    ReplicaStatus,
+    Role,
+    RoleStatus,
+    RunConfig,
+    SchedulerBackend,
+    macros,
+    runopts,
+    is_terminal,
+)
+
+if TYPE_CHECKING:
+    from docker import DockerClient
+    from docker.models.containers import Container
+
+log: logging.Logger = logging.getLogger(__name__)
+
+CONTAINER_STATE: Dict[str, AppState] = {
+    "created": AppState.SUBMITTED,
+    "restarting": AppState.PENDING,
+    "running": AppState.RUNNING,
+    "paused": AppState.PENDING,
+    "removing": AppState.PENDING,
+    "dead": AppState.FAILED,
+}
+
+
+@dataclass
+class DockerContainer:
+    image: str
+    command: List[str]
+    kwargs: Dict[str, object]
+
+
+@dataclass
+class DockerJob:
+    app_id: str
+    containers: List[DockerContainer]
+
+    def __str__(self) -> str:
+        return yaml.dump(self.containers)
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+LABEL_VERSION = "torchx.pytorch.org/version"
+LABEL_APP_ID = "torchx.pytorch.org/app-id"
+LABEL_ROLE_NAME = "torchx.pytorch.org/role-name"
+LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
+
+NETWORK = "torchx"
+
+
+def has_docker() -> bool:
+    try:
+        import docker
+
+        docker.from_env()
+        return True
+    except (ImportError, docker.errors.DockerException):
+        return False
+
+
+class DockerScheduler(Scheduler):
+    """
+    DockerScheduler is a TorchX scheduling interface to Docker.
+
+    This is exposed via the scheduler `local_docker`.
+
+    This scheduler runs the provided app via the local docker runtime using the
+    specified images in the AppDef. Docker must be installed and running.  This
+    provides the closest environment to schedulers that natively use Docker such
+    as Kubernetes.
+
+    .. note:: docker doesn't provide gang scheduling mechanisms. If one replica
+              in a job fails, only that replica will be restarted.
+
+    .. compatibility::
+        type: scheduler
+        features:
+            cancel: true
+            logs: true
+            distributed: true
+            describe: |
+                Partial support. DockerScheduler will return job and replica
+                status but does not provide the complete original AppSpec.
+    """
+
+    def __init__(self, session_name: str) -> None:
+        super().__init__("docker", session_name)
+
+        self.__client: Optional["DockerClient"] = None
+
+    def _client(self) -> "DockerClient":
+        if not self.__client:
+            import docker
+
+            self.__client = docker.from_env()
+
+        return self.__client
+
+    def _ensure_network(self) -> None:
+        import filelock
+        from docker.errors import APIError
+
+        client = self._client()
+        lock_path = os.path.join(tempfile.gettempdir(), "torchx_docker_network_lock")
+
+        # Docker networks.create check_duplicate has a race condition so we need
+        # to do client side locking to ensure only one network is created.
+        with filelock.FileLock(lock_path, timeout=10):
+            try:
+                client.networks.create(
+                    name=NETWORK, driver="bridge", check_duplicate=True
+                )
+            except APIError as e:
+                if "already exists" not in str(e):
+                    raise
+
+    def schedule(self, dryrun_info: AppDryRunInfo[DockerJob]) -> str:
+        client = self._client()
+
+        req = dryrun_info.request
+
+        images = set()
+        for container in req.containers:
+            images.add(container.image)
+        for image in images:
+            log.info(f"Pulling container image: {image} (this may take a while)")
+            try:
+                client.images.pull(image)
+            except Exception as e:
+                log.warning(f"failed to pull image {image}, falling back to local: {e}")
+
+        self._ensure_network()
+
+        for container in req.containers:
+            client.containers.run(
+                container.image,
+                container.command,
+                detach=True,
+                **container.kwargs,
+            )
+
+        return req.app_id
+
+    def _submit_dryrun(self, app: AppDef, cfg: RunConfig) -> AppDryRunInfo[DockerJob]:
+        from docker.types import DeviceRequest
+
+        app_id = make_unique(app.name)
+        req = DockerJob(app_id=app_id, containers=[])
+        for role in app.roles:
+            for replica_id in range(role.num_replicas):
+                values = macros.Values(
+                    img_root="",
+                    app_id=app_id,
+                    replica_id=str(replica_id),
+                )
+                replica_role = values.apply(role)
+                name = f"{app_id}-{role.name}-{replica_id}"
+                c = DockerContainer(
+                    image=replica_role.image,
+                    command=[replica_role.entrypoint] + replica_role.args,
+                    kwargs={
+                        "name": name,
+                        "environment": replica_role.env,
+                        "labels": {
+                            LABEL_VERSION: torchx.__version__,
+                            LABEL_APP_ID: app_id,
+                            LABEL_ROLE_NAME: role.name,
+                            LABEL_REPLICA_ID: str(replica_id),
+                        },
+                        "hostname": name,
+                        "network": NETWORK,
+                    },
+                )
+                if replica_role.max_retries > 0:
+                    c.kwargs["restart_policy"] = {
+                        "Name": "on-failure",
+                        "MaximumRetryCount": replica_role.max_retries,
+                    }
+                resource = replica_role.resource
+                if resource.memMB >= 0:
+                    c.kwargs["mem_limit"] = f"{int(resource.memMB)}m"
+                if resource.cpu >= 0:
+                    c.kwargs["nano_cpus"] = int(resource.cpu * 1e9)
+                if resource.gpu > 0:
+                    # `compute` means a CUDA or OpenCL capable device.
+                    # For more info:
+                    # * https://github.com/docker/docker-py/blob/master/docker/types/containers.py
+                    # * https://github.com/NVIDIA/nvidia-container-runtime
+                    c.kwargs["device_requests"] = [
+                        DeviceRequest(
+                            count=resource.gpu,
+                            capabilities=[["compute"]],
+                        )
+                    ]
+                req.containers.append(c)
+
+        info = AppDryRunInfo(req, repr)
+        info._app = app
+        info._cfg = cfg
+        return info
+
+    def _validate(self, app: AppDef, scheduler: SchedulerBackend) -> None:
+        # Skip validation step
+        pass
+
+    def _get_container(self, app_id: str, role: str, replica_id: int) -> "Container":
+        client = self._client()
+        containers = client.containers.list(
+            all=True,
+            filters={
+                "label": [
+                    f"{LABEL_APP_ID}={app_id}",
+                    f"{LABEL_ROLE_NAME}={role}",
+                    f"{LABEL_REPLICA_ID}={replica_id}",
+                ]
+            },
+        )
+        if len(containers) == 0:
+            raise RuntimeError(
+                f"failed to find container for {app_id}/{role}/{replica_id}"
+            )
+        elif len(containers) > 1:
+            raise RuntimeError(
+                f"found multiple containers for {app_id}/{role}/{replica_id}: {containers}"
+            )
+        return containers[0]
+
+    def _get_containers(self, app_id: str) -> List["Container"]:
+        client = self._client()
+        return client.containers.list(
+            all=True, filters={"label": f"{LABEL_APP_ID}={app_id}"}
+        )
+
+    def _cancel_existing(self, app_id: str) -> None:
+        containers = self._get_containers(app_id)
+        for container in containers:
+            container.stop()
+
+    def run_opts(self) -> runopts:
+        opts = runopts()
+        return opts
+
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        roles = {}
+        roles_statuses = {}
+
+        states = []
+
+        containers = self._get_containers(app_id)
+        for container in containers:
+            role = container.labels[LABEL_ROLE_NAME]
+            replica_id = container.labels[LABEL_REPLICA_ID]
+
+            if role not in roles:
+                roles[role] = Role(
+                    name=role,
+                    num_replicas=0,
+                    image=container.image,
+                )
+                roles_statuses[role] = RoleStatus(role, [])
+            roles[role].num_replicas += 1
+
+            if container.status == "exited":
+                # docker doesn't have success/failed states -- we have to call
+                # `wait()` to get the exit code to determine that
+                status = container.wait(timeout=10)
+                if status["StatusCode"] == 0:
+                    state = AppState.SUCCEEDED
+                else:
+                    state = AppState.FAILED
+            else:
+                state = CONTAINER_STATE[container.status]
+
+            roles_statuses[role].replicas.append(
+                ReplicaStatus(
+                    id=int(replica_id),
+                    role=role,
+                    state=state,
+                    hostname=container.name,
+                )
+            )
+            states.append(state)
+
+        state = AppState.UNKNOWN
+        if all(is_terminal(state) for state in states):
+            if all(state == AppState.SUCCEEDED for state in states):
+                state = AppState.SUCCEEDED
+            else:
+                state = AppState.FAILED
+        else:
+            state = next(state for state in states if not is_terminal(state))
+
+        return DescribeAppResponse(
+            app_id=app_id,
+            roles=list(roles.values()),
+            roles_statuses=list(roles_statuses.values()),
+            state=state,
+        )
+
+    def log_iter(
+        self,
+        app_id: str,
+        role_name: str,
+        k: int = 0,
+        regex: Optional[str] = None,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+        should_tail: bool = False,
+    ) -> Iterable[str]:
+        c = self._get_container(app_id, role_name, k)
+
+        logs = c.logs(
+            since=since,
+            until=until,
+            stream=should_tail,
+        )
+        if len(logs) == 0:
+            logs = []
+        if isinstance(logs, bytes):
+            logs = logs.decode("utf-8")
+        if isinstance(logs, str):
+            logs = logs.split("\n")
+
+        if regex:
+            return filter_regex(regex, logs)
+        else:
+            return logs
+
+
+def create_scheduler(session_name: str, **kwargs: Any) -> DockerScheduler:
+    return DockerScheduler(
+        session_name=session_name,
+    )

--- a/torchx/schedulers/ids.py
+++ b/torchx/schedulers/ids.py
@@ -32,7 +32,7 @@ def random_id() -> str:
     Generates an alphanumeric string ID that matches the requirements from
     https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
     """
-    START_CANDIDATES = "abcdefghijklmnopqrstuvwxyz"
+    START_CANDIDATES = "bcdfghjklmnpqrstvwxz"
     END_CANDIDATES = START_CANDIDATES + "012345679"
 
     out = ""

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from docker.types import DeviceRequest
+from torchx import specs
+from torchx.schedulers.docker_scheduler import (
+    has_docker,
+    DockerScheduler,
+    create_scheduler,
+    DockerContainer,
+    DockerJob,
+)
+from torchx.schedulers.test.local_scheduler_test import LocalSchedulerTestUtil
+from torchx.specs.api import AppDef, AppState, Role, RunConfig
+
+
+def _test_app() -> specs.AppDef:
+    trainer_role = specs.Role(
+        name="trainer",
+        image="pytorch/torchx:latest",
+        entrypoint="main",
+        args=["--output-path", specs.macros.img_root, "--app-id", specs.macros.app_id],
+        env={"FOO": "bar"},
+        resource=specs.Resource(
+            cpu=2,
+            memMB=3000,
+            gpu=4,
+        ),
+        port_map={"foo": 1234},
+        num_replicas=1,
+        max_retries=3,
+    )
+
+    return specs.AppDef("test", roles=[trainer_role])
+
+
+class DockerSchedulerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scheduler: DockerScheduler = create_scheduler(
+            session_name="test_session",
+        )
+
+    def test_submit_dryrun(self) -> None:
+        app = _test_app()
+        cfg = specs.RunConfig()
+        with patch("torchx.schedulers.docker_scheduler.make_unique") as make_unique_ctx:
+            make_unique_ctx.return_value = "app_name_42"
+            info = self.scheduler._submit_dryrun(app, cfg)
+
+        want = DockerJob(
+            "app_name_42",
+            [
+                DockerContainer(
+                    image="pytorch/torchx:latest",
+                    command=[
+                        "main",
+                        "--output-path",
+                        "",
+                        "--app-id",
+                        "app_name_42",
+                    ],
+                    kwargs={
+                        "device_requests": [
+                            DeviceRequest(
+                                count=4,
+                                capabilities=[["compute"]],
+                            )
+                        ],
+                        "environment": {
+                            "FOO": "bar",
+                        },
+                        "labels": {
+                            "torchx.pytorch.org/app-id": "app_name_42",
+                            "torchx.pytorch.org/replica-id": "0",
+                            "torchx.pytorch.org/role-name": "trainer",
+                            "torchx.pytorch.org/version": "0.1.1dev0",
+                        },
+                        "mem_limit": "3000m",
+                        "name": "app_name_42-trainer-0",
+                        "hostname": "app_name_42-trainer-0",
+                        "nano_cpus": int(2e9),
+                        "restart_policy": {
+                            "Name": "on-failure",
+                            "MaximumRetryCount": 3,
+                        },
+                        "network": "torchx",
+                    },
+                )
+            ],
+        )
+        self.assertEqual(str(info), str(want))
+
+
+if has_docker():
+    # These are the live tests that require a local docker instance.
+
+    class DockerSchedulerLiveTest(unittest.TestCase, LocalSchedulerTestUtil):
+        def setUp(self) -> None:
+            self.scheduler: DockerScheduler = create_scheduler(
+                session_name="test_session",
+            )
+
+        def _docker_app(self, entrypoint: str, *args: str) -> AppDef:
+            return AppDef(
+                name="test-app",
+                roles=[
+                    Role(
+                        name="image_test_role",
+                        image="busybox",
+                        entrypoint=entrypoint,
+                        args=list(args),
+                    ),
+                ],
+            )
+
+        def test_docker_submit(self) -> None:
+            app = self._docker_app("echo", "foo")
+            cfg = RunConfig()
+            app_id = self.scheduler.submit(app, cfg)
+
+            desc = self.wait(app_id)
+            self.assertIsNotNone(desc)
+            self.assertEqual(AppState.SUCCEEDED, desc.state)
+            self.assertEqual(len(desc.roles), 1)
+            self.assertEqual(len(desc.roles_statuses), 1)
+            self.assertEqual(len(desc.roles_statuses[0].replicas), 1)
+            self.assertEqual(
+                desc.roles_statuses[0].replicas[0].state, AppState.SUCCEEDED
+            )
+
+            self.assertEqual(desc.app_id, app_id)
+
+        def test_docker_logs(self) -> None:
+            app = self._docker_app("echo", "foo\nbar")
+            cfg = RunConfig()
+
+            start = datetime.utcnow()
+            app_id = self.scheduler.submit(app, cfg)
+            desc = self.wait(app_id)
+            self.assertIsNotNone(desc)
+            # docker truncates to the second so pad out 1 extra second
+            end = datetime.utcnow() + timedelta(seconds=1)
+
+            print(start.isoformat(), end.isoformat())
+
+            self.assertEqual(AppState.SUCCEEDED, desc.state)
+
+            logs = list(
+                self.scheduler.log_iter(
+                    app_id,
+                    "image_test_role",
+                    0,
+                    since=start,
+                    until=end,
+                )
+            )
+            self.assertEqual(
+                logs,
+                [
+                    "foo",
+                    "bar",
+                    "",
+                ],
+            )
+            logs = list(
+                self.scheduler.log_iter(
+                    app_id,
+                    "image_test_role",
+                    0,
+                    regex="bar",
+                )
+            )
+            self.assertEqual(
+                logs,
+                [
+                    "bar",
+                ],
+            )
+
+            logs = list(
+                self.scheduler.log_iter(
+                    app_id,
+                    "image_test_role",
+                    0,
+                    since=end,
+                )
+            )
+            self.assertEqual(logs, [])
+            logs = list(
+                self.scheduler.log_iter(
+                    app_id,
+                    "image_test_role",
+                    0,
+                    until=start,
+                )
+            )
+            self.assertEqual(logs, [])
+
+        def test_docker_cancel(self) -> None:
+            app = self._docker_app("sleep", "10000")
+            cfg = RunConfig()
+            app_id = self.scheduler.submit(app, cfg)
+            status = self.scheduler.describe(app_id)
+
+            self.wait(app_id, wait_for=lambda state: state == AppState.RUNNING)
+            self.scheduler.cancel(app_id)
+
+            desc = self.wait(app_id)
+            self.assertIsNotNone(desc)
+            self.assertEqual(desc.state, AppState.FAILED)
+
+        def test_docker_submit_error(self) -> None:
+            app = self._docker_app("sh", "-c", "exit 1")
+            cfg = RunConfig()
+            app_id = self.scheduler.submit(app, cfg)
+
+            desc = self.wait(app_id)
+            self.assertIsNotNone(desc)
+            self.assertEqual(AppState.FAILED, desc.state)
+            self.assertEqual(len(desc.roles), 1)
+            self.assertEqual(len(desc.roles_statuses), 1)
+            self.assertEqual(len(desc.roles_statuses[0].replicas), 1)
+            self.assertEqual(desc.roles_statuses[0].replicas[0].state, AppState.FAILED)
+
+        def test_docker_submit_error_retries(self) -> None:
+            app = self._docker_app("sh", "-c", "exit 1")
+            app.roles[0].max_retries = 1
+            cfg = RunConfig()
+            app_id = self.scheduler.submit(app, cfg)
+
+            desc = self.wait(app_id)
+            self.assertIsNotNone(desc)
+            self.assertEqual(AppState.FAILED, desc.state)
+
+        def test_docker_submit_dist(self) -> None:
+            app = self._docker_app("echo", "foo")
+
+            app = AppDef(
+                name="test-app",
+                roles=[
+                    Role(
+                        name="ping",
+                        image="busybox",
+                        entrypoint="sh",
+                        args=[
+                            "-c",
+                            f"sleep 1; ping -c1 {specs.macros.app_id}-ping-0; sleep 1",
+                        ],
+                        num_replicas=2,
+                    ),
+                ],
+            )
+            cfg = RunConfig()
+            app_id = self.scheduler.submit(app, cfg)
+            print(app_id)
+
+            desc = self.wait(app_id)
+            self.assertIsNotNone(desc)
+            self.assertEqual(AppState.SUCCEEDED, desc.state)
+            self.assertEqual(len(desc.roles), 1)
+            self.assertEqual(len(desc.roles_statuses), 1)
+            self.assertEqual(len(desc.roles_statuses[0].replicas), 2)
+            self.assertEqual(
+                desc.roles_statuses[0].replicas[0].state, AppState.SUCCEEDED
+            )
+            self.assertEqual(
+                desc.roles_statuses[0].replicas[1].state, AppState.SUCCEEDED
+            )

--- a/torchx/schedulers/test/ids_test.py
+++ b/torchx/schedulers/test/ids_test.py
@@ -39,8 +39,8 @@ class IdsTest(unittest.TestCase):
 
     @patch("os.urandom", return_value=bytes(range(8)))
     def test_random_id_seed(self, urandom: MagicMock) -> None:
-        self.assertEqual(random_id(), "xfik3yru3e")
+        self.assertEqual(random_id(), "fzfjxlmln9")
 
     @patch("os.urandom", return_value=bytes(range(8)))
     def test_make_unique_seed(self, urandom: MagicMock) -> None:
-        self.assertEqual(make_unique("test"), "test-xfik3yru3e")
+        self.assertEqual(make_unique("test"), "test-fzfjxlmln9")

--- a/torchx/schedulers/test/registry_test.py
+++ b/torchx/schedulers/test/registry_test.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
 from torchx.schedulers import get_schedulers, get_default_scheduler_name
+from torchx.schedulers.docker_scheduler import DockerScheduler
 from torchx.schedulers.local_scheduler import LocalScheduler
 
 
@@ -28,7 +29,7 @@ class SchedulersTest(unittest.TestCase):
     def test_get_local_schedulers(self, mock_load_group: MagicMock) -> None:
         schedulers = get_schedulers(session_name="test_session")
         self.assertTrue(isinstance(schedulers["local_cwd"], LocalScheduler))
-        self.assertTrue(isinstance(schedulers["local_docker"], LocalScheduler))
+        self.assertTrue(isinstance(schedulers["local_docker"], DockerScheduler))
 
         self.assertEqual(get_default_scheduler_name(), "local_docker")
 


### PR DESCRIPTION
<!-- Change Summary -->

This replaces the `DockerImageProvider` with a new `DockerScheduler`. This new scheduler is fully stateless and implements the full TorchX specs.

Improvements upon old scheduler:
* stateless (all state is stored in Docker agent) -- thus supports running multiple sequential commands such as `torchx log ...` across processes
* creates a `torchx` bridge network so each container gets assigned a hostname + IP and can communicate between each other (fixes https://github.com/pytorch/torchx/issues/286)
* doesn't mess up user terminal on `ctrl-c` (fixes https://github.com/pytorch/torchx/issues/287)
* supports resource settings (cpu, mem, gpu)
* supports retries (no gang semantics, just container)
* supports stderr + stdout logs as well as since/util

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
```
pyre
pytest -n8
```

```
tristanr@tristanr-arch2 ~/D/torchx (dockerscheduler) [1]> torchx run utils.sh --image busybox:latest --num_replicas 3 sh -c 'sleep 1; ping -c1 ${app_id}-sh-0; sleep 1'
torchx 2021-10-27 15:51:50 INFO     Pulling container image: busybox:latest (this may take a while)
local_docker://torchx/sh-lsgcv92jm13ps
torchx 2021-10-27 15:51:52 INFO     Waiting for the app to finish...
torchx 2021-10-27 15:51:56 INFO     Job finished: SUCCEEDED
tristanr@tristanr-arch2 ~/D/torchx (dockerscheduler)> torchx log local_docker://torchx/sh-lsgcv92jm13ps
sh/0 PING sh-lsgcv92jm13ps-sh-0 (172.21.0.2): 56 data bytes
sh/0 64 bytes from 172.21.0.2: seq=0 ttl=64 time=0.070 ms
sh/0
sh/0 --- sh-lsgcv92jm13ps-sh-0 ping statistics ---
sh/0 1 packets transmitted, 1 packets received, 0% packet loss
sh/0 round-trip min/avg/max = 0.070/0.070/0.070 ms
sh/0
sh/2 PING sh-lsgcv92jm13ps-sh-0 (172.21.0.2): 56 data bytes
sh/2 64 bytes from 172.21.0.2: seq=0 ttl=64 time=0.063 ms
sh/2
sh/2 --- sh-lsgcv92jm13ps-sh-0 ping statistics ---
sh/2 1 packets transmitted, 1 packets received, 0% packet loss
sh/2 round-trip min/avg/max = 0.063/0.063/0.063 ms
sh/2
sh/1 PING sh-lsgcv92jm13ps-sh-0 (172.21.0.2): 56 data bytes
sh/1 64 bytes from 172.21.0.2: seq=0 ttl=64 time=0.261 ms
sh/1
sh/1 --- sh-lsgcv92jm13ps-sh-0 ping statistics ---
sh/1 1 packets transmitted, 1 packets received, 0% packet loss
sh/1 round-trip min/avg/max = 0.261/0.261/0.261 ms
sh/1
tristanr@tristanr-arch2 ~/D/torchx (dockerscheduler)> torchx status local_docker://torchx/sh-lsgcv92jm13ps
torchx 2021-10-27 15:52:20 INFO     AppDef:
  State: SUCCEEDED
  Num Restarts: -1
Roles:
 *sh[0]:SUCCEEDED
  sh[1]:SUCCEEDED
  sh[2]:SUCCEEDED
```
