### PR TITLE
improve local scheduler log ordering

### DIFF
--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -676,6 +676,9 @@ class LocalScheduler(Scheduler):
             else:
                 env["PATH"] = join_PATH(env.get("PATH"), cwd)
 
+        # default to unbuffered python for faster responsiveness locally
+        env.setdefault("PYTHONUNBUFFERED", "x")
+
         args_pfmt = pprint.pformat(asdict(replica_params), indent=2, width=80)
         log.debug(f"Running {role_name} (replica {replica_id}):\n {args_pfmt}")
 


### PR DESCRIPTION
Summary:
This sets `PYTHONUNBUFFERED` to improve local scheduler logging latency. With this set each python log line gets immediately written out so you avoid large blocks of logs from the buffering. It also preserves groups unlike `readline()` since a stack trace will be written out as a single write

There's can still be some small amount of ordering mismatches but it's better than it was before

Differential Revision: D33433782

