### PR TITLE
dist.ddp: make rendezvous work out of the box on all schedulers

### DIFF
--- a/scripts/slurmint.sh
+++ b/scripts/slurmint.sh
@@ -20,7 +20,7 @@ if [[ -z "${SLURM_INSTANCE_MASTER}" ]]; then
 fi
 
 JOB="$USER-$(uuidgen)"
-DIR="/tmp/$JOB"
+DIR="/home/ubuntu/integ-tests/$JOB"
 VENV="$DIR/venv"
 
 function run_cmd {
@@ -44,8 +44,8 @@ REMOTE_WHEEL="$DIR/$(basename "$WHEEL")"
 SCRIPT="scripts/slurmtest.sh"
 REMOTE_SCRIPT="$DIR/$(basename "$SCRIPT")"
 
-run_cmd mkdir "$DIR"
-run_cmd virtualenv -p /usr/bin/python3.8 "$VENV"
+run_cmd mkdir -p "$DIR"
+run_cmd virtualenv -p /home/ubuntu/miniconda3/bin/python "$VENV"
 run_scp "$WHEEL" "$REMOTE_WHEEL"
 run_scp "$SCRIPT" "$REMOTE_SCRIPT"
 run_cmd "$REMOTE_SCRIPT" "$REMOTE_WHEEL" "$VENV"

--- a/scripts/slurmtest.sh
+++ b/scripts/slurmtest.sh
@@ -10,23 +10,43 @@ set -ex
 REMOTE_WHEEL="$1"
 VENV="$2"
 
+BASE_DIR="$(dirname "$REMOTE_WHEEL")"
+DIR="$BASE_DIR/project"
+mkdir "$DIR"
+cd "$DIR"
+
 # shellcheck disable=SC1091
 source /opt/slurm/etc/slurm.sh
 sbatch --version
 # shellcheck disable=SC1090
 source "$VENV"/bin/activate
 python --version
-pip install "$REMOTE_WHEEL"
 
-APP_ID="$(torchx run --wait --scheduler slurm --scheduler_args partition=compute,time=10,comment=hello utils.echo --num_replicas 3)"
+pip install "$REMOTE_WHEEL"
+pip install numpy
+pip install torch==1.10.2+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
+
+cat <<EOT > .torchxconfig
+[slurm]
+partition=compute
+time=10
+comment=hello
+nomem=true
+EOT
+
+cat <<EOT > main.py
+print("hello world!")
+EOT
+
+APP_ID="$(torchx run --wait --log --scheduler slurm dist.ddp -j 2x1 --script main.py)"
 torchx status "$APP_ID"
 torchx describe "$APP_ID"
 sacct -j "$(basename "$APP_ID")"
 torchx log "$APP_ID"
-LINES="$(torchx log "$APP_ID" | wc -l)"
+LINES="$(torchx log "$APP_ID" | grep -c 'hello world')"
 
-if [ "$LINES" -ne 3 ]
+if [ "$LINES" -ne 2 ]
 then
-    echo "expected 3 log lines"
+    echo "expected 2 log lines"
     exit 1
 fi

--- a/torchx/components/integration_tests/component_provider.py
+++ b/torchx/components/integration_tests/component_provider.py
@@ -36,12 +36,12 @@ class ComponentProvider(ABC):
 
 class DDPComponentProvider(ComponentProvider):
     def get_app_def(self) -> AppDef:
-        rdzv_endpoint: str = "localhost:29400"
         return dist_components.ddp(
             script="torchx/components/integration_tests/test/dummy_app.py",
             name="ddp-trainer",
             image=self._image,
-            rdzv_endpoint=rdzv_endpoint,
+            j="2x2",
+            max_restarts=3,
         )
 
 

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -24,6 +24,7 @@ from torchx.specs import (
     SchedulerBackend,
     runopts,
 )
+from torchx.workspace.api import Workspace
 
 
 class Stream(str, Enum):
@@ -90,13 +91,25 @@ class Scheduler(abc.ABC):
         """
         pass
 
-    def submit(self, app: AppDef, cfg: Mapping[str, CfgVal]) -> str:
+    def submit(
+        self,
+        app: AppDef,
+        cfg: Mapping[str, CfgVal],
+        workspace: Optional[str] = None,
+    ) -> str:
         """
         Submits the application to be run by the scheduler.
+
+        WARNING: Mostly used for tests. Users should prefer to use the TorchX runner instead.
 
         Returns:
             The application id that uniquely identifies the submitted app.
         """
+        if workspace:
+            sched = self
+            assert isinstance(sched, Workspace)
+            role = app.roles[0]
+            sched.build_workspace_and_update_role(role, workspace)
         dryrun_info = self.submit_dryrun(app, cfg)
         return self.schedule(dryrun_info)
 

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -254,9 +254,14 @@ def app_to_resource(app: AppDef, queue: str) -> Dict[str, object]:
                 img_root="",
                 app_id=unique_app_id,
                 replica_id=str(replica_id),
+                rank0_env=f"VC_{cleanup_str(app.roles[0].name)}_0_HOSTS".upper(),
             )
+            if role_idx == 0 and replica_id == 0:
+                values.rank0_env = "TORCHX_RANK0_HOST"
             name = cleanup_str(f"{role.name}-{replica_id}")
             replica_role = values.apply(role)
+            if role_idx == 0 and replica_id == 0:
+                replica_role.env["TORCHX_RANK0_HOST"] = "localhost"
 
             pod = role_to_pod(name, replica_role)
             pod.metadata.labels.update(pod_labels(app, role_idx, role, replica_id))

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -864,8 +864,10 @@ class LocalScheduler(Scheduler):
                     img_root=img_root,
                     app_id=app_id,
                     replica_id=str(replica_id),
+                    rank0_env="TORCHX_RANK0_HOST",
                 )
                 replica_role = values.apply(role)
+                replica_role.env["TORCHX_RANK0_HOST"] = "localhost"
 
                 replica_log_dir = os.path.join(app_log_dir, role.name, str(replica_id))
                 if "TORCHELASTIC_ERROR_FILE" not in replica_role.env:

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -45,6 +45,12 @@ try:
 except ImportError:
     _has_ray = False
 
+
+def has_ray() -> bool:
+    """Indicates whether Ray is installed in the current Python environment."""
+    return _has_ray
+
+
 if _has_ray:
 
     _logger: logging.Logger = logging.getLogger(__name__)
@@ -69,10 +75,6 @@ if _has_ray:
         actors_json = json.dumps(actors, cls=_EnhancedJSONEncoder)
         with open(os.path.join(dirpath, output_filename), "w") as tmp:
             json.dump(actors_json, tmp)
-
-    def has_ray() -> bool:
-        """Indicates whether Ray is installed in the current Python environment."""
-        return _has_ray
 
     @dataclass
     class RayJob:
@@ -230,7 +232,10 @@ if _has_ray:
                 # Replace the ${img_root}, ${app_id}, and ${replica_id} placeholders
                 # in arguments and environment variables.
                 role = macros.Values(
-                    img_root=role.image, app_id=app_id, replica_id="${rank}"
+                    img_root=role.image,
+                    app_id=app_id,
+                    replica_id="${rank}",
+                    rank0_env="MASTER_ADDR",
                 ).apply(role)
 
                 actor = RayActor(

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -323,6 +323,7 @@ class SlurmScheduler(Scheduler):
                     img_root=role.image,
                     app_id=macros.app_id,
                     replica_id=str(replica_id),
+                    rank0_env="SLURM_JOB_NODELIST_HET_GROUP_0",
                 )
                 name = f"{role.name}-{replica_id}"
                 replica_role = values.apply(role)

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -523,6 +523,7 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
                 self.assertEqual([role.entrypoint, *role.args], replica_param.args)
                 self.assertEqual(
                     {
+                        "TORCHX_RANK0_HOST": "localhost",
                         ERR_FILE_ENV: join(replica_log_dir, "error.json"),
                         **role.env,
                     },
@@ -571,6 +572,7 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
                 self.assertEqual([role.entrypoint, *role.args], replica_param.args)
                 self.assertEqual(
                     {
+                        "TORCHX_RANK0_HOST": "localhost",
                         ERR_FILE_ENV: join(replica_log_dir, "error.json"),
                         **role.env,
                     },

--- a/torchx/schedulers/test/ray_scheduler_test.py
+++ b/torchx/schedulers/test/ray_scheduler_test.py
@@ -11,22 +11,24 @@ from typing import Any, Iterator, Type, Optional, Dict, List, cast
 from unittest import TestCase
 from unittest.mock import patch
 
-import ray
 from torchx.schedulers import get_schedulers
 from torchx.schedulers.api import AppDryRunInfo, DescribeAppResponse
-from torchx.schedulers.ray import ray_driver
 from torchx.schedulers.ray.ray_common import RayActor
 from torchx.schedulers.ray_scheduler import (
-    RayScheduler,
-    _logger,
     has_ray,
-    RayJob,
-    serialize,
 )
 from torchx.specs import AppDef, CfgVal, Resource, Role, runopts
 
 
 if has_ray():
+    import ray
+    from torchx.schedulers.ray import ray_driver
+    from torchx.schedulers.ray_scheduler import (
+        RayScheduler,
+        _logger,
+        RayJob,
+        serialize,
+    )
 
     class RaySchedulerRegistryTest(TestCase):
         def test_get_schedulers_returns_ray_scheduler(self) -> None:

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -137,11 +137,19 @@ class macros:
     app_id = "${app_id}"
     replica_id = "${replica_id}"
 
+    # rank0_env will be filled with the name of the environment variable that
+    # provides the master host address. To get the actual hostname the
+    # environment variable must be resolved by the app via either shell
+    # expansion (wrap sh/bash) or via the application.
+    # This may not be available on all schedulers.
+    rank0_env = "${rank0_env}"
+
     @dataclass
     class Values:
         img_root: str
         app_id: str
         replica_id: str
+        rank0_env: str
         base_img_root: str = "DEPRECATED"
 
         def apply(self, role: "Role") -> "Role":

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -383,6 +383,7 @@ class MacrosTest(unittest.TestCase):
             app_id="app_id",
             replica_id="replica_id",
             base_img_root="base_img_root",
+            rank0_env="rank0_env",
         )
         for key, val in asdict(v).items():
             template = f"tmpl-{getattr(macros, key)}"
@@ -401,6 +402,7 @@ class MacrosTest(unittest.TestCase):
             app_id="app_id",
             replica_id="replica_id",
             base_img_root="base_img_root",
+            rank0_env="rank0_env",
         )
         newrole = v.apply(role)
         self.assertNotEqual(newrole, role)

--- a/torchx/test/version_test.py
+++ b/torchx/test/version_test.py
@@ -16,9 +16,6 @@ class VersionTest(unittest.TestCase):
         self.assertIsNotNone(torchx.IMAGE)
 
     def test_images(self) -> None:
-        from torchx.version import __version__, TORCHX_IMAGE, EXAMPLES_IMAGE
+        from torchx.version import __version__, TORCHX_IMAGE
 
         self.assertEqual(TORCHX_IMAGE, f"ghcr.io/pytorch/torchx:{__version__}")
-        self.assertEqual(
-            EXAMPLES_IMAGE, f"ghcr.io/pytorch/torchx-examples:{__version__}"
-        )

--- a/torchx/version.py
+++ b/torchx/version.py
@@ -19,4 +19,3 @@ __version__ = "0.1.2dev0"
 # Use the github container registry images corresponding to the current package
 # version.
 TORCHX_IMAGE = f"ghcr.io/pytorch/torchx:{__version__}"
-EXAMPLES_IMAGE = f"ghcr.io/pytorch/torchx-examples:{__version__}"


### PR DESCRIPTION
<!-- Change Summary -->

Every OSS scheduler we support provides a special environment variable for the rank0 host address. This creates a new macro that provides that for all the schedulers and updates `dist.ddp` to use it.

This macro is a bit different since it's a `rank0_env` macro which provides the name of the ENV variable to read from. To use that, the component either needs to read that or do something like `f"/bin/bash -c main.py $${macros.rank0_env}`. We wrap dist.ddp with `/bin/bash` to achieve this. Due to the macro template language we need to use `$$` instead of just `$`.

Other misc changes:
* fixed ray tests to skip if `ray` isn't installed
* deleted TORCHX_IMAGE_EXAMPLES since it doesn't exist anymore
* updated dist.ddp to have `-m`, `--max_restarts` and set LOGLEVEL by default

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Updated slurm, docker and aws batch integ tests to use `dist.ddp` instead of bespoke usage.

Tested k8s and local_cwd manually.

I haven't tested ray

Updated component test framework to use two workers