### PR TITLE
Make `copy` component to create directories for `dst` path

### DIFF
--- a/torchx/apps/utils/copy_main.py
+++ b/torchx/apps/utils/copy_main.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import os
 import shutil
 import sys
 from typing import List
@@ -45,6 +46,12 @@ def main(argv: List[str]) -> None:
 
     src_fs, src_path = fsspec.core.url_to_fs(args.src)
     dst_fs, dst_path = fsspec.core.url_to_fs(args.dst)
+    dst_dir_path = os.path.dirname(dst_path)
+    try:
+        dst_fs.mkdir(dst_dir_path, create_parents=True)
+    except FileExistsError:
+        # Some fs, e.g. memory://, raise this exception if the dir already exists.
+        pass
 
     if src_fs == dst_fs:
         print("filesystems are the same, using fs.copy() method")

--- a/torchx/apps/utils/test/copy_test.py
+++ b/torchx/apps/utils/test/copy_test.py
@@ -41,6 +41,6 @@ class CopyTest(unittest.TestCase):
     def test_different_fs(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             src = "memory://foo"
-            dst = "file://" + os.path.join(tmpdir, "bar")
+            dst = "file://" + os.path.join(tmpdir, "foo", "bar")
 
             self._copy(src, dst)


### PR DESCRIPTION
Summary:
Make `copy` component to create directories for `dst` path

This should resolve https://github.com/pytorch/torchx/issues/340 issue

Differential Revision: D32449132

