### PR TITLE
docs: add banner for Meta employees

### DIFF
--- a/docs/source/_static/css/torchx.css
+++ b/docs/source/_static/css/torchx.css
@@ -42,3 +42,11 @@ article.pytorch-article .py dt span.pre {
   font: inherit;
   color: inherit;
 }
+
+#redirect-banner {
+  border-bottom: 1px solid #e2e2e2;
+}
+#redirect-banner > p {
+  margin: 0.8rem;
+  text-align: center;
+}

--- a/docs/source/_static/js/torchx.js
+++ b/docs/source/_static/js/torchx.js
@@ -44,3 +44,8 @@ if (downloadNote.length >= 1) {
     console.log("hiding")
     $(".pytorch-call-to-action-links").hide();
 }
+
+const NETWORK_TEST_URL = 'https://staticdocs.thefacebook.com/ping';
+fetch(NETWORK_TEST_URL).then(() => {
+    $("#redirect-banner").prependTo("body").show();
+});

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,11 +1,22 @@
 {% extends "!layout.html" %}
 
+
 {% block sidebartitle %}
     <div class="version">
       <a href='/torchx/versions.html'>{{ version }} &#x25BC</a>
     </div>
     {% include "searchbox.html" %}
 {% endblock %}
+
+{%- block extrabody %}
+  <div id="redirect-banner" style="display: none">
+    <p>
+      This is the public documentation. There's an internal wiki with extra
+      information for Meta employees at
+      <a href="https://fburl.com/torchx">https://fburl.com/torchx</a>
+    </p>
+  </div>
+{%- endblock %}
 
 {%- block content %}
   {% if pagename.startswith("examples") %}


### PR DESCRIPTION
<!-- Change Summary -->

This adds a banner to link to Meta specific documentation. This makes a query against an internal endpoint and if it succeeds it displays the banner.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
cd docs && make clean html
```
view site with VPN and without

![Screenshot 2021-11-08 at 14-55-35 TorchX — PyTorch TorchX main documentation](https://user-images.githubusercontent.com/909104/140832667-7dc2308e-1832-4b99-a418-b158c951e8bb.png)
![Screenshot 2021-11-08 at 14-55-21 TorchX — PyTorch TorchX main documentation](https://user-images.githubusercontent.com/909104/140832673-9d27ee6c-c302-4781-8447-eda2f973e5f0.png)
