### PR TITLE
specs,schedulers: add Role.mounts+BindMount and implement in docker,kubernetes,aws_batch schedulers

### DIFF
--- a/docs/source/ext/compatibility.py
+++ b/docs/source/ext/compatibility.py
@@ -17,6 +17,7 @@ COMPATIBILITY_SETS = {
         "cancel": "Cancel Job",
         "describe": "Describe Job",
         "workspaces": "Workspaces / Patching",
+        "mounts": "Mounts",
     },
 }
 

--- a/docs/source/specs.rst
+++ b/docs/source/specs.rst
@@ -63,6 +63,15 @@ Run Status
 .. autoclass:: ReplicaState
    :members:
 
+
+Mounts
+--------
+
+.. autoclass:: BindMount
+   :members:
+
+.. autofunction:: parse_mounts
+
 Component Linter
 -----------------
 .. automodule:: torchx.specs.file_linter

--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -124,7 +124,7 @@ Components APIs
 import os
 import shlex
 from pathlib import Path
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional, List
 
 import torchx
 import torchx.specs as specs
@@ -146,6 +146,7 @@ def ddp(
     max_retries: int = 0,
     rdzv_backend: str = "c10d",
     rdzv_endpoint: Optional[str] = None,
+    mounts: Optional[List[str]] = None,
 ) -> specs.AppDef:
     """
     Distributed data parallel style application (one role, multi-replica).
@@ -171,6 +172,7 @@ def ddp(
         max_retries: the number of scheduler retries allowed
         rdzv_backend: rendezvous backend (only matters when nnodes > 1)
         rdzv_endpoint: rendezvous server endpoint (only matters when nnodes > 1), defaults to rank0 host for schedulers that support it
+        mounts: the list of mounts to bind mount into the worker environment/container (ex. type=bind,src=/host,dst=/job[,readonly])
     """
 
     if (script is None) == (m is None):
@@ -244,6 +246,7 @@ def ddp(
                     "c10d": 29500,
                 },
                 max_retries=max_retries,
+                mounts=specs.parse_mounts(mounts) if mounts else [],
             )
         ],
     )

--- a/torchx/components/test/dist_test.py
+++ b/torchx/components/test/dist_test.py
@@ -11,3 +11,9 @@ from torchx.components.component_test_base import ComponentTestCase
 class DistributedComponentTest(ComponentTestCase):
     def test_ddp(self) -> None:
         self.validate(dist, "ddp")
+
+    def test_ddp_mounts(self) -> None:
+        app = dist.ddp(
+            script="foo.py", mounts=["type=bind", "src=/dst", "dst=/dst", "readonly"]
+        )
+        self.assertEqual(len(app.roles[0].mounts), 1)

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -551,6 +551,7 @@ class LocalScheduler(Scheduler):
             workspaces: |
                 Partial support. LocalScheduler runs the app from a local
                 directory but does not support programmatic workspaces.
+            mounts: false
     """
 
     def __init__(

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -108,6 +108,28 @@ if _has_ray:
         actors: List[RayActor] = field(default_factory=list)
 
     class RayScheduler(Scheduler):
+        """
+        **Config Options**
+
+        .. runopts::
+            class: torchx.schedulers.ray_scheduler.RayScheduler
+
+        **Compatibility**
+
+        .. compatibility::
+            type: scheduler
+            features:
+                cancel: true
+                logs: true
+                distributed: true
+                describe: |
+                    Partial support. RayScheduler will return job status but
+                    does not provide the complete original AppSpec.
+                workspaces: false
+                mounts: false
+
+        """
+
         def __init__(self, session_name: str) -> None:
             super().__init__("ray", session_name)
 

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -272,6 +272,7 @@ class SlurmScheduler(Scheduler, DirWorkspace):
             workspaces: |
                 If ``job_dir`` is specified the DirWorkspace will create a new
                 isolated directory with a snapshot of the workspace.
+            mounts: false
     """
 
     def __init__(self, session_name: str) -> None:

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -39,6 +39,9 @@ def _test_app() -> specs.AppDef:
         port_map={"foo": 1234},
         num_replicas=2,
         max_retries=3,
+        mounts=[
+            specs.BindMount(src_path="/src", dst_path="/dst", read_only=True),
+        ],
     )
 
     return specs.AppDef("test", roles=[trainer_role])
@@ -109,6 +112,21 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                                     {"type": "GPU", "value": "4"},
                                 ],
                                 "logConfiguration": {"logDriver": "awslogs"},
+                                "mountPoints": [
+                                    {
+                                        "containerPath": "/dst",
+                                        "readOnly": True,
+                                        "sourceVolume": "mount_0",
+                                    }
+                                ],
+                                "volumes": [
+                                    {
+                                        "name": "mount_0",
+                                        "host": {
+                                            "sourcePath": "/src",
+                                        },
+                                    }
+                                ],
                             },
                         },
                         {
@@ -136,6 +154,21 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                                     {"type": "GPU", "value": "4"},
                                 ],
                                 "logConfiguration": {"logDriver": "awslogs"},
+                                "mountPoints": [
+                                    {
+                                        "containerPath": "/dst",
+                                        "readOnly": True,
+                                        "sourceVolume": "mount_0",
+                                    }
+                                ],
+                                "volumes": [
+                                    {
+                                        "name": "mount_0",
+                                        "host": {
+                                            "sourcePath": "/src",
+                                        },
+                                    }
+                                ],
                             },
                         },
                     ],

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import fsspec
-from docker.types import DeviceRequest
+from docker.types import DeviceRequest, Mount
 from torchx import specs
 from torchx.components.dist import ddp
 from torchx.schedulers.api import Stream
@@ -48,6 +48,9 @@ def _test_app() -> specs.AppDef:
         port_map={"foo": 1234},
         num_replicas=1,
         max_retries=3,
+        mounts=[
+            specs.BindMount(src_path="/tmp", dst_path="/tmp", read_only=True),
+        ],
     )
 
     return specs.AppDef("test", roles=[trainer_role])
@@ -105,6 +108,14 @@ class DockerSchedulerTest(unittest.TestCase):
                             "MaximumRetryCount": 3,
                         },
                         "network": "torchx",
+                        "mounts": [
+                            Mount(
+                                target="/tmp",
+                                source="/tmp",
+                                read_only=True,
+                                type="bind",
+                            )
+                        ],
                     },
                 )
             ],

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -26,6 +26,7 @@ from .api import (  # noqa: F401 F403
     AppHandle,
     AppState,
     AppStatus,
+    BindMount,
     CfgVal,
     InvalidRunConfigException,
     MalformedAppHandleException,
@@ -46,6 +47,7 @@ from .api import (  # noqa: F401 F403
     parse_app_handle,
     runopt,
     runopts,
+    parse_mounts,
 )
 
 


### PR DESCRIPTION
<!-- Change Summary -->

This adds a new Role option called `mounts` that allows for specifying different types of mounts on the worker. Currently the only supported mount is `BindMount` which does a simple bind from host to container. For more complex binds in the future we can easily extend `mounts: List[BindMount]` to `mounts: List[Union[BindMount, PersistentVolumeClaimMount]]` if necessary

This also adds in a new argument to `dist.ddp`

```shell
$ torchx run --scheduler local_docker --wait --log dist.ddp --script dist_app.py -j 1x1 --mounts type=bind,src=/tmp,dst=/tmp,readonly
```

To help with these parsing it there's a new `parse_mounts` method in specs. The format for these is:
```
type=bind,src=<src>,dst=<dst>[,readonly][,type=bind,...]
```

This follows the docker CLI format https://docs.docker.com/storage/bind-mounts/

Fixes #415

References
* https://docker-py.readthedocs.io/en/stable/api.html#docker.types.Mount
* https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
* https://docs.aws.amazon.com/batch/latest/APIReference/API_MountPoint.html

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI

Still need to add some more unit tests per scheduler (maybe component test?)
