### PR TITLE
kubernetes_scheduler: add service_account runopt so users can specify per job acls + log fix

### DIFF
--- a/torchx/pipelines/kfp/adapter.py
+++ b/torchx/pipelines/kfp/adapter.py
@@ -235,6 +235,7 @@ def container_from_app(
 def resource_from_app(
     app: api.AppDef,
     queue: str,
+    service_account: Optional[str] = None,
 ) -> dsl.ResourceOp:
     """
     resource_from_app generates a KFP ResourceOp from the provided app that uses
@@ -266,5 +267,5 @@ def resource_from_app(
         action="create",
         success_condition="status.state.phase = Completed",
         failure_condition="status.state.phase = Failed",
-        k8s_resource=app_to_resource(app, queue),
+        k8s_resource=app_to_resource(app, queue, service_account=service_account),
     )


### PR DESCRIPTION
<!-- Change Summary -->

Fixes #406

This adds a new `service_account` runopt that sets the `service_account_name` on the pod spec of each pod.

https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodSpec.md

It also fixes a small bug when fetching logs w/ `_` in the role name.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

added unit tests

```
torchx run --scheduler kubernetes -c service_account=default --wait --log dist.ddp --script dist_app.py -j 1x1
```
