### PR TITLE
(torchx/scheduler) add pretty print repr lambda for SlurmBatchRunRequest for dryrun

### DIFF
--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -196,8 +196,15 @@ export SLURM_UNBUFFEREDIO=1
 
 srun {" ".join(srun_groups)}
 """
-        sbatch_cmd = self.cmd + sbatch_groups
         return script
+
+    def __repr__(self) -> str:
+        return f"""{' '.join(self.cmd + ['$SBATCH_SCRIPT'])}
+
+#----------------
+# SBATCH_SCRIPT
+#----------------
+{self.materialize()}"""
 
 
 class SlurmScheduler(Scheduler):
@@ -345,6 +352,7 @@ class SlurmScheduler(Scheduler):
             cmd=cmd,
             replicas=replicas,
         )
+
         return AppDryRunInfo(req, repr)
 
     def _validate(self, app: AppDef, scheduler: SchedulerBackend) -> None:


### PR DESCRIPTION
Summary:
Makes `torchx run --dryrun -s slurm` pretty print the slurm scheduler reqeust object.

BEFORE:

```
torchx 2022-03-09 14:52:15 INFO
=== SCHEDULER REQUEST ===
SlurmBatchRequest(cmd=['sbatch', '--parsable'], replicas={'trainer-0': SlurmReplicaRequest(name='trainer-0', entrypoint='python', args=['-m', 'torch.distributed.run', '--rdzv_backend', 'c10d', '--rdzv_id', '${app_id}', '--nnodes', '1', '--nproc_per_node', '8', '--tee', '3
', '--role', '', '-m', 'torchx.examples.apps.fb.compute_world_size.main'], srun_opts={'output': 'slurm-${app_id}-trainer-0.out', 'error': 'slurm-${app_id}-trainer-0.err'}, sbatch_opts={'ntasks-per-node': '1', 'cpus-per-task': '56', 'mem': '1572864', 'gpus-per-task': '8'},
 env={'HYDRA_MAIN_MODULE': 'torchx.examples.apps.fb.compute_world_size.main', 'NCCL_DEBUG': 'INFO', 'NCCL_ASYNC_ERROR_HANDLING': '1', 'NCCL_DEBUG_SUBSYS': 'INIT,ENV,GRAPH', 'MALLOC_CONF': 'oversize_threshold:67108864,dirty_decay_ms:180000,muzzy_decay_ms:180000', 'NCCL_SOC
KET_IFNAME': 'eth1', 'NCCL_IB_HCA': 'mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1', 'LOGLEVEL': 'WARNING'})})
```

AFTER:

```
=== SCHEDULER REQUEST ===
{
  "cmd": [
    "sbatch",
    "--parsable"
  ],
  "replicas": {
    "trainer-0": {
      "name": "trainer-0",
      "entrypoint": "python",
      "args": [
        "-m",
        "torch.distributed.run",
        "--rdzv_backend",
        "c10d",
        "--rdzv_id",
        "${app_id}",
        "--nnodes",
        "1",
        "--nproc_per_node",
        "8",
        "--tee",
        "3",
        "--role",
        "",
        "-m",
        "torchx.examples.apps.fb.compute_world_size.main"
      ],
      "srun_opts": {
        "output": "slurm-${app_id}-trainer-0.out",
        "error": "slurm-${app_id}-trainer-0.err"
      },
      "sbatch_opts": {
        "ntasks-per-node": "1",
        "cpus-per-task": "56",
        "mem": "1572864",
        "gpus-per-task": "8"
      },
      "env": {
        "HYDRA_MAIN_MODULE": "torchx.examples.apps.fb.compute_world_size.main",
        "NCCL_DEBUG": "INFO",
        "NCCL_ASYNC_ERROR_HANDLING": "1",
        "NCCL_DEBUG_SUBSYS": "INIT,ENV,GRAPH",
        "MALLOC_CONF": "oversize_threshold:67108864,dirty_decay_ms:180000,muzzy_decay_ms:180000",
        "NCCL_SOCKET_IFNAME": "eth1",
        "NCCL_IB_HCA": "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1",
        "LOGLEVEL": "WARNING"
      }
    }
  }
}

```

Reviewed By: mannatsingh, aivanou

Differential Revision: D34770528

