### PR TITLE
component_integration_tests: add aws_batch, ray + more interpretable

### DIFF
--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -9,6 +9,15 @@ on:
 jobs:
   components-launch:
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+       include:
+         - scheduler: "aws_batch"
+         - scheduler: "kubernetes"
+         - scheduler: "local_cwd"
+         - scheduler: "local_docker"
+         - scheduler: "ray"
+      fail-fast: false
     permissions:
       id-token: write
       contents: read
@@ -48,8 +57,12 @@ jobs:
           set -eux
           pip install -r dev-requirements.txt
           pip install -e .[kubernetes]
+
+      - name: Start Ray
+        if: ${{ matrix.scheduler == 'ray' }}
+        run: ray start --head
       - name: Run Components Integration Tests
         env:
           INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
           CONTAINER_REPO: ${{ secrets.CONTAINER_REPO }}
-        run: scripts/component_integration_tests.py
+        run: scripts/component_integration_tests.py --scheduler ${{ matrix.scheduler }}

--- a/torchx/components/component_test_base.py
+++ b/torchx/components/component_test_base.py
@@ -57,6 +57,10 @@ class ComponentUtils:
             app_status = runner.wait(app_handle)
             print(f"Final status: {app_status}")
             if none_throws(app_status).state != AppState.SUCCEEDED:
+                for line in runner.log_lines(
+                    app_handle, role_name=app_def.roles[0].name
+                ):
+                    print(f"{app_handle}: {line}")
                 raise AssertionError(
                     f"App {app_handle} failed with status: {app_status}"
                 )

--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -142,7 +142,7 @@ def ddp(
     memMB: int = 1024,
     j: str = "1x2",
     env: Optional[Dict[str, str]] = None,
-    max_restarts: Optional[int] = None,
+    max_retries: int = 0,
     rdzv_backend: str = "c10d",
     rdzv_endpoint: Optional[str] = None,
 ) -> specs.AppDef:
@@ -167,7 +167,7 @@ def ddp(
         h: a registered named resource (if specified takes precedence over cpu, gpu, memMB)
         j: {nnodes}x{nproc_per_node}, for gpu hosts, nproc_per_node must not exceed num gpus
         env: environment varibles to be passed to the run (e.g. ENV1=v1,ENV2=v2,ENV3=v3)
-        max_restarts: the number of restarts allowed
+        max_retries: the number of scheduler retries allowed
         rdzv_backend: rendezvous backend (only matters when nnodes > 1)
         rdzv_endpoint: rendezvous server endpoint (only matters when nnodes > 1), defaults to rank0 host for schedulers that support it
     """
@@ -219,8 +219,6 @@ def ddp(
         "--nproc_per_node",
         str(nproc_per_node),
     ]
-    if max_restarts is not None:
-        cmd += ["--max_restarts", str(max_restarts)]
     if script is not None:
         cmd += [script]
     elif m is not None:
@@ -240,6 +238,7 @@ def ddp(
                 port_map={
                     "c10d": 29500,
                 },
+                max_retries=max_retries,
             )
         ],
     )

--- a/torchx/components/integration_tests/component_provider.py
+++ b/torchx/components/integration_tests/component_provider.py
@@ -40,8 +40,9 @@ class DDPComponentProvider(ComponentProvider):
             script="torchx/components/integration_tests/test/dummy_app.py",
             name="ddp-trainer",
             image=self._image,
+            cpu=1,
             j="2x2",
-            max_restarts=3,
+            max_retries=3,
         )
 
 
@@ -49,8 +50,8 @@ class ServeComponentProvider(ComponentProvider):
     # TODO(aivanou): Remove dryrun and test e2e serve component+app
     def get_app_def(self) -> AppDef:
         return serve_components.torchserve(
-            model_path="",
-            management_api="",
+            model_path="dummy_path",
+            management_api="dummy_api",
             image=self._image,
             dryrun=True,
         )

--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -35,6 +35,7 @@ https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html#
 for how to create a image repository.
 """
 
+import threading
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Iterable, Mapping, Optional, Any, TYPE_CHECKING, Tuple
@@ -120,6 +121,19 @@ class BatchJob:
         return str(self)
 
 
+def _thread_local_session() -> "boto3.session.Session":
+    KEY = "torchx_aws_batch_session"
+    local = threading.local()
+    if hasattr(local, KEY):
+        # pyre-ignore[16]
+        return getattr(local, KEY)
+    import boto3.session
+
+    session = boto3.session.Session()
+    setattr(local, KEY, session)
+    return session
+
+
 class AWSBatchScheduler(Scheduler, DockerWorkspace):
     """
     AWSBatchScheduler is a TorchX scheduling interface to AWS Batch.
@@ -174,20 +188,16 @@ class AWSBatchScheduler(Scheduler, DockerWorkspace):
     @property
     # pyre-fixme[3]: Return annotation cannot be `Any`.
     def _client(self) -> Any:
-        if self.__client is None:
-            import boto3
-
-            self.__client = boto3.client("batch")
-        return self.__client
+        if self.__client:
+            return self.__client
+        return _thread_local_session().client("batch")
 
     @property
     # pyre-fixme[3]: Return annotation cannot be `Any`.
     def _log_client(self) -> Any:
-        if self.__log_client is None:
-            import boto3
-
-            self.__log_client = boto3.client("logs")
-        return self.__log_client
+        if self.__log_client:
+            return self.__log_client
+        return _thread_local_session().client("logs")
 
     def schedule(self, dryrun_info: AppDryRunInfo[BatchJob]) -> str:
         cfg = dryrun_info._cfg

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -291,7 +291,8 @@ does NOT support retries correctly. More info: https://github.com/volcano-sh/vol
             "tasks": tasks,
             "maxRetry": job_retries,
             "plugins": {
-                "svc": [],
+                # https://github.com/volcano-sh/volcano/issues/533
+                "svc": ["--publish-not-ready-addresses"],
                 "env": [],
             },
         },

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -193,7 +193,8 @@ spec:
   maxRetry: 3
   plugins:
     env: []
-    svc: []
+    svc:
+    - --publish-not-ready-addresses
   queue: testqueue
   schedulerName: volcano
   tasks:


### PR DESCRIPTION
<!-- Change Summary -->

This adds aws_batch and ray to the integration tests and refactors them to run per scheduler in parallel to make it clearer what's running.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI + pyre