### PR TITLE
schedulers/kubernetes_scheduler: add workspace/patching support

### DIFF
--- a/docs/source/ext/compatibility.py
+++ b/docs/source/ext/compatibility.py
@@ -16,6 +16,7 @@ COMPATIBILITY_SETS = {
         "distributed": "Distributed Jobs",
         "cancel": "Cancel Job",
         "describe": "Describe Job",
+        "workspaces": "Workspaces / Patching",
     },
 }
 

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -160,7 +160,8 @@ class CmdRunTest(unittest.TestCase):
         self.cmd_run.run(args)
         mock_runner_run.assert_not_called()
 
-    def test_runopts_not_found(self) -> None:
+    @patch("torchx.runner.workspaces.WorkspaceRunner._patch_app")
+    def test_runopts_not_found(self, patch_app: MagicMock) -> None:
         args = self.parser.parse_args(
             [
                 "--dryrun",

--- a/torchx/runner/workspaces.py
+++ b/torchx/runner/workspaces.py
@@ -103,6 +103,7 @@ class WorkspaceRunner(Runner):
             img = images.get(role.image)
             if not img:
                 img = sched.build_workspace_image(role.image, workspace)
+                log.info(f"built image {img} from {role.image}")
                 images[role.image] = img
             role.image = img
 

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -127,6 +127,7 @@ class DockerScheduler(WorkspaceScheduler):
             describe: |
                 Partial support. DockerScheduler will return job and replica
                 status but does not provide the complete original AppSpec.
+            workspaces: true
     """
 
     def __init__(self, session_name: str) -> None:
@@ -416,7 +417,7 @@ class DockerScheduler(WorkspaceScheduler):
         Returns:
             The new Docker image ID.
         """
-        return _build_container_from_workspace(self._client(), img, workspace)
+        return build_container_from_workspace(self._client(), img, workspace)
 
 
 def _to_str(a: Union[str, bytes]) -> str:
@@ -467,9 +468,13 @@ def _build_context(img: str, workspace: str) -> IO[bytes]:
     return f
 
 
-def _build_container_from_workspace(
+def build_container_from_workspace(
     client: "DockerClient", img: str, workspace: str
 ) -> str:
+    """
+    build_container_from_workspace creates a new Docker container with the
+    workspace filesystem applied as a layer on top of the provided base image.
+    """
     context = _build_context(img, workspace)
 
     try:

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -548,6 +548,9 @@ class LocalScheduler(Scheduler):
                 LocalScheduler supports multiple replicas but all replicas will
                 execute on the local host.
             describe: true
+            workspaces: |
+                Partial support. LocalScheduler runs the app from a local
+                directory but does not support programmatic workspaces.
     """
 
     def __init__(

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -240,6 +240,11 @@ class SlurmScheduler(Scheduler):
             describe: |
                 Partial support. SlurmScheduler will return job and replica
                 status but does not provide the complete original AppSpec.
+            workspaces: |
+                Partial support. Typical Slurm usage is from a shared NFS mount
+                so code will automatically be updated on the workers.
+                SlurmScheduler does not support programmatic patching via
+                WorkspaceScheduler.
 
     """
 


### PR DESCRIPTION
<!-- Change Summary -->

This adds patching support to the kubernetes scheduler. It requires you to specify `image_repo` as a config option with the docker repository to push to.

If the dryrun/schedule methods find a local image such as `sha256:...` it'll remap it to a remote repo package and push it during schedule.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pyre
pytest torchx/schedulers/test/kubernetes_scheduler_test.py
```

```
(torchx) tristanr@tristanr-arch2 ~/D/torchx-proj> torchx run --scheduler kubernetes -c queue=default,image_repo=495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/integration-tests --wait --log utils.sh sh foo.sh
torchx 2022-02-09 15:51:12 INFO     loaded configs from /home/tristanr/Developer/torchx-proj/.torchxconfig
torchx 2022-02-09 15:51:12 INFO     building patch images for workspace: file:///home/tristanr/Developer/torchx-proj...
torchx 2022-02-09 15:51:13 INFO     built image sha256:d1cd394f88861a5ca18de88cc0801513cd6c3dc7d945f7cbfe7121bb1d552bec from ghcr.io/pytorch/torchx:0.1.2dev0
torchx 2022-02-09 15:51:14 INFO     pushing image 495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/integration-tests:d1cd394f88861a5ca18de88cc0801513cd6c3dc7d945f7cbfe7121bb1d552bec...
torchx 2022-02-09 15:51:14 INFO     docker: {'status': 'The push refers to repository [495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/integration-tests]'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': '004e5e059580'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': 'de1d3a8ac491'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': 'e6d41c036803'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': '0827b8e37332'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': 'a8496aa14f72'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': '1f84c52a7d38'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': '0f801b69538d'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': '354dfcbe6a14'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': 'f15a0881ce19'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Preparing', 'progressDetail': {}, 'id': '824bf068fd3d'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Waiting', 'progressDetail': {}, 'id': '1f84c52a7d38'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Waiting', 'progressDetail': {}, 'id': '824bf068fd3d'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Waiting', 'progressDetail': {}, 'id': 'f15a0881ce19'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Waiting', 'progressDetail': {}, 'id': '0f801b69538d'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Waiting', 'progressDetail': {}, 'id': '354dfcbe6a14'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': '0827b8e37332'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': 'de1d3a8ac491'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': 'e6d41c036803'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': '004e5e059580'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': 'a8496aa14f72'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': '824bf068fd3d'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': '0f801b69538d'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': '1f84c52a7d38'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': 'f15a0881ce19'}
torchx 2022-02-09 15:51:15 INFO     docker: {'status': 'Layer already exists', 'progressDetail': {}, 'id': '354dfcbe6a14'}
torchx 2022-02-09 15:51:16 INFO     docker: {'status': 'd1cd394f88861a5ca18de88cc0801513cd6c3dc7d945f7cbfe7121bb1d552bec: digest: sha256:da9fba179cb37f2f6d6d09c16dc4f0c39ca84a6fbb767c0aff7b77738b608805 size: 2413'}
torchx 2022-02-09 15:51:16 INFO     docker: {'progressDetail': {}, 'aux': {'Tag': 'd1cd394f88861a5ca18de88cc0801513cd6c3dc7d945f7cbfe7121bb1d552bec', 'Digest': 'sha256:da9fba179cb37f2f6d6d09c16dc4f0c39ca84a6fbb767c0aff7b77738b608805', 'Size': 2413}}
kubernetes://torchx/default:sh-n71zqm25lrk61
torchx 2022-02-09 15:51:17 INFO     Launched app: kubernetes://torchx/default:sh-n71zqm25lrk61
torchx 2022-02-09 15:51:17 INFO     AppStatus:
  msg: <NONE>
  num_restarts: -1
  roles: []
  state: PENDING (2)
  structured_error_msg: <NONE>
  ui_url: null

torchx 2022-02-09 15:51:17 INFO     Job URL: None
torchx 2022-02-09 15:51:17 INFO     Waiting for the app to finish...
torchx 2022-02-09 15:51:17 INFO     Waiting for app to start before logging...
torchx 2022-02-09 15:51:22 INFO     Job finished: SUCCEEDED
sh/0 2022-02-09T23:51:21.702981500Z foo
```
