### PR TITLE
torchx/runner,cli: add patching support via WorkspaceScheduler

### DIFF
--- a/torchx/runner/test/workspaces_test.py
+++ b/torchx/runner/test/workspaces_test.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Mapping
+from unittest.mock import MagicMock, call
+
+from torchx.runner.workspaces import (
+    get_workspace_runner,
+    WorkspaceRunner,
+)
+from torchx.schedulers.api import (
+    WorkspaceScheduler,
+)
+from torchx.specs.api import AppDryRunInfo, AppDef, CfgVal
+
+
+class WorkspaceRunnerTest(unittest.TestCase):
+    def test_get_workspace_runner(self) -> None:
+        self.assertIsInstance(get_workspace_runner(), WorkspaceRunner)
+
+    def test_workspace_runner(self) -> None:
+        scheduler = MagicMock(spec=WorkspaceScheduler)
+
+        def submit_dryrun(app: AppDef, cfg: Mapping[str, CfgVal]) -> AppDryRunInfo[str]:
+            self.assertEqual(app.roles[0].image, "$img")
+
+            dryrun_info: AppDryRunInfo[str] = AppDryRunInfo(str("req"), str)
+            dryrun_info._app = app
+            return dryrun_info
+
+        scheduler.submit_dryrun = submit_dryrun
+        scheduler.build_workspace_image.return_value = "$img"
+        runner = WorkspaceRunner(
+            "workspaces_test",
+            schedulers={
+                "mock": scheduler,
+            },
+        )
+        app_args = ["--image", "dummy_image", "--script", "test.py"]
+        workspace = "memory:///foo"
+        ret = runner.run_component("dist.ddp", app_args, "mock", workspace)
+
+        self.assertEqual(
+            scheduler.build_workspace_image.mock_calls,
+            [
+                call("dummy_image", workspace),
+            ],
+        )

--- a/torchx/runner/workspaces.py
+++ b/torchx/runner/workspaces.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This contains an experimental patching runner that can overlay a workspace on
+top of the provided image. This allows for fast iterations without having to
+rebuild a new image with your application code.
+
+The workspace is a fsspec filesystem that gets walked and overlaid on the image.
+This allows having multiple different interfaces such as from Jupyter Notebooks
+as well as local file systems.
+"""
+
+import logging
+import warnings
+from typing import List, Mapping, Optional
+
+from torchx.runner.api import Runner
+from torchx.schedulers import get_schedulers
+from torchx.schedulers.api import WorkspaceScheduler
+from torchx.specs import (
+    from_function,
+    AppDef,
+    SchedulerBackend,
+    AppHandle,
+    CfgVal,
+    AppDryRunInfo,
+)
+from torchx.specs.finder import get_component
+
+log: logging.Logger = logging.getLogger(__name__)
+
+
+class WorkspaceRunner(Runner):
+    """
+    WorkspaceRunner is a special runner that takes an optional workspace
+    argument for the run and dryrun_component methods. If a workspace is
+    specified a new image will be built with the workspace overlaid on top.
+
+    WARNING: This is in prototype stage and may have backwards incompatible
+    changes made without notice.
+    """
+
+    def run_component(
+        self,
+        component: str,
+        component_args: List[str],
+        scheduler: SchedulerBackend,
+        workspace: Optional[str],
+        cfg: Optional[Mapping[str, CfgVal]] = None,
+    ) -> AppHandle:
+        dryrun_info = self.dryrun_component(
+            component,
+            component_args,
+            scheduler,
+            workspace,
+            cfg,
+        )
+        return self.schedule(dryrun_info)
+
+    def dryrun_component(
+        self,
+        component: str,
+        component_args: List[str],
+        scheduler: SchedulerBackend,
+        workspace: Optional[str],
+        cfg: Optional[Mapping[str, CfgVal]] = None,
+    ) -> AppDryRunInfo:
+        component_def = get_component(component)
+        app = from_function(component_def.fn, component_args)
+        return self.dryrun(app, scheduler, workspace, cfg)
+
+    def dryrun(
+        self,
+        app: AppDef,
+        scheduler: SchedulerBackend,
+        workspace: Optional[str],
+        cfg: Optional[Mapping[str, CfgVal]] = None,
+    ) -> AppDryRunInfo:
+        if workspace:
+            self._patch_app(app, scheduler, workspace)
+
+        return super().dryrun(app, scheduler, cfg)
+
+    def _patch_app(self, app: AppDef, scheduler: str, workspace: str) -> None:
+        sched = self._scheduler(scheduler)
+        if not isinstance(sched, WorkspaceScheduler):
+            warnings.warn(
+                f"can't apply workspace to image since {sched} is not a "
+                "WorkspaceScheduler"
+            )
+            return
+
+        log.info(f"building patch images for workspace: {workspace}...")
+
+        images = {}
+        for role in app.roles:
+            img = images.get(role.image)
+            if not img:
+                img = sched.build_workspace_image(role.image, workspace)
+                images[role.image] = img
+            role.image = img
+
+    def __enter__(self) -> "WorkspaceRunner":
+        return self
+
+
+def get_workspace_runner(
+    name: Optional[str] = None, **scheduler_params: object
+) -> WorkspaceRunner:
+    """
+    Returns a WorkspaceRunner. See torchx.runner.get_runner for more info.
+    """
+    if not name:
+        name = "torchx"
+
+    schedulers = get_schedulers(session_name=name, **scheduler_params)
+    return WorkspaceRunner(name, schedulers)

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -280,6 +280,22 @@ class Scheduler(abc.ABC):
                 )
 
 
+class WorkspaceScheduler(Scheduler):
+    """
+    WorkspaceScheduler is a Scheduler that has workspace support.
+
+    Experimental: this interface may change without notice.
+    """
+
+    @abc.abstractmethod
+    def build_workspace_image(self, img: str, workspace: str) -> str:
+        """
+        build_workspace_image builds a new image with the workspace filesystem
+        overlaid on it and returns the new image name.
+        """
+        ...
+
+
 def filter_regex(regex: str, data: Iterable[str]) -> Iterable[str]:
     """
     filter_regex takes a string iterator and returns an iterator that only has

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -31,7 +31,7 @@ import yaml
 from torchx.schedulers.api import (
     AppDryRunInfo,
     DescribeAppResponse,
-    Scheduler,
+    WorkspaceScheduler,
     filter_regex,
     Stream,
 )
@@ -102,7 +102,7 @@ def has_docker() -> bool:
         return False
 
 
-class DockerScheduler(Scheduler):
+class DockerScheduler(WorkspaceScheduler):
     """
     DockerScheduler is a TorchX scheduling interface to Docker.
 
@@ -415,7 +415,6 @@ class DockerScheduler(Scheduler):
 
         Returns:
             The new Docker image ID.
-
         """
         return _build_container_from_workspace(self._client(), img, workspace)
 
@@ -444,7 +443,6 @@ def _copy_to_tarfile(workspace: str, tf: tarfile.TarFile) -> None:
         assert isinstance(dir, str), "path must be str"
         relpath = posixpath.relpath(dir, path)
         for file, info in files.items():
-            print(relpath, dir, file, info)
             with fs.open(info["name"], "rb") as f:
                 tinfo = tarfile.TarInfo(posixpath.join(relpath, file))
                 tinfo.size = info["size"]
@@ -486,5 +484,5 @@ def _build_container_from_workspace(
         )
     finally:
         context.close()
-    print(image)
+
     return image.id


### PR DESCRIPTION
<!-- Change Summary -->

This adds patching support to the cli and runner. 

To keep this somewhat isolated from the main APIs there's now a couple of new concepts:
* WorkspaceScheduler extends Scheduler and adds a build_workspace_image
* WorkspaceRunner extends Runner and adds support for building a workspace image as part of dryrun

This makes the cli run command use the WorkspaceRunner instead of the normal Runner for experimentation purposes.

Patching is enabled if the cwd contains a .torchxconfig file.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ touch .torchxconfig
$ echo "echo foo" > foo.sh
$ torchx run --scheduler local_docker utils.sh sh foo.sh
torchx 2021-12-10 16:24:19 INFO     loaded configs from /home/tristanr/Developer/torchx-proj/.torchxconfig
torchx 2021-12-10 16:24:19 INFO     building patch images for workspace: file:///home/tristanr/Developer/torchx-proj...
torchx 2021-12-10 16:24:21 INFO     Pulling container image: sha256:0da419b5accdba18412014ffeafcf782acd53d6522a198ee7cbfb48556f355be (this may take a while)
torchx 2021-12-10 16:24:23 WARNING  failed to pull image sha256:0da419b5accdba18412014ffeafcf782acd53d6522a198ee7cbfb48556f355be, falling back to local: 404 Client Error for htt
p+docker://localhost/v1.41/images/create?tag=0da419b5accdba18412014ffeafcf782acd53d6522a198ee7cbfb48556f355be&fromImage=sha256: Not Found ("pull access denied for sha256, reposi
tory does not exist or may require 'docker login': denied: requested access to the resource is denied")
local_docker://torchx/sh-g7frzl4q92g2bd
torchx 2021-12-10 16:24:24 INFO     Waiting for the app to finish...
torchx 2021-12-10 16:24:24 INFO     Job finished: SUCCEEDED
sh/0 foo
```
