### PR TITLE
docs: add documentation for workspaces + general cleanup

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -42,6 +42,17 @@ jobs:
         run: |
           cd docs
           make papermill
+      - name: Coverage
+        run: |
+          set -ex
+          cd docs
+          make coverage
+          if [ "$(wc -l build/*/coverage/python.txt)" -ne 2 ]
+          then
+              cat build/*/coverage/python.txt
+              echo "missing documentation coverage!"
+              exit 1
+          fi
 
   docpush:
     runs-on: ubuntu-18.04

--- a/docs/source/app_best_practices.rst
+++ b/docs/source/app_best_practices.rst
@@ -111,7 +111,7 @@ model definition from a python file and then you'll load the weights and state
 dict from a ``.ckpt`` or ``.pt`` file.
 
 This is how Pytorch Lightning's
-`ModelCheckpoint <https://pytorch-lightning.readthedocs.io/en/latest/extensions/generated/pytorch_lightning.callbacks.ModelCheckpoint.html>`__ hook works.
+`ModelCheckpoint <https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.ModelCheckpoint.html>`__ hook works.
 
 This is the most common but makes it harder to make a reusable app since your
 trainer app needs to include the model definition code.

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -10,11 +10,12 @@ The top level modules in TorchX are:
 
 1. :mod:`torchx.specs`: application spec (job definition) APIs
 2. :mod:`torchx.components`: predefined (builtin) app specs
-3. :mod:`torchx.runner`: given an app spec, submits the app as a job on a scheduler
-4. :mod:`torchx.schedulers`: backend job schedulers that the runner supports
-5. :mod:`torchx.pipelines`: adapters that convert the given app spec to a "stage" in an ML pipeline platform
-6. :mod:`torchx.runtime`: util and abstraction libraries you can use in authoring apps (not app spec)
-7. :mod:`torchx.cli`: CLI tool
+3. :mod:`torchx.workspace`: handles patching images for remote execution
+4. :mod:`torchx.cli`: CLI tool
+5. :mod:`torchx.runner`: given an app spec, submits the app as a job on a scheduler
+6. :mod:`torchx.schedulers`: backend job schedulers that the runner supports
+7. :mod:`torchx.pipelines`: adapters that convert the given app spec to a "stage" in an ML pipeline platform
+8. :mod:`torchx.runtime`: util and abstraction libraries you can use in authoring apps (not app spec)
 
 Below is a UML diagram
 

--- a/docs/source/components/utils.rst
+++ b/docs/source/components/utils.rst
@@ -4,9 +4,10 @@ Utils
 .. automodule:: torchx.components.utils
 .. currentmodule:: torchx.components.utils
 
-.. autofunction:: torchx.components.utils.echo
-.. autofunction:: torchx.components.utils.touch
-.. autofunction:: torchx.components.utils.sh
-.. autofunction:: torchx.components.utils.copy
-.. autofunction:: torchx.components.utils.python
-.. autofunction:: torchx.components.utils.booth
+.. autofunction:: echo
+.. autofunction:: touch
+.. autofunction:: sh
+.. autofunction:: copy
+.. autofunction:: python
+.. autofunction:: booth
+.. autofunction:: binary

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,12 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
 ]
 
+# coverage options
+
+coverage_ignore_modules = [
+    "torchx.components.component_test_base",
+]
+
 # katex options
 #
 #

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ most unique applications can be serviced without customizing the whole vertical 
 
 
 **GETTING STARTED?** First learn the :ref:`basic concepts<basics:Basic Concepts>` and
-follow the :ref:`quickstart guide<quickstart:Quickstart>`.
+follow the :ref:`quickstart guide<quickstart:Quickstart - Custom Components>`.
 
 .. image:: torchx_index_diag.png
 
@@ -47,7 +47,36 @@ Documentation
    quickstart.md
    cli
 
+   runner.config
+
    advanced
+
+
+Works With
+---------------
+
+.. _Schedulers:
+.. toctree::
+   :maxdepth: 1
+   :caption: Schedulers
+
+   schedulers/local
+   schedulers/docker
+   schedulers/kubernetes
+   schedulers/slurm
+   schedulers/ray
+   schedulers/aws_batch
+
+.. _Pipelines:
+.. toctree::
+   :maxdepth: 1
+   :caption: Pipelines
+
+   pipelines/kfp
+
+
+Examples
+------------
 
 .. toctree::
    :maxdepth: 1
@@ -56,6 +85,7 @@ Documentation
 
    examples_apps/index
    examples_pipelines/index
+
 
 
 Components Library
@@ -85,28 +115,6 @@ Runtime Library
    runtime/tracking
 
 
-Works With
----------------
-
-.. _Schedulers:
-.. toctree::
-   :maxdepth: 1
-   :caption: Schedulers
-
-   schedulers/local
-   schedulers/kubernetes
-   schedulers/slurm
-   schedulers/ray
-   schedulers/aws_batch
-
-.. _Pipelines:
-.. toctree::
-   :maxdepth: 1
-   :caption: Pipelines
-
-   pipelines/kfp
-
-
 Reference
 -----------
 
@@ -118,6 +126,7 @@ Reference
    specs
    runner
    schedulers
+   workspace
    pipelines
 
 .. toctree::
@@ -126,15 +135,3 @@ Reference
 
    app_best_practices
    component_best_practices
-
-
-Experimental
----------------
-.. toctree::
-   :maxdepth: 1
-   :caption: Experimental Features
-
-   experimental/runner.config
-
-
-

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -12,7 +12,7 @@ jupyter:
     name: python3
 ---
 
-# Quickstart
+# Quickstart - Custom Components
 
 This is a self contained guide on how to build a simple app and component spec
 and launch it via two different schedulers.

--- a/docs/source/runner.config.rst
+++ b/docs/source/runner.config.rst
@@ -1,4 +1,4 @@
-(beta) .torchxconfig file
+.torchxconfig
 -----------------------------
 
 .. automodule:: torchx.runner.config
@@ -10,3 +10,7 @@ Config API Functions
 .. autofunction:: apply
 .. autofunction:: load
 .. autofunction:: dump
+.. autofunction:: find_configs
+.. autofunction:: get_configs
+.. autofunction:: get_config
+.. autofunction:: load_sections

--- a/docs/source/runtime/hpo.rst
+++ b/docs/source/runtime/hpo.rst
@@ -14,4 +14,7 @@ Ax (Adaptive Experimentation)
 .. currentmodule:: torchx.runtime.hpo.ax
 
 .. autoclass:: TorchXRunner
+   :members:
+
 .. autoclass:: AppMetric
+   :members:

--- a/docs/source/schedulers/aws_batch.rst
+++ b/docs/source/schedulers/aws_batch.rst
@@ -2,7 +2,17 @@ AWS Batch
 =================
 
 .. automodule:: torchx.schedulers.aws_batch_scheduler
+
 .. currentmodule:: torchx.schedulers.aws_batch_scheduler
 
 .. autoclass:: AWSBatchScheduler
    :members:
+   :show-inheritance:
+
+.. autoclass:: BatchJob
+   :members:
+
+Reference
+~~~~~~~~~~~~
+
+.. autofunction:: create_scheduler

--- a/docs/source/schedulers/docker.rst
+++ b/docs/source/schedulers/docker.rst
@@ -1,0 +1,23 @@
+Docker
+=================
+
+.. automodule:: torchx.schedulers.docker_scheduler
+
+.. currentmodule:: torchx.schedulers.docker_scheduler
+
+.. autoclass:: DockerScheduler
+   :members:
+   :show-inheritance:
+
+.. autoclass:: DockerJob
+   :members:
+
+Reference
+~~~~~~~~~~~~
+
+.. autofunction:: create_scheduler
+
+.. autoclass:: DockerContainer
+   :members:
+
+.. autofunction:: has_docker

--- a/docs/source/schedulers/kubernetes.rst
+++ b/docs/source/schedulers/kubernetes.rst
@@ -2,8 +2,22 @@ Kubernetes
 =================
 
 .. automodule:: torchx.schedulers.kubernetes_scheduler
+
 .. currentmodule:: torchx.schedulers.kubernetes_scheduler
 
 .. autoclass:: KubernetesScheduler
    :members:
+   :show-inheritance:
 
+.. autoclass:: KubernetesJob
+   :members:
+
+Reference
+~~~~~~~~~~~~
+
+.. autofunction:: create_scheduler
+.. autofunction:: app_to_resource
+.. autofunction:: cleanup_str
+.. autofunction:: pod_labels
+.. autofunction:: role_to_pod
+.. autofunction:: sanitize_for_serialization

--- a/docs/source/schedulers/local.rst
+++ b/docs/source/schedulers/local.rst
@@ -2,24 +2,38 @@ Local
 =================
 
 .. automodule:: torchx.schedulers.local_scheduler
+
 .. currentmodule:: torchx.schedulers.local_scheduler
 
 .. autoclass:: LocalScheduler
    :members:
-
-.. automodule:: torchx.schedulers.docker_scheduler
-.. currentmodule:: torchx.schedulers.docker_scheduler
-
-.. autoclass:: DockerScheduler
-   :members:
+   :show-inheritance:
 
 Image Providers
 ~~~~~~~~~~~~~~~~~
-
-.. currentmodule:: torchx.schedulers.local_scheduler
 
 .. autoclass:: ImageProvider
    :members:
 
 .. autoclass:: CWDImageProvider
+   :members:
+
+.. autoclass:: LocalDirectoryImageProvider
+   :members:
+
+Reference
+~~~~~~~~~~~~
+
+.. autofunction:: create_cwd_scheduler
+
+.. autoclass:: LogIterator
+   :members:
+
+.. autoclass:: PopenRequest
+   :members:
+
+.. autoclass:: ReplicaParam
+   :members:
+
+.. autoclass:: SignalException
    :members:

--- a/docs/source/schedulers/ray.rst
+++ b/docs/source/schedulers/ray.rst
@@ -2,7 +2,16 @@ Ray
 =================
 
 .. automodule:: torchx.schedulers.ray_scheduler
+
 .. currentmodule:: torchx.schedulers.ray_scheduler
 
 .. autoclass:: RayScheduler
+   :members:
+   :show-inheritance:
+
+.. autofunction:: create_scheduler
+.. autofunction:: has_ray
+.. autofunction:: serialize
+
+.. autoclass:: RayJob
    :members:

--- a/docs/source/schedulers/slurm.rst
+++ b/docs/source/schedulers/slurm.rst
@@ -2,7 +2,17 @@ Slurm
 =================
 
 .. automodule:: torchx.schedulers.slurm_scheduler
+
 .. currentmodule:: torchx.schedulers.slurm_scheduler
 
 .. autoclass:: SlurmScheduler
+   :members:
+   :show-inheritance:
+
+.. autofunction:: create_scheduler
+
+.. autoclass:: SlurmBatchRequest
+   :members:
+
+.. autoclass:: SlurmReplicaRequest
    :members:

--- a/docs/source/specs.rst
+++ b/docs/source/specs.rst
@@ -24,13 +24,21 @@ Resource
 .. autoclass:: Resource
    :members:
 
+.. autofunction:: resource
+
 .. autofunction:: get_named_resources
+
 
 AWS Named Resources
 ^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: torchx.specs.named_resources_aws
 
 .. currentmodule:: torchx.specs.named_resources_aws
+
+.. autofunction:: aws_m5_2xlarge
+.. autofunction:: aws_p3_2xlarge
+.. autofunction:: aws_p3_8xlarge
+.. autofunction:: aws_t3_medium
 
 Macros
 ------------
@@ -61,3 +69,22 @@ Component Linter
 .. currentmodule:: torchx.specs.file_linter
 
 .. autofunction:: validate
+.. autofunction:: get_fn_docstring
+
+.. autoclass:: LinterMessage
+   :members:
+
+.. autoclass:: TorchFunctionVisitor
+   :members:
+
+.. autoclass:: TorchXArgumentHelpFormatter
+   :members:
+
+.. autoclass:: TorchxFunctionArgsValidator
+   :members:
+
+.. autoclass:: TorchxFunctionValidator
+   :members:
+
+.. autoclass:: TorchxReturnValidator
+   :members:

--- a/docs/source/workspace.rst
+++ b/docs/source/workspace.rst
@@ -1,0 +1,21 @@
+torchx.workspace
+================
+
+.. automodule:: torchx.workspace
+   :show-inheritance:
+
+.. currentmodule:: torchx.workspace
+
+.. autoclass:: Workspace
+  :members:
+
+torchx.workspace.docker_workspace
+#######################################
+
+
+.. automodule:: torchx.workspace.docker_workspace
+.. currentmodule:: torchx.workspace.docker_workspace
+
+.. autoclass:: DockerWorkspace
+  :members:
+  :private-members: _update_app_images, _push_images

--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -6,6 +6,8 @@
 # LICENSE file in the root directory of this source tree.
 
 """
+Status: Beta
+
 You can store the scheduler run cfg (run configs) for your project
 by storing them in the ``.torchxconfig`` file. Currently this file is only read
 and honored when running the component from the CLI.

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -23,7 +23,7 @@ class SchedulerFactory(Protocol):
         ...
 
 
-def try_get_ray_scheduler() -> Optional[SchedulerFactory]:
+def _try_get_ray_scheduler() -> Optional[SchedulerFactory]:
     try:
         from torchx.schedulers.ray_scheduler import _has_ray  # @manual
 
@@ -52,7 +52,7 @@ def get_scheduler_factories() -> Dict[str, SchedulerFactory]:
         "aws_batch": aws_batch_scheduler.create_scheduler,
     }
 
-    ray_scheduler_creator = try_get_ray_scheduler()
+    ray_scheduler_creator = _try_get_ray_scheduler()
     if ray_scheduler_creator:
         default_schedulers["ray"] = ray_scheduler_creator
 

--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -74,7 +74,7 @@ JOB_STATE: Dict[str, AppState] = {
 }
 
 
-def role_to_node_properties(idx: int, role: Role) -> Dict[str, object]:
+def _role_to_node_properties(idx: int, role: Role) -> Dict[str, object]:
     resource = role.resource
     reqs = []
     cpu = resource.cpu
@@ -244,7 +244,7 @@ class AWSBatchScheduler(Scheduler, DockerWorkspace):
                     # localhost for rank0.
                     # See: https://docs.aws.amazon.com/batch/latest/userguide/job_env_vars.html
                     replica_role.env["TORCHX_RANK0_HOST"] = "localhost"
-                nodes.append(role_to_node_properties(rank, replica_role))
+                nodes.append(_role_to_node_properties(rank, replica_role))
 
         req = BatchJob(
             name=name,

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -95,7 +95,7 @@ def _terminate_process_handler(signum: int, frame: FrameType) -> None:
 @dataclass
 class ReplicaParam:
     """
-    Holds ``LocalScheduler._popen()``parameters for each replica of the role.
+    Holds ``LocalScheduler._popen()`` parameters for each replica of the role.
     """
 
     args: List[str]
@@ -452,7 +452,7 @@ class _LocalAppDef:
         return f"{{app_id:{self.id}, state:{self.state}, pid_map:{role_to_pid}}}"
 
 
-def join_PATH(*paths: Optional[str]) -> str:
+def _join_PATH(*paths: Optional[str]) -> str:
     """
     Joins strings that go in the PATH env var.
     Deals with empty strings and None-types, making sure no leading
@@ -492,7 +492,7 @@ class PopenRequest:
     role_log_dirs: Dict[RoleName, List[str]]
 
 
-def register_termination_signals() -> None:
+def _register_termination_signals() -> None:
     """
     Register SIGTERM and SIGINT handlers only for the main thread.
     """
@@ -569,7 +569,7 @@ class LocalScheduler(Scheduler):
         if cache_size <= 0:
             raise ValueError("cache size must be greater than zero")
         self._cache_size = cache_size
-        register_termination_signals()
+        _register_termination_signals()
 
         self._extra_paths: List[str] = extra_paths or []
 
@@ -679,7 +679,7 @@ class LocalScheduler(Scheduler):
         env.update(replica_params.env)
 
         # prepend extra_paths to PATH
-        env["PATH"] = join_PATH(*self._extra_paths, env.get("PATH"))
+        env["PATH"] = _join_PATH(*self._extra_paths, env.get("PATH"))
 
         cwd = replica_params.cwd
         if cwd:
@@ -688,9 +688,9 @@ class LocalScheduler(Scheduler):
             # otherwise append cwd to PATH so that the binaries in PATH
             # precede over those in cwd
             if prepend_cwd:
-                env["PATH"] = join_PATH(cwd, env.get("PATH"))
+                env["PATH"] = _join_PATH(cwd, env.get("PATH"))
             else:
-                env["PATH"] = join_PATH(env.get("PATH"), cwd)
+                env["PATH"] = _join_PATH(env.get("PATH"), cwd)
 
         # default to unbuffered python for faster responsiveness locally
         env.setdefault("PYTHONUNBUFFERED", "x")

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -273,6 +273,11 @@ if _has_ray:
                     break
 
         def wait_until_finish(self, app_id: str, timeout: int = 30) -> None:
+            """
+            ``wait_until_finish`` waits until the specified job has finished
+            with a given timeout. This is intended for testing. Programmatic
+            usage should use the runner wait method instead.
+            """
             addr, app_id = app_id.split("-")
 
             client = JobSubmissionClient(f"http://{addr}")

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -92,6 +92,10 @@ class SlurmReplicaRequest:
     def from_role(
         cls, name: str, role: Role, cfg: Mapping[str, CfgVal]
     ) -> "SlurmReplicaRequest":
+        """
+        ``from_role`` creates a SlurmReplicaRequest for the specific role and
+        name.
+        """
         sbatch_opts = {}
         for k, v in cfg.items():
             if v is None:

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -31,7 +31,7 @@ from torchx.schedulers.local_scheduler import (
     LocalScheduler,
     ReplicaParam,
     create_cwd_scheduler,
-    join_PATH,
+    _join_PATH,
     make_unique,
 )
 from torchx.specs.api import AppDef, AppState, Role, is_terminal, macros, Resource
@@ -973,20 +973,20 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
 
 class JoinPATHTest(unittest.TestCase):
     def test_join_PATH(self) -> None:
-        self.assertEqual("", join_PATH(None))
-        self.assertEqual("", join_PATH(""))
-        self.assertEqual("", join_PATH("", None))
-        self.assertEqual("/usr/local/bin", join_PATH("/usr/local/bin", ""))
-        self.assertEqual("/usr/local/bin", join_PATH("/usr/local/bin", None))
-        self.assertEqual("/usr/local/bin", join_PATH("", "/usr/local/bin"))
-        self.assertEqual("/usr/local/bin", join_PATH(None, "/usr/local/bin"))
+        self.assertEqual("", _join_PATH(None))
+        self.assertEqual("", _join_PATH(""))
+        self.assertEqual("", _join_PATH("", None))
+        self.assertEqual("/usr/local/bin", _join_PATH("/usr/local/bin", ""))
+        self.assertEqual("/usr/local/bin", _join_PATH("/usr/local/bin", None))
+        self.assertEqual("/usr/local/bin", _join_PATH("", "/usr/local/bin"))
+        self.assertEqual("/usr/local/bin", _join_PATH(None, "/usr/local/bin"))
 
         path = ":/usr/bin:/bin:"
         self.assertEqual(
-            "/usr/local/bin:/usr/bin:/bin", join_PATH("/usr/local/bin", path)
+            "/usr/local/bin:/usr/bin:/bin", _join_PATH("/usr/local/bin", path)
         )
         self.assertEqual(
-            "/usr/bin:/bin:/usr/local/bin", join_PATH(path, "/usr/local/bin")
+            "/usr/bin:/bin:/usr/local/bin", _join_PATH(path, "/usr/local/bin")
         )
 
 

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -93,11 +93,12 @@ def resource(
     Example:
 
     .. code-block:: python
-     resource(cpu=1) # returns Resource(cpu=1)
-     resource(named_resource="foobar") # returns registered named resource "foo"
-     resource(cpu=1, named_resource="foobar") # returns registered named resource "foo" (cpu=1 ignored)
-     resource() # returns default resource values
-     resource(cpu=None, gpu=None, memMB=None) # throws
+
+         resource(cpu=1) # returns Resource(cpu=1)
+         resource(named_resource="foobar") # returns registered named resource "foo"
+         resource(cpu=1, named_resource="foobar") # returns registered named resource "foo" (cpu=1 ignored)
+         resource() # returns default resource values
+         resource(cpu=None, gpu=None, memMB=None) # throws
     """
 
     if h:

--- a/torchx/specs/file_linter.py
+++ b/torchx/specs/file_linter.py
@@ -94,6 +94,9 @@ class LinterMessage:
 class TorchxFunctionValidator(abc.ABC):
     @abc.abstractmethod
     def validate(self, app_specs_func_def: ast.FunctionDef) -> List[LinterMessage]:
+        """
+        Method to call to validate the provided function def.
+        """
         raise NotImplementedError()
 
     def _gen_linter_message(self, description: str, lineno: int) -> LinterMessage:
@@ -244,11 +247,14 @@ class TorchFunctionVisitor(ast.NodeVisitor):
         self.visited_function = False
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """
+        Validates the function def with the child validators.
+        """
         if node.name != self.component_function_name:
             return
         self.visited_function = True
-        for validatior in self.validators:
-            self.linter_errors += validatior.validate(node)
+        for validator in self.validators:
+            self.linter_errors += validator.validate(node)
 
 
 def validate(path: str, component_function: str) -> List[LinterMessage]:

--- a/torchx/workspace/__init__.py
+++ b/torchx/workspace/__init__.py
@@ -4,4 +4,20 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""
+Status: Beta
+
+Workspaces are used to apply local changes on top of existing images so you can
+execute your code on a remote cluster. This module contains the interfaces used
+by workspace implementations.
+
+These workspaces are defined as an ``fsspec`` path which the directories and
+files under will be used to generate a patch.
+
+Example workspace paths:
+
+    * ``file://.`` the current working directory
+    * ``memory://foo-bar/`` an in-memory workspace for notebook/programmatic usage
+"""
+
 from torchx.workspace.api import Workspace  # noqa: F401

--- a/torchx/workspace/api.py
+++ b/torchx/workspace/api.py
@@ -19,7 +19,7 @@ class Workspace(abc.ABC):
     automatically rebuild images or generate diff patches that are
     applied to the ``Role``, allowing the user to make local code
     changes to the application and having those changes be reflected
-    (either through a new image or an overlayed patch) at runtime
+    (either through a new image or an overlaid patch) at runtime
     without a manual image rebuild. The exact semantics of what the
     workspace build artifact is, is implementation dependent.
     """
@@ -29,7 +29,7 @@ class Workspace(abc.ABC):
         """
         Builds the specified ``workspace`` with respect to ``img``
         and updates the ``role`` to reflect the built workspace artifacts.
-        In the simplest case, this method builds a new image and udpates
+        In the simplest case, this method builds a new image and updates
         the role's image. Certain (more efficient) implementations build
         incremental diff patches that overlay on top of the role's image.
 


### PR DESCRIPTION
<!-- Change Summary -->

This makes some of the changes listed in https://docs.google.com/document/d/14icG0GJG1nPHF3DW7yMreZpe3S8FwYdrI_XYIzDTSbI/edit#heading=h.6ixj5co4aocb

* Adds workspaces documention
* Adds coverage test to docs build to ensure all exported methods/classes are documented in the docs.
* Adds previously undocumented methods/classes to docs
* Moves torchconfig from experimental to beta
* Splits docker/local scheduler docs
* Reshuffles the sidebar to prioritize the schedulers over some of the other content

Next steps:

* update readme/index/quickstart guides to highlight workspaces + patching w/ ddp builtin
* deprioritize/remove some of the more complex custom component examples

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
$ make -C docs coverage; and cat docs/build/0.1.2dev0/coverage/python.txt
$ pyre
$ pytest
```

CI

![Screenshot 2022-02-28 at 17-21-17 torchx workspace — PyTorch TorchX main documentation](https://user-images.githubusercontent.com/909104/156086755-8330fece-dc86-442d-a656-aaef775bd3e5.png)
