### PR TITLE
github workfows: allow credentials failure for runs with no secrets

### DIFF
--- a/.github/workflows/aws-batch-integration-tests.yaml
+++ b/.github/workflows/aws-batch-integration-tests.yaml
@@ -26,11 +26,14 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: github-torchx
+        continue-on-error: true
       - name: Install dependencies
         run: |
           set -eux
           pip install -e .[dev]
       - name: Run AWS Batch Integration Tests
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           set -ex
 

--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -26,6 +26,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: github-torchx
+        continue-on-error: true
       - name: Configure Kube Config
         env:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/kfp-integration-tests.yaml
+++ b/.github/workflows/kfp-integration-tests.yaml
@@ -27,6 +27,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: github-torchx
+        continue-on-error: true
       - name: Configure Kube Config
         env:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/kubernetes-dist-train-integration-tests.yaml
+++ b/.github/workflows/kubernetes-dist-train-integration-tests.yaml
@@ -26,6 +26,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: github-torchx
+        continue-on-error: true
       - name: Configure Kube Config
         env:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/slurm-integration-tests.yaml
+++ b/.github/workflows/slurm-integration-tests.yaml
@@ -26,6 +26,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: github-torchx
+        continue-on-error: true
       - name: Install Dependencies
         run:
           set -ex

--- a/scripts/awsbatchint.sh
+++ b/scripts/awsbatchint.sh
@@ -7,14 +7,19 @@
 
 set -ex
 
-APP_ID="$(torchx run --wait --scheduler aws_batch -c queue=torchx utils.echo)"
-torchx status "$APP_ID"
-torchx describe "$APP_ID"
-torchx log "$APP_ID"
-LINES="$(torchx log "$APP_ID" | wc -l)"
+if [ -z "$AWS_ROLE_ARN" ]; then
+  # only dryrun if no secrets
+  torchx run --wait --scheduler aws_batch --dryrun -c queue=torchx utils.echo
+else
+  APP_ID="$(torchx run --wait --scheduler aws_batch -c queue=torchx utils.echo)"
+  torchx status "$APP_ID"
+  torchx describe "$APP_ID"
+  torchx log "$APP_ID"
+  LINES="$(torchx log "$APP_ID" | wc -l)"
 
-if [ "$LINES" -ne 1 ]
-then
-    echo "expected 1 log lines"
-    exit 1
+  if [ "$LINES" -ne 1 ]
+  then
+      echo "expected 1 log lines"
+      exit 1
+  fi
 fi


### PR DESCRIPTION
Summary:
https://github.com/pytorch/torchx/runs/5191403515?check_suite_focus=true

{F701191215}

Our integration tests now fail when exporting from Meta or on external PRs because there's no secrets available to run the integration tests.

We used to continue and dryrun the tests but that behavior regressed in https://github.com/pytorch/torchx/commit/adcfcd70e86176b2db579816406894d991b67ade this restores that continue behavior.

Differential Revision: D34223966

