### PR TITLE
cli: change torchx color to blue and fix for closed stdout

### DIFF
--- a/torchx/cli/colors.py
+++ b/torchx/cli/colors.py
@@ -8,13 +8,15 @@
 import sys
 
 # only print colors if outputting directly to a terminal
-if sys.stdout.isatty():
+if not sys.stdout.closed and sys.stdout.isatty():
     GREEN = "\033[32m"
+    BLUE = "\033[34m"
     ORANGE = "\033[38:2:238:76:44m"
     GRAY = "\033[2m"
     ENDC = "\033[0m"
 else:
     GREEN = ""
     ORANGE = ""
+    BLUE = ""
     GRAY = ""
     ENDC = ""

--- a/torchx/cli/main.py
+++ b/torchx/cli/main.py
@@ -17,7 +17,7 @@ from torchx.cli.cmd_log import CmdLog
 from torchx.cli.cmd_run import CmdBuiltins, CmdRun
 from torchx.cli.cmd_runopts import CmdRunopts
 from torchx.cli.cmd_status import CmdStatus
-from torchx.cli.colors import ENDC, GRAY, ORANGE
+from torchx.cli.colors import ENDC, GRAY, BLUE
 from torchx.util.entrypoints import load_group
 
 
@@ -97,7 +97,7 @@ def run_main(subcmds: Dict[str, SubCommand], argv: List[str] = sys.argv[1:]) -> 
     args = parser.parse_args(argv)
     logging.basicConfig(
         level=args.log_level,
-        format=f"{ORANGE}torchx{ENDC} {GRAY}%(asctime)s %(levelname)-8s{ENDC} %(message)s",
+        format=f"{BLUE}torchx{ENDC} {GRAY}%(asctime)s %(levelname)-8s{ENDC} %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     if "func" not in args:


### PR DESCRIPTION
<!-- Change Summary -->

Fixes #418. 
Fixes #413.

This changes the `torchx` logo color to blue since the PT orange can be confused with an red error message and fixes a bug where `isatty` fails due to `stdout` being closed in strange environments.

Color choices:
* red/orange - too close to error colors
* green - already used by log role/rank prefixes
* purple - clashes with green
* blue - neutral/meta
* cyan - a little too bright (backup if blue is too dark)
* black - no
* brown - ick
* gray - already used for timestamps
* white - user feedback is colors are good :)

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

![2022-03-11-122158_1090x138_scrot](https://user-images.githubusercontent.com/909104/157956804-366cfa94-2bd9-402b-a907-a2d63a9ff259.png)

