### PR TITLE
Move `poll_trial_status` and `poll_available_capacity` to `TorchXRunner`, remove `TorchXScheduler`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 aiobotocore==2.1.0
-ax-platform[mysql]==0.2.2
+ax-platform[mysql]==0.2.3
 black==21.10b0
 boto3==1.20.24
 captum>=0.4.0

--- a/docs/source/runtime/hpo.rst
+++ b/docs/source/runtime/hpo.rst
@@ -14,5 +14,4 @@ Ax (Adaptive Experimentation)
 .. currentmodule:: torchx.runtime.hpo.ax
 
 .. autoclass:: TorchXRunner
-.. autoclass:: TorchXScheduler
 .. autoclass:: AppMetric

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -45,7 +45,7 @@ class CmdRunTest(unittest.TestCase):
         self.cmd_run.add_arguments(self.parser)
 
     def tearDown(self) -> None:
-        shutil.rmtree(self.tmpdir)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def test_run_with_user_conf_abs_path(self) -> None:
         args = self.parser.parse_args(

--- a/torchx/runtime/hpo/__init__.py
+++ b/torchx/runtime/hpo/__init__.py
@@ -54,13 +54,13 @@ find ``x1`` and ``x2`` that minimizes the booth function.
     SearchSpace,
  )
  from ax.modelbridge.dispatch_utils import choose_generation_strategy
- from ax.service.scheduler import SchedulerOptions
+ from ax.service.scheduler import SchedulerOptions, Scheduler
  from ax.service.utils.best_point import get_best_parameters
  from ax.service.utils.report_utils import exp_to_df
  from ax.utils.common.constants import Keys
  from pyre_extensions import none_throws
  from torchx.components import utils
- from torchx.runtime.hpo.ax import AppMetric, TorchXRunner, TorchXScheduler
+ from torchx.runtime.hpo.ax import AppMetric, TorchXRunner
 
  # Run HPO on the booth function (https://en.wikipedia.org/wiki/Test_functions_for_optimization)
 
@@ -100,7 +100,7 @@ find ``x1`` and ``x2`` that minimizes the booth function.
      properties={Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF: True},
  )
 
- scheduler = TorchXScheduler(
+ scheduler = Scheduler(
      experiment=experiment,
      generation_strategy=(
          choose_generation_strategy(

--- a/torchx/runtime/hpo/test/ax_test.py
+++ b/torchx/runtime/hpo/test/ax_test.py
@@ -22,14 +22,14 @@ from ax.core import (
     SearchSpace,
 )
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
-from ax.service.scheduler import SchedulerOptions
+from ax.service.scheduler import SchedulerOptions, Scheduler
 from ax.service.utils.report_utils import exp_to_df
 from ax.utils.common.constants import Keys
 from torchx.components import utils
-from torchx.runtime.hpo.ax import AppMetric, TorchXRunner, TorchXScheduler
+from torchx.runtime.hpo.ax import AppMetric, TorchXRunner
 
 
-class TorchXSchedulerTest(unittest.TestCase):
+class TorchXAxTest(unittest.TestCase):
     def setUp(self) -> None:
         self.test_dir = tempfile.mkdtemp("torchx_runtime_hpo_ax_test")
 
@@ -84,7 +84,7 @@ class TorchXSchedulerTest(unittest.TestCase):
 
         # maybe add-on cfg into SchedulerOption?
         # so that we can pass it from one place
-        scheduler = TorchXScheduler(
+        scheduler = Scheduler(
             experiment=experiment,
             generation_strategy=(
                 choose_generation_strategy(
@@ -114,7 +114,7 @@ class TorchXSchedulerTest(unittest.TestCase):
             is_test=True,
             properties={Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF: True},
         )
-        scheduler = TorchXScheduler(
+        scheduler = Scheduler(
             experiment=experiment,
             generation_strategy=(
                 choose_generation_strategy(
@@ -152,7 +152,7 @@ class TorchXSchedulerTest(unittest.TestCase):
 
         # maybe add-on cfg into SchedulerOption?
         # so that we can pass it from one place
-        scheduler = TorchXScheduler(
+        scheduler = Scheduler(
             experiment=experiment,
             generation_strategy=(
                 choose_generation_strategy(


### PR DESCRIPTION
Summary:
Adjusting the TorchX setup following D31031589 and D31032567
Deprecate `torchx.runtime.hpo.ax.TorchXScheduler`

Differential Revision: D33062113

