### PR TITLE
update to torch 1.11, python 3.10

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -10,7 +10,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         platform: [ubuntu-18.04]
         include:
           - python-version: 3.9

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,12 +12,14 @@ kfp==1.8.9
 moto==3.0.2
 pyre-extensions==0.0.21
 pytest
-pytorch-lightning==1.5.6
-ray[default]==1.9.2
-torch-model-archiver==0.4.2
-torch==1.10.0
-torchserve==0.4.2
-torchtext==0.11.0
-torchvision==0.11.1
+pytorch-lightning==1.5.10
+torch-model-archiver>=0.4.2
+torch>=1.10.0
+torchserve>=0.4.2
+torchtext>=0.11.0
+torchvision>=0.11.1
 ts==0.5.1
 usort==0.6.4
+
+# Ray doesn't support Python 3.10
+ray[default]==1.11.0; python_version < '3.10'

--- a/torchx/runtime/container/Dockerfile
+++ b/torchx/runtime/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime
+FROM pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime
 
 WORKDIR /app
 

--- a/torchx/schedulers/ray/ray_driver.py
+++ b/torchx/schedulers/ray/ray_driver.py
@@ -137,6 +137,7 @@ def create_command_actors(
 
 def main() -> None:  # pragma: no cover
     actors: List[RayActor] = load_actor_json("actors.json")
+    # pyre-fixme[16]: Module `worker` has no attribute `init`.
     ray.init(address="auto", namespace="torchx-ray")
     pgs: List[PlacementGroup] = create_placement_groups(actors)
     command_actors: List[CommandActor] = create_command_actors(actors, pgs)
@@ -148,6 +149,7 @@ def main() -> None:  # pragma: no cover
 
     # Await return result of remote ray function
     while len(active_workers) > 0:
+        # pyre-fixme[16]: Module `worker` has no attribute `wait`.
         completed_workers, active_workers = ray.wait(active_workers)
         # If a failure occurs the ObjectRef will be marked as completed.
         # Calling ray.get will expose the failure as a RayActorError.

--- a/torchx/schedulers/test/ray_scheduler_test.py
+++ b/torchx/schedulers/test/ray_scheduler_test.py
@@ -258,12 +258,14 @@ if has_ray():
         def __new__(cls):  # pyre-ignore[3]
             if cls._instance is None:
                 cls._instance = super(RayClusterSetup, cls).__new__(cls)
+                # pyre-fixme[16]: Module `worker` has no attribute `shutdown`.
                 ray.shutdown()
                 start_status: int = os.system("ray start --head")
                 if start_status != 0:
                     raise AssertionError(
                         "ray start --head command has failed. Cannot proceed with running tests"
                     )
+                # pyre-fixme[16]: Module `worker` has no attribute `init`.
                 ray.init(address="auto", ignore_reinit_error=True)
                 cls.reference_count: int = 2
             return cls._instance
@@ -274,6 +276,7 @@ if has_ray():
                 cls.teardown_ray_cluster()
 
         def teardown_ray_cluster(cls) -> None:
+            # pyre-fixme[16]: Module `worker` has no attribute `shutdown`.
             ray.shutdown()
 
     class RayDriverTest(TestCase):
@@ -306,6 +309,7 @@ if has_ray():
         def test_ray_cluster(self) -> None:
             ray_cluster_setup = RayClusterSetup()
             ray_scheduler = self.setup_ray_cluster()
+            # pyre-fixme[16]: Module `worker` has no attribute `is_initialized`.
             assert ray.is_initialized() is True
 
             job_id = self.schedule_ray_job(ray_scheduler)

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -494,7 +494,7 @@ def get_type_name(tp: Type[CfgVal]) -> str:
 
     Note: we use this method to print out generic typing like List[str].
     """
-    if hasattr(tp, "__name__"):
+    if tp.__module__ != "typing" and hasattr(tp, "__name__"):
         return tp.__name__
     else:
         return str(tp)


### PR DESCRIPTION
<!-- Change Summary -->

Now that torch 1.11 is released we should update to it. Also adds python 3.10 support to the unit tests now that torch supports it.

Ray doesn't support Python 3.10 so we exclude it from dev-requirements on 3.10. https://github.com/ray-project/ray/pull/21221

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI

```
torchx/runtime/container/build.sh
```
