### PR TITLE
aws_batch_scheduler: add workspace support

### DIFF
--- a/.github/workflows/aws-batch-integration-tests.yaml
+++ b/.github/workflows/aws-batch-integration-tests.yaml
@@ -27,6 +27,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: github-torchx
         continue-on-error: true
+      - name: Configure Docker
+        run: |
+          set -eux
+          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 495572122715.dkr.ecr.us-west-2.amazonaws.com
+        continue-on-error: true
       - name: Install dependencies
         run: |
           set -eux

--- a/scripts/awsbatchint.sh
+++ b/scripts/awsbatchint.sh
@@ -7,11 +7,13 @@
 
 set -ex
 
+RUN_ARGS="--scheduler aws_batch -c queue=torchx,image_repo=495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/integration-tests utils.echo"
+
 if [ -z "$AWS_ROLE_ARN" ]; then
   # only dryrun if no secrets
-  torchx run --wait --scheduler aws_batch --dryrun -c queue=torchx utils.echo
+  torchx run --dryrun $RUN_ARGS
 else
-  APP_ID="$(torchx run --wait --scheduler aws_batch -c queue=torchx utils.echo)"
+  APP_ID="$(torchx run --wait $RUN_ARGS)"
   torchx status "$APP_ID"
   torchx describe "$APP_ID"
   torchx log "$APP_ID"

--- a/torchx/workspace/docker_workspace.py
+++ b/torchx/workspace/docker_workspace.py
@@ -5,19 +5,42 @@
 # LICENSE file in the root directory of this source tree.
 
 import io
+import logging
 import posixpath
 import tarfile
 import tempfile
-from typing import IO
+from typing import IO, TYPE_CHECKING, Optional, Dict, Tuple, Mapping
 
 import fsspec
 import torchx
-from torchx.specs import Role
+from torchx.specs import Role, AppDef, CfgVal
 from torchx.workspace.api import Workspace
+
+if TYPE_CHECKING:
+    from docker import DockerClient
+
+log: logging.Logger = logging.getLogger(__name__)
 
 
 class DockerWorkspace(Workspace):
+    """
+    DockerWorkspace will build patched docker images from the workspace.
+    """
+
     LABEL_VERSION: str = "torchx.pytorch.org/version"
+
+    def __init__(self, docker_client: Optional["DockerClient"] = None) -> None:
+        self.__docker_client = docker_client
+
+    @property
+    def _docker_client(self) -> "DockerClient":
+        client = self.__docker_client
+        if client is None:
+            import docker
+
+            client = docker.from_env()
+            self.__docker_client = client
+        return client
 
     def build_workspace_and_update_role(self, role: Role, workspace: str) -> None:
         """
@@ -32,9 +55,8 @@ class DockerWorkspace(Workspace):
         context = _build_context(role.image, workspace)
 
         try:
-            import docker
 
-            image, logs = docker.from_env().images.build(
+            image, _ = self._docker_client.images.build(
                 fileobj=context,
                 custom_context=True,
                 pull=True,
@@ -46,6 +68,47 @@ class DockerWorkspace(Workspace):
             role.image = image.id
         finally:
             context.close()
+
+    def _update_app_images(
+        self, app: AppDef, cfg: Mapping[str, CfgVal]
+    ) -> Dict[str, Tuple[str, str]]:
+        HASH_PREFIX = "sha256:"
+
+        images_to_push = {}
+        for role in app.roles:
+            if role.image.startswith(HASH_PREFIX):
+                image_repo = cfg.get("image_repo")
+                if not image_repo:
+                    raise KeyError(
+                        f"must specify the image repository via `image_repo` config to be able to upload local image {role.image}"
+                    )
+                assert isinstance(image_repo, str), "image_repo must be str"
+
+                image_hash = role.image[len(HASH_PREFIX) :]
+                remote_image = image_repo + ":" + image_hash
+                images_to_push[role.image] = (
+                    image_repo,
+                    image_hash,
+                )
+                role.image = remote_image
+        return images_to_push
+
+    def _push_images(self, images_to_push: Dict[str, Tuple[str, str]]) -> None:
+        if len(images_to_push) == 0:
+            return
+
+        client = self._docker_client
+        for local, (repo, tag) in images_to_push.items():
+            log.info(f"pushing image {repo}:{tag}...")
+            img = client.images.get(local)
+            img.tag(repo, tag=tag)
+            for line in client.images.push(repo, tag=tag, stream=True, decode=True):
+                ERROR_KEY = "error"
+                if ERROR_KEY in line:
+                    raise RuntimeError(
+                        f"failed to push docker image: {line[ERROR_KEY]}"
+                    )
+                log.info(f"docker: {line}")
 
 
 def _build_context(img: str, workspace: str) -> IO[bytes]:

--- a/torchx/workspace/test/docker_workspace_test.py
+++ b/torchx/workspace/test/docker_workspace_test.py
@@ -5,9 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from unittest.mock import MagicMock
 
 import fsspec
-from torchx.specs import Role
+from torchx.specs import Role, AppDef
 from torchx.workspace.docker_workspace import DockerWorkspace
 
 
@@ -41,3 +42,75 @@ if has_docker():
             workspace.build_workspace_and_update_role(role, "memory://test_workspace")
 
             self.assertNotEqual("busybox", role.image)
+
+
+class DockerWorkspaceMockTest(unittest.TestCase):
+    def test_update_app_images(self) -> None:
+        app = AppDef(
+            name="foo",
+            roles=[
+                Role(
+                    name="a",
+                    image="sha256:hasha",
+                ),
+                Role(name="b", image="sha256:hashb"),
+                Role(
+                    name="c",
+                    image="c",
+                ),
+            ],
+        )
+        want = AppDef(
+            name="foo",
+            roles=[
+                Role(
+                    name="a",
+                    image="example.com/repo:hasha",
+                ),
+                Role(
+                    name="b",
+                    image="example.com/repo:hashb",
+                ),
+                Role(
+                    name="c",
+                    image="c",
+                ),
+            ],
+        )
+        # no image_repo
+        with self.assertRaisesRegex(KeyError, "image_repo"):
+            DockerWorkspace()._update_app_images(app, {})
+        # with image_repo
+        images_to_push = DockerWorkspace()._update_app_images(
+            app,
+            {
+                "image_repo": "example.com/repo",
+            },
+        )
+        self.assertEqual(
+            images_to_push,
+            {
+                "sha256:hasha": ("example.com/repo", "hasha"),
+                "sha256:hashb": ("example.com/repo", "hashb"),
+            },
+        )
+        self.assertEqual(app, want)
+
+    def test_push_images(self) -> None:
+        client = MagicMock()
+        img = MagicMock()
+        client.images.get.return_value = img
+        workspace = DockerWorkspace(docker_client=client)
+        workspace._push_images(
+            {
+                "sha256:hasha": ("example.com/repo", "hasha"),
+                "sha256:hashb": ("example.com/repo", "hashb"),
+            }
+        )
+        self.assertEqual(client.images.get.call_count, 2)
+        self.assertEqual(img.tag.call_count, 2)
+        self.assertEqual(client.images.push.call_count, 2)
+
+    def test_push_images_empty(self) -> None:
+        workspace = DockerWorkspace()
+        workspace._push_images({})


### PR DESCRIPTION
<!-- Change Summary -->

This adds `DockerWorkspace` support to the AWS Batch scheduler and does a little bit of refactoring to move some logic from KubernetesScheduler into DockerWorkspace so it can be shared across the different remote docker schedulers.

This also creates `torchx/workspace/test/__init__.py` so the tests are correctly discovered.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Added more unit tests

```
$ torchx run --scheduler aws_batch --wait --log dist.ddp --script foo.py  -j 1x2
$ torchx run --scheduler local_docker --wait --log dist.ddp --script foo.py  -j 1x2
```

