### PR TITLE
lightning_classy_vision: bump trainer mem usage to 4GB after CUDA version bump

### DIFF
--- a/torchx/examples/apps/lightning_classy_vision/component.py
+++ b/torchx/examples/apps/lightning_classy_vision/component.py
@@ -120,7 +120,7 @@ def trainer(
                 image=image,
                 resource=named_resources[resource]
                 if resource
-                else specs.Resource(cpu=1, gpu=0, memMB=3000),
+                else specs.Resource(cpu=1, gpu=0, memMB=4000),
             )
         ],
     )


### PR DESCRIPTION
<!-- Change Summary -->

After the CUDA version bump the trainer integration test sometimes gets OOMKilled. This bumps the memory limit to 4GB to avoid that issue.

Ex: http://localhost:8080/#/runs/details/64c16011-41e9-4305-bd64-b4b57e71324e

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI
