### PR TITLE
cli/run: add --log which prints logs while waiting

### DIFF
--- a/torchx/cli/test/cmd_log_test.py
+++ b/torchx/cli/test/cmd_log_test.py
@@ -11,7 +11,7 @@ from typing import Iterator, Optional
 from unittest.mock import MagicMock, patch
 
 from torchx.cli.cmd_log import ENDC, GREEN, get_logs, validate
-from torchx.specs import AppDef, Role, parse_app_handle
+from torchx.specs import AppDef, Role, parse_app_handle, AppStatus, AppState
 
 
 class SentinelError(Exception):
@@ -38,6 +38,9 @@ class MockRunner:
                 Role(name="trainer", image="test_image", num_replicas=3),
             ],
         )
+
+    def status(self, app_handle: str) -> AppStatus:
+        return AppStatus(state=AppState.RUNNING)
 
     def log_lines(
         self,

--- a/torchx/cli/test/components.py
+++ b/torchx/cli/test/components.py
@@ -60,3 +60,19 @@ def simple(
     )
 
     return specs.AppDef(name="my_train_job", roles=[trainer, ps, reader])
+
+
+def echo_stderr(msg: str) -> specs.AppDef:
+    touch = specs.Role(
+        name="echo",
+        image="/tmp",
+        entrypoint="python3",
+        args=[
+            "-c",
+            "import sys; sys.stderr.write(sys.argv[1])",
+            msg,
+        ],
+        num_replicas=1,
+    )
+
+    return specs.AppDef(name="echo", roles=[touch])

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -315,9 +315,17 @@ _TERMINAL_STATES: List[AppState] = [
     AppState.CANCELLED,
 ]
 
+_STARTED_STATES: List[AppState] = _TERMINAL_STATES + [
+    AppState.RUNNING,
+]
+
 
 def is_terminal(state: AppState) -> bool:
     return state in _TERMINAL_STATES
+
+
+def is_started(state: AppState) -> bool:
+    return state in _STARTED_STATES
 
 
 # =======================


### PR DESCRIPTION
<!-- Change Summary -->

This adds a new `--log` command that will print the operator logs from a background thread. This is most useful when dealing with small quick running operators.

NOTE: this changes the behavior for `torchx log` to wait for up to 10 seconds for the job to start before attempting to fetch the logs. This allows delayed schedulers such as kubernetes to create the job instance before log fetching.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pytest -n8 torchx/cli/
torchx run --scheduler kubernetes -cfg queue=default --log --wait utils.sh --image alpine:latest --num_replicas 1 env
```
