### PR TITLE
slurm_scheduler: add more runopts. Fixes #389

### DIFF
--- a/scripts/slurmtest.sh
+++ b/scripts/slurmtest.sh
@@ -18,7 +18,7 @@ source "$VENV"/bin/activate
 python --version
 pip install "$REMOTE_WHEEL"
 
-APP_ID="$(torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10 utils.echo --num_replicas 3)"
+APP_ID="$(torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10,comment=hello utils.echo --num_replicas 3)"
 torchx status "$APP_ID"
 torchx describe "$APP_ID"
 sacct -j "$(basename "$APP_ID")"


### PR DESCRIPTION
<!-- Change Summary -->

This adds 4 runopts:
* constraint
* comment
* mail-user
* mail-type

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Added unit tests for all fields

Integ test for comment

Hard for us to test constraint since our cluster doesn't have any node constraints

```
torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10,comment=hello,mail-user=<addr>,mail-type=END utils.echo --num_replicas 3
```
This passes but I don't believe the mail from our cluster is deliverable.