### PR TITLE
github/workflows: switch to configure-aws-credentials

### DIFF
--- a/.github/workflows/aws-batch-integration-tests.yaml
+++ b/.github/workflows/aws-batch-integration-tests.yaml
@@ -20,20 +20,12 @@ jobs:
           architecture: x64
       - name: Checkout TorchX
         uses: actions/checkout@v2
-      - name: Configure AWS
-        env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-        run: |
-          if [ -n "$AWS_ROLE_ARN" ]; then
-            export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-            export AWS_DEFAULT_REGION=us-west-2
-
-            echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-            echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-            echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
-
-            curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-          fi
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-torchx
       - name: Install dependencies
         run: |
           set -eux

--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -20,20 +20,12 @@ jobs:
           architecture: x64
       - name: Checkout TorchX
         uses: actions/checkout@v2
-      - name: Configure AWS
-        env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-        run: |
-          if [ -n "$AWS_ROLE_ARN" ]; then
-            export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-            export AWS_DEFAULT_REGION=us-west-2
-
-            echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-            echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-            echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
-
-            curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-          fi
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-torchx
       - name: Configure Kube Config
         env:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/kfp-integration-tests.yaml
+++ b/.github/workflows/kfp-integration-tests.yaml
@@ -21,20 +21,12 @@ jobs:
           mkdir -p ~/.local/bin/kubectl
           mv ./kubectl ~/.local/bin/kubectl
           export PATH=$PATH:~/.local/bin/kubectl
-      - name: Configure AWS
-        env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-        run: |
-          if [ -n "$AWS_ROLE_ARN" ]; then
-            export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-            export AWS_DEFAULT_REGION=us-west-2
-
-            echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-            echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-            echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
-
-            curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-          fi
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-torchx
       - name: Configure Kube Config
         env:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/kubernetes-dist-train-integration-tests.yaml
+++ b/.github/workflows/kubernetes-dist-train-integration-tests.yaml
@@ -20,20 +20,12 @@ jobs:
           architecture: x64
       - name: Checkout TorchX
         uses: actions/checkout@v2
-      - name: Configure AWS
-        env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-        run: |
-          if [ -n "$AWS_ROLE_ARN" ]; then
-            export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-            export AWS_DEFAULT_REGION=us-west-2
-
-            echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-            echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-            echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
-
-            curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-          fi
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-torchx
       - name: Configure Kube Config
         env:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/slurm-integration-tests.yaml
+++ b/.github/workflows/slurm-integration-tests.yaml
@@ -20,20 +20,12 @@ jobs:
           architecture: x64
       - name: Checkout TorchX
         uses: actions/checkout@v2
-      - name: Configure AWS
-        env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-        run: |
-          if [ -n "$AWS_ROLE_ARN" ]; then
-            export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-            export AWS_DEFAULT_REGION=us-west-2
-
-            echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-            echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-            echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
-
-            curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-          fi
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-torchx
       - name: Install Dependencies
         run:
           set -ex


### PR DESCRIPTION
<!-- Change Summary -->

Our integration tests are hitting an error when acquiring AWS credentials. 
```
botocore.errorfactory.InvalidIdentityTokenException: An error occurred (InvalidIdentityToken) when calling the AssumeRoleWithWebIdentity operation: Couldn't retrieve verification key from your identity provider,  please reference AssumeRoleWithWebIdentity documentation for requirements
```

https://github.com/pytorch/torchx/runs/5147711223?check_suite_focus=true

This switches to the `aws-actions/configure-aws-credentials` GitHub action since it includes retries as of https://github.com/aws-actions/configure-aws-credentials/pull/350

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI