### PR TITLE
slurm_scheduler: inherit cwd instead of image + skip mem request via cfg

### DIFF
--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -54,7 +54,21 @@ class SlurmSchedulerTest(unittest.TestCase):
         )
         self.assertEqual(
             srun,
-            ["--chdir=/some/path", "--export=FOO=bar", "echo", "'hello slurm'", "test"],
+            ["--export=FOO=bar", "echo", "'hello slurm'", "test"],
+        )
+
+        # test nomem option
+        sbatch, srun = SlurmReplicaRequest.from_role(
+            "role-name", role, cfg={"nomem": True}
+        ).materialize()
+        self.assertEqual(
+            sbatch,
+            [
+                "--job-name=role-name",
+                "--ntasks-per-node=1",
+                "--cpus-per-task=2",
+                "--gpus-per-task=3",
+            ],
         )
 
     def test_replica_request_app_id(self) -> None:
@@ -135,9 +149,9 @@ class SlurmSchedulerTest(unittest.TestCase):
 # exit on error
 set -e
 
-srun --chdir=/some/path echo 0 'hello '"$SLURM_JOB_ID"'' :\\
-     --chdir=/some/path echo 1 'hello '"$SLURM_JOB_ID"'' :\\
-     --chdir=/some/path echo
+srun echo 0 'hello '"$SLURM_JOB_ID"'' :\\
+     echo 1 'hello '"$SLURM_JOB_ID"'' :\\
+     echo
 """,
         )
 


### PR DESCRIPTION
<!-- Change Summary -->

This makes the slurm_scheduler inherit the local cwd instead of specifying chdir to the image to better match the behavior of local_cwd and the other schedulers. It also adds a `nomem=true` cfg option so you can avoid requesting memory on pcluster nodes

Fixes  #371 
Fixes #359

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pytest torchx/schedulers/test/slurm_scheduler_test.py
scripts/slurmint.sh
```

CI