### PR TITLE
(torchx/runner) split run_component into run_component and dryrun_component instead of overloading it

### DIFF
--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -373,18 +373,19 @@ class RunnerTest(unittest.TestCase):
             local_sched_mock.submit.called_once_with(app, cfg)
 
     def test_run_from_module(self, _) -> None:
-        local_sched_mock = MagicMock()
-        schedulers = {"local_dir": local_sched_mock, "local": local_sched_mock}
-        with Runner(name="test_session", schedulers=schedulers) as runner:
-            app_args = ["--image", "dummy_image", "--script", "test.py"]
-            with patch.object(runner, "run") as run_mock:
-                _ = runner.run_component("dist.ddp", app_args, "local")
-                args, kwargs = run_mock.call_args
-                actual_app = args[0]
+        runner = get_runner(name="test_session")
+        app_args = ["--image", "dummy_image", "--script", "test.py"]
+        with patch.object(runner, "schedule") as schedule_mock, patch.object(
+            runner, "dryrun"
+        ) as dryrun_mock:
+            _ = runner.run_component("dist.ddp", app_args, "local")
+            args, kwargs = dryrun_mock.call_args
+            actual_app = args[0]
 
-            self.assertEqual(actual_app.name, "test")
-            self.assertEqual(1, len(actual_app.roles))
-            self.assertEqual("test", actual_app.roles[0].name)
+        print(actual_app)
+        self.assertEqual(actual_app.name, "test")
+        self.assertEqual(1, len(actual_app.roles))
+        self.assertEqual("test", actual_app.roles[0].name)
 
     def test_run_from_file_no_function_found(self, _) -> None:
         local_sched_mock = MagicMock()

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -222,10 +222,9 @@ class GetBuiltinSourceTest(unittest.TestCase):
         runner = get_runner()
         app_handle = runner.run_component(
             scheduler="local_cwd",
-            component_name=f"{str(echo_copy)}:echo",
-            app_args=["--msg", "hello world"],
+            component=f"{str(echo_copy)}:echo",
+            component_args=["--msg", "hello world"],
         )
-        # pyre-ignore[6]: remove this line after https://github.com/pytorch/torchx/issues/331
         status = runner.wait(app_handle, wait_interval=0.1)
         self.assertIsNotNone(status)
         self.assertEqual(AppState.SUCCEEDED, status.state)
@@ -249,15 +248,14 @@ class GetBuiltinSourceTest(unittest.TestCase):
         app_handle = runner.run_component(
             scheduler="local_cwd",
             cfg=RunConfig({"prepend_cwd": True}),
-            component_name=f"{str(booth_copy)}:booth",
-            app_args=[
+            component=f"{str(booth_copy)}:booth",
+            component_args=[
                 "--x1=1",
                 "--x2=3",
                 f"--trial_idx={trial_idx}",
                 f"--tracker_base={tracker_base}",
             ],
         )
-        # pyre-ignore[6]: remove this line after https://github.com/pytorch/torchx/issues/331
         status = runner.wait(app_handle, wait_interval=0.1)
         self.assertIsNotNone(status)
         self.assertEqual(AppState.SUCCEEDED, status.state)


### PR DESCRIPTION
Summary: Closes: https://github.com/pytorch/torchx/issues/331

Differential Revision: D32338074

