### PR TITLE
local_scheduler/Tee: remove select to avoid fd limit

### DIFF
--- a/torchx/schedulers/streams.py
+++ b/torchx/schedulers/streams.py
@@ -7,23 +7,12 @@
 
 import io
 import os
-import select
 import threading
-from types import TracebackType
-from typing import (
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    TYPE_CHECKING,
-    Iterator,
-    Type,
-    BinaryIO,
-)
+import time
+from typing import List
 
 
-class Tee(BinaryIO):
+class Tee:
     """
     Tee is a IO writer that allows writing to multiple writers. This uses pipe
     and file descriptors so it works with subprocess.
@@ -34,19 +23,16 @@ class Tee(BinaryIO):
     directly via write().
     """
 
-    def __init__(self, *streams: io.FileIO) -> None:
-        assert len(streams) > 0, "must have at least one stream"
-        for s in streams:
-            assert s.writable(), f"{s} must be writable"
-            assert not s.closed, f"{s} must not be closed"
-            assert s.fileno() >= 0, f"{s} must have fileno"
-            assert s.mode == "wb", f"{s} must be in wb mode"
-
+    def __init__(self, out: io.FileIO, *sources: str) -> None:
+        assert len(sources) > 0, "must have at least one stream"
         self.streams_lock = threading.Lock()  # protects streams
-        self.streams: Tuple[io.FileIO] = streams
-        r, w = os.pipe()
-        self._fileno: int = w
-        self.r: io.FileIO = io.open(r, "rb", buffering=0)
+        self.out = out
+        self.streams: List[io.FileIO] = []
+        for source in sources:
+            r = io.open(source, "rb", buffering=0)
+            os.set_blocking(r.fileno(), False)
+            self.streams.append(r)
+
         self._closed = False
 
         self.thread = threading.Thread(
@@ -58,103 +44,27 @@ class Tee(BinaryIO):
     def _start_thread(self) -> None:
         BUFSIZE = 64000
         while True:
-            r, w, e = select.select([self.r], [], [], 0.1)
-            if self.r not in r:
+            read = False
+            for r in self.streams:
+                data = r.read(BUFSIZE)
+                if data:
+                    read = True
+                    self.write(data)
+            if not read:
                 if self._closed:
                     break
-                continue
-
-            data = self.r.read(BUFSIZE)
-            self.write(data)
-
-    @property
-    def mode(self) -> str:
-        return "wb"
-
-    @property
-    def name(self) -> "Union[os.PathLike[bytes], os.PathLike[str], bytes, int, str]":
-        return self.streams[0].name
+                time.sleep(0.1)
 
     def close(self) -> None:
+        if self._closed:
+            return
         self._closed = True
         self.thread.join()
         with self.streams_lock:
             for s in self.streams:
                 s.close()
-            self.r.close()
-
-    @property
-    def closed(self) -> bool:
-        return self._closed
-
-    def fileno(self) -> int:
-        return self._fileno
-
-    def flush(self) -> None:
-        with self.streams_lock:
-            for s in self.streams:
-                s.flush()
-
-    def isatty(self) -> bool:
-        return False
-
-    def read(self, n: Optional[int] = -1) -> bytes:
-        raise NotImplementedError("_Tee doesn't support read")
-
-    def readable(self) -> bool:
-        return False
-
-    def readline(self, limit: int = -1) -> bytes:
-        raise NotImplementedError("_Tee doesn't support readline")
-
-    def readlines(self, hint: int = -1) -> List[bytes]:
-        raise NotImplementedError("_Tee doesn't support readlines")
-
-    def seek(self, offset: int, whence: int = 0) -> int:
-        raise NotImplementedError("_Tee doesn't support seek")
-
-    def seekable(self) -> bool:
-        return False
-
-    def tell(self) -> int:
-        raise NotImplementedError("_Tee doesn't support tell")
-
-    def truncate(self, size: Optional[int] = None) -> int:
-        raise NotImplementedError("_Tee doesn't support truncate")
-
-    def writable(self) -> bool:
-        return True
+            self.out.close()
 
     def write(self, s: bytes) -> int:
         with self.streams_lock:
-            n = 0
-            for stream in self.streams:
-                n = stream.write(s)
-            return n
-
-    def writelines(self, lines: Iterable[bytes]) -> None:
-        with self.streams_lock:
-            for s in self.streams:
-                s.writelines(lines)
-
-    def __enter__(self) -> BinaryIO:
-        return self
-
-    def __exit__(
-        self,
-        t: Optional[Type[BaseException]],
-        value: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> None:
-        pass
-
-    def __iter__(self) -> Iterator[bytes]:
-        return self
-
-    def __next__(self) -> bytes:
-        raise NotImplementedError("_Tee doesn't support __next__")
-
-
-if TYPE_CHECKING:
-    # Enforce that Tee is a valid BinaryIO type
-    _TEE: BinaryIO = Tee()
+            return self.out.write(s)

--- a/torchx/schedulers/test/streams_test.py
+++ b/torchx/schedulers/test/streams_test.py
@@ -27,83 +27,15 @@ class TeeTest(unittest.TestCase):
         ab_path = os.path.join(self.test_dir, "ab")
 
         ab = io.open(ab_path, "wb", buffering=0)
-        a = Tee(io.open(a_path, "wb", buffering=0), ab)
-        b = Tee(io.open(b_path, "wb", buffering=0), ab)
 
-        a.write(b"1")
-        b.write(b"2")
-        a.write(b"3")
-        b.write(b"4")
+        with open(a_path, "wb") as a, open(b_path, "wb") as b:
+            a.write(b"1")
+            b.write(b"2")
+            tee = Tee(ab, a_path, b_path)
+            a.write(b"3")
+            b.write(b"4")
 
-        a.close()
-        b.close()
+        tee.close()
 
-        with open(a_path, "rb") as f:
-            self.assertEqual(f.read(), b"13")
-        with open(b_path, "rb") as f:
-            self.assertEqual(f.read(), b"24")
         with open(ab_path, "rb") as f:
-            self.assertEqual(f.read(), b"1234")
-
-    def test_basic(self) -> None:
-        a_path = os.path.join(self.test_dir, "a")
-        b_path = os.path.join(self.test_dir, "b")
-        a = Tee(
-            io.open(a_path, "wb", buffering=0),
-            io.open(b_path, "wb", buffering=0),
-        )
-        self.assertEqual(a.mode, "wb")
-        self.assertEqual(a.name, a_path)
-        self.assertFalse(a.closed)
-        self.assertGreaterEqual(a.fileno(), 0)
-
-        self.assertFalse(a.isatty())
-        self.assertFalse(a.readable())
-        self.assertFalse(a.seekable())
-        self.assertTrue(a.writable())
-
-        with self.assertRaises(NotImplementedError):
-            a.read()
-        with self.assertRaises(NotImplementedError):
-            a.readline()
-        with self.assertRaises(NotImplementedError):
-            a.readlines()
-        with self.assertRaises(NotImplementedError):
-            a.seek(0)
-        with self.assertRaises(NotImplementedError):
-            a.tell()
-        with self.assertRaises(NotImplementedError):
-            a.truncate()
-        with self.assertRaises(NotImplementedError):
-            list(a)
-
-        with a as f:
-            self.assertEqual(f, a)
-
-        a.write(b"1\n")
-        a.writelines([b"2\n", b"3\n"])
-        a.flush()
-
-        a.close()
-        self.assertTrue(a.closed)
-
-        with open(a_path, "rb") as f:
-            self.assertEqual(f.read(), b"1\n2\n3\n")
-        with open(b_path, "rb") as f:
-            self.assertEqual(f.read(), b"1\n2\n3\n")
-
-    def test_fileno(self) -> None:
-        a_path = os.path.join(self.test_dir, "a")
-        ab_path = os.path.join(self.test_dir, "ab")
-
-        ab = io.open(ab_path, "wb", buffering=0)
-        a = Tee(io.open(a_path, "wb", buffering=0), ab)
-
-        w: io.FileIO = io.open(a.fileno(), "wb", buffering=0)
-        w.write(b"1")
-        w.write(b"3")
-
-        a.close()
-
-        with open(a_path, "rb") as f:
-            self.assertEqual(f.read(), b"13")
+            self.assertCountEqual(f.read(), b"1234")


### PR DESCRIPTION
<!-- Change Summary -->

       WARNING: select() can monitor only file descriptors numbers that
       are less than FD_SETSIZE (1024)—an unreasonably low limit for
       many modern applications—and this limitation will not change.
       All modern applications should instead use poll(2) or epoll(7),
       which do not suffer this limitation.

https://man7.org/linux/man-pages/man2/select.2.html

:man_facepalming: 

This also adds an extra close to the write side of the pipe to make sure we're not leaking any FDs.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pytest
pyre
```
