### PR TITLE
(torchx/cli) implement builtins --print (aka copy)

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -23,9 +23,11 @@ from torchx.specs.finder import (
     ComponentNotFoundException,
     ComponentValidationException,
     _Component,
+    get_builtin_source,
     get_components,
 )
 from torchx.util.types import to_dict
+
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -60,17 +62,25 @@ def _parse_run_config(arg: str, scheduler_opts: specs.runopts) -> specs.RunConfi
 
 class CmdBuiltins(SubCommand):
     def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        pass
+        subparser.add_argument(
+            "--print",
+            type=str,
+            help="prints the builtin's component def to stdout",
+        )
 
     def _builtins(self) -> Dict[str, _Component]:
         return get_components()
 
     def run(self, args: argparse.Namespace) -> None:
-        builtin_components = self._builtins()
-        num_builtins = len(builtin_components)
-        print(f"Found {num_builtins} builtin components:")
-        for i, component in enumerate(builtin_components.values()):
-            print(f" {i + 1:2d}. {component.name}")
+        builtin_name = args.print
+        if not builtin_name:
+            builtin_components = self._builtins()
+            num_builtins = len(builtin_components)
+            print(f"Found {num_builtins} builtin components:")
+            for i, component in enumerate(builtin_components.values()):
+                print(f" {i + 1:2d}. {component.name}")
+        else:
+            print(get_builtin_source(builtin_name))
 
 
 class CmdRun(SubCommand):

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -217,3 +217,12 @@ class CmdBuiltinTest(unittest.TestCase):
         self.assertTrue(len(builtins) > 0)
         for component in builtins.values():
             self.assertListEqual([], component.validation_errors)
+
+    def test_print_builtin(self) -> None:
+        parser = argparse.ArgumentParser()
+
+        cmd_builtins = CmdBuiltins()
+        cmd_builtins.add_arguments(parser)
+
+        cmd_builtins.run(parser.parse_args(["--print", "dist.ddp"]))
+        # nothing to assert, just make sure it runs

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -6,21 +6,26 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import shutil
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import torchx.specs.finder as finder
 from pyre_extensions import none_throws
-from torchx.specs.api import AppDef, Role
+from torchx.runner import get_runner
+from torchx.runtime.tracking import FsspecResultTracker
+from torchx.specs.api import AppDef, AppState, Role, RunConfig
 from torchx.specs.finder import (
-    ModuleComponentsFinder,
+    ComponentNotFoundException,
+    ComponentValidationException,
     CustomComponentsFinder,
+    ModuleComponentsFinder,
+    _load_components,
     get_component,
     get_components,
-    ComponentValidationException,
-    ComponentNotFoundException,
-    _load_components,
 )
 
 
@@ -191,3 +196,72 @@ to your component (see: https://pytorch.org/torchx/latest/component_best_practic
     def test_get_component_invalid(self) -> None:
         with self.assertRaises(ComponentValidationException):
             get_component(f"{current_file_path()}:invalid_component")
+
+
+class GetBuiltinSourceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = Path(tempfile.mkdtemp("torchx_specs_finder_test"))
+
+        # this is so that the test can pick up penv python (fb-only)
+        # which is added as a test resource
+        self.orig_cwd = os.getcwd()
+        os.chdir(os.path.dirname(__file__))
+
+    def tearDown(self) -> None:
+        os.chdir(self.orig_cwd)
+        shutil.rmtree(self.test_dir)
+
+    def test_get_builtin_source_with_echo(self) -> None:
+        echo_src = finder.get_builtin_source("utils.echo")
+
+        # save it to a file and try running it
+        echo_copy = self.test_dir / "echo_copy.py"
+        with open(echo_copy, "w") as f:
+            f.write(echo_src)
+
+        runner = get_runner()
+        app_handle = runner.run_component(
+            scheduler="local_cwd",
+            component_name=f"{str(echo_copy)}:echo",
+            app_args=["--msg", "hello world"],
+        )
+        # pyre-ignore[6]: remove this line after https://github.com/pytorch/torchx/issues/331
+        status = runner.wait(app_handle, wait_interval=0.1)
+        self.assertIsNotNone(status)
+        self.assertEqual(AppState.SUCCEEDED, status.state)
+
+    def test_get_builtin_source_with_booth(self) -> None:
+        # try copying and running a builtin that is NOT the first
+        # defined function in the file
+
+        booth_src = finder.get_builtin_source("utils.booth")
+
+        # save it to a file and try running it
+        booth_copy = self.test_dir / "booth_copy.py"
+        with open(booth_copy, "w") as f:
+            f.write(booth_src)
+
+        runner = get_runner()
+
+        trial_idx = 0
+        tracker_base = str(self.test_dir / "tracking")
+
+        app_handle = runner.run_component(
+            scheduler="local_cwd",
+            cfg=RunConfig({"prepend_cwd": True}),
+            component_name=f"{str(booth_copy)}:booth",
+            app_args=[
+                "--x1=1",
+                "--x2=3",
+                f"--trial_idx={trial_idx}",
+                f"--tracker_base={tracker_base}",
+            ],
+        )
+        # pyre-ignore[6]: remove this line after https://github.com/pytorch/torchx/issues/331
+        status = runner.wait(app_handle, wait_interval=0.1)
+        self.assertIsNotNone(status)
+        self.assertEqual(AppState.SUCCEEDED, status.state)
+
+        tracker = FsspecResultTracker(tracker_base)
+        # booth function has global min of 0 at (1, 3)
+        self.assertEqual(0, tracker[trial_idx]["booth_eval"])


### PR DESCRIPTION
Summary:
Closes: https://github.com/pytorch/torchx/issues/316

Usage:

```
$ cd ~/fbsource/fbcode/torchx/fb/example/
$ torchx builtins --print fb.dist.ddp > dist_cpy.py
$ torchx run dist_cpy.py:ddp --img bento_kernel_pytorch_lightning -m torchx.fb.example.main
```

NOTE: will update the docs separately

Differential Revision: D32144324

