### PR TITLE
(torchx/components-test) make component_test_base.validate actually lint + validate through to --help

### DIFF
--- a/docs/source/component_best_practices.rst
+++ b/docs/source/component_best_practices.rst
@@ -136,7 +136,6 @@ Unit Tests
 
 .. autoclass:: torchx.components.component_test_base.ComponentTestCase
    :members:
-   :private-members: _validate
 
 Integration Tests
 -------------------

--- a/torchx/components/test/dist_test.py
+++ b/torchx/components/test/dist_test.py
@@ -10,4 +10,4 @@ from torchx.components.component_test_base import ComponentTestCase
 
 class DistributedComponentTest(ComponentTestCase):
     def test_ddp(self) -> None:
-        self._validate(dist, "ddp")
+        self.validate(dist, "ddp")

--- a/torchx/components/test/utils_test.py
+++ b/torchx/components/test/utils_test.py
@@ -10,19 +10,19 @@ from torchx.components.component_test_base import ComponentTestCase
 
 class UtilsComponentTest(ComponentTestCase):
     def test_sh(self) -> None:
-        self._validate(utils, "sh")
+        self.validate(utils, "sh")
 
     def test_python(self) -> None:
-        self._validate(utils, "python")
+        self.validate(utils, "python")
 
     def test_touch(self) -> None:
-        self._validate(utils, "touch")
+        self.validate(utils, "touch")
 
     def test_echo(self) -> None:
-        self._validate(utils, "echo")
+        self.validate(utils, "echo")
 
     def test_copy(self) -> None:
-        self._validate(utils, "copy")
+        self.validate(utils, "copy")
 
     def test_booth(self) -> None:
-        self._validate(utils, "booth")
+        self.validate(utils, "booth")

--- a/torchx/examples/apps/datapreproc/test/component_test.py
+++ b/torchx/examples/apps/datapreproc/test/component_test.py
@@ -10,4 +10,4 @@ from torchx.components.component_test_base import ComponentTestCase
 
 class DatapreprocComponentTest(ComponentTestCase):
     def test_trainer(self) -> None:
-        self._validate(datapreproc, "data_preproc")
+        self.validate(datapreproc, "data_preproc")

--- a/torchx/examples/apps/lightning_classy_vision/test/component_test.py
+++ b/torchx/examples/apps/lightning_classy_vision/test/component_test.py
@@ -10,7 +10,7 @@ from torchx.components.component_test_base import ComponentTestCase
 
 class DistributedComponentTest(ComponentTestCase):
     def test_trainer(self) -> None:
-        self._validate(lightning_classy_vision, "trainer")
+        self.validate(lightning_classy_vision, "trainer")
 
     def test_interpret(self) -> None:
-        self._validate(lightning_classy_vision, "interpret")
+        self.validate(lightning_classy_vision, "interpret")


### PR DESCRIPTION
Summary:
Component test was not linting + validating all the way through. This changes it so that it validates the component by effectively running:

```
torchx run COMPONENT --help
```

Reviewed By: aivanou

Differential Revision: D32009994

