### PR TITLE
Dockerfile: switch base to pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime

### DIFF
--- a/torchx/runtime/container/Dockerfile
+++ b/torchx/runtime/container/Dockerfile
@@ -1,13 +1,11 @@
-FROM pytorch/pytorch:1.9.0-cuda10.2-cudnn7-runtime
-
-RUN pip install fsspec[s3]
+FROM pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime
 
 WORKDIR /app
 
 # copy requirements early so we don't have to redownload dependencies on code
 # changes
 COPY dev-requirements.txt /app
-RUN pip install --upgrade -r dev-requirements.txt
+RUN pip install -r dev-requirements.txt
 
 COPY . /app
 


### PR DESCRIPTION
<!-- Change Summary -->

* This switches the base docker image to pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime which is the new officially supported pytorch image. 
* We also removed the unnecessary `pip install fsspec[s3]` since it's in the dev requirements already.
* Removed `--upgrade` to avoid reinstalling existing dependencies. This should reduce the container size.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
tristanr@tristanr-arch2 ~/D/torchx (cuda113)> ./torchx/runtime/container/build.sh
tristanr@tristanr-arch2 ~/D/torchx (cuda113)> docker run --rm --network test2 -it torchx:latest python -c 'import torchx; print(torchx.__version__)'
0.1.1dev0
```

CI


