### PR TITLE
schedulers/runner/cli: add support for fetching logs for stdout, stderr and combined streams

### DIFF
--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -72,8 +72,8 @@ class CmdRunTest(unittest.TestCase):
             self.cmd_run.run(args)
             self.assertTrue(os.path.isfile(str(self.tmpdir / "foobar.txt.testv2")))
 
-    @patch("sys.stdout", new_callable=io.StringIO)
-    def test_run_with_log(self, stdout: MagicMock) -> None:
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_run_with_log(self, stderr: io.StringIO) -> None:
         with cwd(str(Path(__file__).parent)):
             args = self.parser.parse_args(
                 [
@@ -90,7 +90,7 @@ class CmdRunTest(unittest.TestCase):
             )
 
             self.cmd_run.run(args)
-        self.assertRegex(stdout.getvalue(), "echo/0.*toast")
+        self.assertRegex(stderr.getvalue(), "echo/0.*toast")
 
     @patch(
         "torchx.runner.Runner.wait", side_effect=SignalException("msg", signal.SIGTERM)

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 from pyre_extensions import none_throws
 from torchx.runner.events import log_event
 from torchx.schedulers import get_schedulers
-from torchx.schedulers.api import Scheduler
+from torchx.schedulers.api import Scheduler, Stream
 from torchx.specs.api import (
     AppDef,
     AppDryRunInfo,
@@ -420,6 +420,7 @@ class Runner:
         since: Optional[datetime] = None,
         until: Optional[datetime] = None,
         should_tail: bool = False,
+        streams: Optional[Stream] = None,
     ) -> Iterable[str]:
         """
         Returns an iterator over the log lines of the specified job container.
@@ -484,7 +485,14 @@ class Runner:
             if not self.status(app_handle):
                 raise UnknownAppException(app_handle)
             log_iter = scheduler.log_iter(
-                app_id, role_name, k, regex, since, until, should_tail
+                app_id,
+                role_name,
+                k,
+                regex,
+                since,
+                until,
+                should_tail,
+                streams=streams,
             )
             return log_iter
 

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -350,7 +350,7 @@ class RunnerTest(unittest.TestCase):
 
             self.assertEqual(["hello", "world"], lines)
             scheduler_mock.log_iter.assert_called_once_with(
-                app_id, role_name, replica_id, regex, since, until, False
+                app_id, role_name, replica_id, regex, since, until, False, streams=None
             )
 
     @patch("json.dumps")

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 
 from torchx.runner.config import apply, dump, load
 from torchx.schedulers import Scheduler, get_schedulers
-from torchx.schedulers.api import DescribeAppResponse
+from torchx.schedulers.api import DescribeAppResponse, Stream
 from torchx.specs import AppDef, AppDryRunInfo, RunConfig, runopts
 
 
@@ -46,6 +46,7 @@ class TestScheduler(Scheduler):
         since: Optional[datetime] = None,
         until: Optional[datetime] = None,
         should_tail: bool = False,
+        streams: Optional[Stream] = None,
     ) -> Iterable[str]:
         raise NotImplementedError()
 

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -9,6 +9,7 @@ import abc
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 from typing import Iterable, List, Optional
 
 from torchx.specs.api import (
@@ -23,6 +24,12 @@ from torchx.specs.api import (
     SchedulerBackend,
     runopts,
 )
+
+
+class Stream(str, Enum):
+    STDOUT = "stdout"
+    STDERR = "stderr"
+    COMBINED = "combined"
 
 
 @dataclass
@@ -193,6 +200,7 @@ class Scheduler(abc.ABC):
         since: Optional[datetime] = None,
         until: Optional[datetime] = None,
         should_tail: bool = False,
+        streams: Optional[Stream] = None,
     ) -> Iterable[str]:
         """
         Returns an iterator to the log lines of the ``k``th replica of the ``role``.
@@ -243,6 +251,12 @@ class Scheduler(abc.ABC):
 
         7. Some schedulers may support line cursors by supporting ``__getitem__``
            (e.g. ``iter[50]`` seeks to the 50th log line).
+
+        Args:
+            streams: The IO output streams to select.
+                One of: combined, stdout, stderr.
+                If the selected stream isn't supported by the scheduler it will
+                throw an ValueError.
 
         Returns:
             An ``Iterator`` over log lines of the specified role replica

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -18,6 +18,7 @@ from torchx.schedulers.api import (
     DescribeAppResponse,
     Scheduler,
     filter_regex,
+    Stream,
 )
 from torchx.schedulers.ids import make_unique
 from torchx.specs.api import (
@@ -334,6 +335,7 @@ class DockerScheduler(Scheduler):
         since: Optional[datetime] = None,
         until: Optional[datetime] = None,
         should_tail: bool = False,
+        streams: Optional[Stream] = None,
     ) -> Iterable[str]:
         c = self._get_container(app_id, role_name, k)
 
@@ -341,6 +343,8 @@ class DockerScheduler(Scheduler):
             since=since,
             until=until,
             stream=should_tail,
+            stderr=streams != Stream.STDOUT,
+            stdout=streams != Stream.STDERR,
         )
         if len(logs) == 0:
             logs = []

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -45,6 +45,7 @@ from torchx.schedulers.api import (
     DescribeAppResponse,
     Scheduler,
     filter_regex,
+    Stream,
 )
 from torchx.schedulers.ids import make_unique
 from torchx.specs.api import (
@@ -485,8 +486,12 @@ class KubernetesScheduler(Scheduler):
         since: Optional[datetime] = None,
         until: Optional[datetime] = None,
         should_tail: bool = False,
+        streams: Optional[Stream] = None,
     ) -> Iterable[str]:
         assert until is None, "kubernetes API doesn't support until"
+
+        if streams not in (None, Stream.COMBINED):
+            raise ValueError("KubernetesScheduler only supports COMBINED log stream")
 
         from kubernetes import client, watch
 

--- a/torchx/schedulers/streams.py
+++ b/torchx/schedulers/streams.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import io
+import os
+import select
+import threading
+from types import TracebackType
+from typing import (
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    TYPE_CHECKING,
+    Iterator,
+    Type,
+    BinaryIO,
+)
+
+
+class Tee(BinaryIO):
+    """
+    Tee is a IO writer that allows writing to multiple writers. This uses pipe
+    and file descriptors so it works with subprocess.
+
+    .. note:: Tee creates a background thread so must be closed.
+
+    The order of writes is not guaranteed when writing to both fileno() and
+    directly via write().
+    """
+
+    def __init__(self, *streams: io.FileIO) -> None:
+        assert len(streams) > 0, "must have at least one stream"
+        for s in streams:
+            assert s.writable(), f"{s} must be writable"
+            assert not s.closed, f"{s} must not be closed"
+            assert s.fileno() >= 0, f"{s} must have fileno"
+            assert s.mode == "wb", f"{s} must be in wb mode"
+
+        self.streams_lock = threading.Lock()  # protects streams
+        self.streams: Tuple[io.FileIO] = streams
+        r, w = os.pipe()
+        self._fileno: int = w
+        self.r: io.FileIO = io.open(r, "rb", buffering=0)
+        self._closed = False
+
+        self.thread = threading.Thread(
+            target=self._start_thread,
+        )
+        self.thread.daemon = True
+        self.thread.start()
+
+    def _start_thread(self) -> None:
+        BUFSIZE = 64000
+        while True:
+            r, w, e = select.select([self.r], [], [], 0.1)
+            if self.r not in r:
+                if self._closed:
+                    break
+                continue
+
+            data = self.r.read(BUFSIZE)
+            self.write(data)
+
+    @property
+    def mode(self) -> str:
+        return "wb"
+
+    @property
+    def name(self) -> "Union[os.PathLike[bytes], os.PathLike[str], bytes, int, str]":
+        return self.streams[0].name
+
+    def close(self) -> None:
+        self._closed = True
+        self.thread.join()
+        with self.streams_lock:
+            for s in self.streams:
+                s.close()
+            self.r.close()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def fileno(self) -> int:
+        return self._fileno
+
+    def flush(self) -> None:
+        with self.streams_lock:
+            for s in self.streams:
+                s.flush()
+
+    def isatty(self) -> bool:
+        return False
+
+    def read(self, n: Optional[int] = -1) -> bytes:
+        raise NotImplementedError("_Tee doesn't support read")
+
+    def readable(self) -> bool:
+        return False
+
+    def readline(self, limit: int = -1) -> bytes:
+        raise NotImplementedError("_Tee doesn't support readline")
+
+    def readlines(self, hint: int = -1) -> List[bytes]:
+        raise NotImplementedError("_Tee doesn't support readlines")
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        raise NotImplementedError("_Tee doesn't support seek")
+
+    def seekable(self) -> bool:
+        return False
+
+    def tell(self) -> int:
+        raise NotImplementedError("_Tee doesn't support tell")
+
+    def truncate(self, size: Optional[int] = None) -> int:
+        raise NotImplementedError("_Tee doesn't support truncate")
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, s: bytes) -> int:
+        with self.streams_lock:
+            n = 0
+            for stream in self.streams:
+                n = stream.write(s)
+            return n
+
+    def writelines(self, lines: Iterable[bytes]) -> None:
+        with self.streams_lock:
+            for s in self.streams:
+                s.writelines(lines)
+
+    def __enter__(self) -> BinaryIO:
+        return self
+
+    def __exit__(
+        self,
+        t: Optional[Type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        pass
+
+    def __iter__(self) -> Iterator[bytes]:
+        return self
+
+    def __next__(self) -> bytes:
+        raise NotImplementedError("_Tee doesn't support __next__")
+
+
+if TYPE_CHECKING:
+    # Enforce that Tee is a valid BinaryIO type
+    _TEE: BinaryIO = Tee()

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Iterable, Optional, Union
 from unittest.mock import MagicMock, patch
 
-from torchx.schedulers.api import DescribeAppResponse, Scheduler
+from torchx.schedulers.api import DescribeAppResponse, Scheduler, Stream
 from torchx.specs.api import (
     NULL_RESOURCE,
     AppDef,
@@ -51,6 +51,7 @@ class SchedulerTest(unittest.TestCase):
             since: Optional[datetime] = None,
             until: Optional[datetime] = None,
             should_tail: bool = False,
+            streams: Optional[Stream] = None,
         ) -> Iterable[str]:
             return iter([])
 

--- a/torchx/schedulers/test/streams_test.py
+++ b/torchx/schedulers/test/streams_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import io
+import os.path
+import shutil
+import tempfile
+import unittest
+
+from torchx.schedulers.streams import Tee
+
+
+class TeeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = tempfile.mkdtemp(prefix="torchx_runner_config_test")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_combined(self) -> None:
+        a_path = os.path.join(self.test_dir, "a")
+        b_path = os.path.join(self.test_dir, "b")
+        ab_path = os.path.join(self.test_dir, "ab")
+
+        ab = io.open(ab_path, "wb", buffering=0)
+        a = Tee(io.open(a_path, "wb", buffering=0), ab)
+        b = Tee(io.open(b_path, "wb", buffering=0), ab)
+
+        a.write(b"1")
+        b.write(b"2")
+        a.write(b"3")
+        b.write(b"4")
+
+        a.close()
+        b.close()
+
+        with open(a_path, "rb") as f:
+            self.assertEqual(f.read(), b"13")
+        with open(b_path, "rb") as f:
+            self.assertEqual(f.read(), b"24")
+        with open(ab_path, "rb") as f:
+            self.assertEqual(f.read(), b"1234")
+
+    def test_basic(self) -> None:
+        a_path = os.path.join(self.test_dir, "a")
+        b_path = os.path.join(self.test_dir, "b")
+        a = Tee(
+            io.open(a_path, "wb", buffering=0),
+            io.open(b_path, "wb", buffering=0),
+        )
+        self.assertEqual(a.mode, "wb")
+        self.assertEqual(a.name, a_path)
+        self.assertFalse(a.closed)
+        self.assertGreaterEqual(a.fileno(), 0)
+
+        self.assertFalse(a.isatty())
+        self.assertFalse(a.readable())
+        self.assertFalse(a.seekable())
+        self.assertTrue(a.writable())
+
+        with self.assertRaises(NotImplementedError):
+            a.read()
+        with self.assertRaises(NotImplementedError):
+            a.readline()
+        with self.assertRaises(NotImplementedError):
+            a.readlines()
+        with self.assertRaises(NotImplementedError):
+            a.seek(0)
+        with self.assertRaises(NotImplementedError):
+            a.tell()
+        with self.assertRaises(NotImplementedError):
+            a.truncate()
+        with self.assertRaises(NotImplementedError):
+            list(a)
+
+        with a as f:
+            self.assertEqual(f, a)
+
+        a.write(b"1\n")
+        a.writelines([b"2\n", b"3\n"])
+        a.flush()
+
+        a.close()
+        self.assertTrue(a.closed)
+
+        with open(a_path, "rb") as f:
+            self.assertEqual(f.read(), b"1\n2\n3\n")
+        with open(b_path, "rb") as f:
+            self.assertEqual(f.read(), b"1\n2\n3\n")
+
+    def test_fileno(self) -> None:
+        a_path = os.path.join(self.test_dir, "a")
+        ab_path = os.path.join(self.test_dir, "ab")
+
+        ab = io.open(ab_path, "wb", buffering=0)
+        a = Tee(io.open(a_path, "wb", buffering=0), ab)
+
+        w: io.FileIO = io.open(a.fileno(), "wb", buffering=0)
+        w.write(b"1")
+        w.write(b"3")
+
+        a.close()
+
+        with open(a_path, "rb") as f:
+            self.assertEqual(f.read(), b"13")


### PR DESCRIPTION
<!-- Change Summary -->

This adds a new `streams` parameter to runner, scheduler and `torchx log` that allows selecting between stdout, stderr and combined.

* The defaults are up to the specific scheduler. For OSS it defaults to merged. Kubernetes doesn't support individual streams so only has combined output.
* This changes the local scheduler so it always logs to a file and then prints the logs via --log support in run.
* For `local_*` schedulers `torchx run` will always print the logs and wait
* Logs are now printed on stderr when running as part of `torchx run`

Fixes  #324

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pyre
pytest
```

## torchx run
![2021-10-29-155815_1004x112_scrot](https://user-images.githubusercontent.com/909104/139509778-3e2a3c38-e9d7-4e26-a77a-6af00c04bd96.png)

## torchx log
![2021-10-29-155938_877x1007_scrot](https://user-images.githubusercontent.com/909104/139509856-4dadc0f4-8ecb-4373-96e5-e9adc9df4c6a.png)

