### PR TITLE
Remove unnecessary `to upper` named resource translation

### DIFF
--- a/torchx/components/base/__init__.py
+++ b/torchx/components/base/__init__.py
@@ -23,7 +23,7 @@ def _resolve_resource(resource: Union[str, Resource]) -> Resource:
     if isinstance(resource, Resource):
         return resource
     else:
-        return named_resources[resource.upper()]
+        return named_resources[resource]
 
 
 def torch_dist_role(


### PR DESCRIPTION
Summary: Remove unnecessary `to upper` named resource translation

Reviewed By: kiukchung

Differential Revision: D32471240

