### PR TITLE
slurm_scheduler: add support for per replica log files and API access

### DIFF
--- a/scripts/slurmtest.sh
+++ b/scripts/slurmtest.sh
@@ -18,12 +18,12 @@ source "$VENV"/bin/activate
 python --version
 pip install "$REMOTE_WHEEL"
 
-APP_ID="$(torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10 utils.echo --image /tmp --num_replicas 3)"
+APP_ID="$(torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10 utils.echo --num_replicas 3)"
 torchx status "$APP_ID"
 torchx describe "$APP_ID"
-LOG_FILE="slurm-$(basename "$APP_ID").out"
-cat "$LOG_FILE"
-LINES="$(wc -l "$LOG_FILE" | cut -d' ' -f1)"
+sacct -j "$(basename "$APP_ID")"
+torchx log "$APP_ID"
+LINES="$(torchx log "$APP_ID" | wc -l)"
 
 if [ "$LINES" -ne 3 ]
 then

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -909,14 +909,19 @@ class LocalScheduler(Scheduler):
 
 class LogIterator:
     def __init__(
-        self, app_id: str, regex: str, log_file: str, scheduler: LocalScheduler
+        self,
+        app_id: str,
+        regex: str,
+        log_file: str,
+        scheduler: Scheduler,
+        should_tail: bool = True,
     ) -> None:
         self._app_id: str = app_id
         self._regex: Pattern[str] = re.compile(regex)
         self._log_file: str = log_file
         self._log_fp: Optional[TextIO] = None
-        self._scheduler: LocalScheduler = scheduler
-        self._app_finished: bool = False
+        self._scheduler: Scheduler = scheduler
+        self._app_finished: bool = not should_tail
 
     def _check_finished(self) -> None:
         # either the app (already finished) was evicted from the LRU cache


### PR DESCRIPTION
<!-- Change Summary -->

This adds `torchx log` support to the slurm scheduler.  #371

It writes out a `slurm-<jobid>-<role>-<replica_id>.out` per worker with the combined stdout/stderr. We may want to split these in the future but for now it's fine. These files are logged out to the cwd per normal slurm behavior so `torchx log` will stop working if the user changes their working directory.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pytest torchx/schedulers/test/slurm_scheduler_test.py
scripts/slurmint.sh
```

Updated integration test to use `torchx log` instead of `slurm-<id>.out`
