### PR TITLE
add IPython tests exclude to Pyre config

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -2,7 +2,8 @@
   "exclude": [
     ".*/build/.*",
     ".*/docs/.*",
-    ".*/setup.py"
+    ".*/setup.py",
+    ".*/IPython/core/tests/nonascii.*"
   ],
   "source_directories": [
     "."


### PR DESCRIPTION
<!-- Change Summary -->

IPython causes pyre to crash for some unknown reason. This excludes those files

https://fb.workplace.com/groups/pyreqa/posts/4723678241055304/?comment_id=4752013021555159&reply_comment_id=4752152538207874

D33198235


Test plan:
<!--  How you tested the change, ideally with a unit test :) -->



CI
