### PR TITLE
(torchx/components) pass --tee=3 to dist.ddp to prefix local_rank on the worker's stdout and stderr streams

### DIFF
--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -219,6 +219,8 @@ def ddp(
         str(nnodes),
         "--nproc_per_node",
         str(nproc_per_node),
+        "--tee",
+        "3",
     ]
     if script is not None:
         cmd += [script]


### PR DESCRIPTION
Summary:
Addresses the QOL issue around SLURM logs mentioned in https://github.com/pytorch/torchx/issues/405

TL;DR - since torchx launches nodes (not tasks) in SLURM, the stdout and stderr logs are combined for all 8 workers on the node (versus having separate ones for each worker when launched as task). This makes `dist.ddp` set `--tee=3` flag to torchelastic which prefixes each line of stderr and stdout of the workers with the local_rank of that worker so that the user can easily grep out the logs for a particular worker.

Differential Revision: D34726681

