### PR TITLE
specs,schedulers: add VolumeMount

### DIFF
--- a/docs/source/specs.rst
+++ b/docs/source/specs.rst
@@ -67,10 +67,14 @@ Run Status
 Mounts
 --------
 
+.. autofunction:: parse_mounts
+
 .. autoclass:: BindMount
    :members:
 
-.. autofunction:: parse_mounts
+.. autoclass:: VolumeMount
+   :members:
+
 
 Component Linter
 -----------------

--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -172,7 +172,7 @@ def ddp(
         max_retries: the number of scheduler retries allowed
         rdzv_backend: rendezvous backend (only matters when nnodes > 1)
         rdzv_endpoint: rendezvous server endpoint (only matters when nnodes > 1), defaults to rank0 host for schedulers that support it
-        mounts: the list of mounts to bind mount into the worker environment/container (ex. type=bind,src=/host,dst=/job[,readonly])
+        mounts: mounts to mount into the worker environment/container (ex. type=<bind/volume>,src=/host,dst=/job[,readonly]). See scheduler documentation for more info.
     """
 
     if (script is None) == (m is None):

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -114,13 +114,30 @@ class DockerSchedulerTest(unittest.TestCase):
                                 source="/tmp",
                                 read_only=True,
                                 type="bind",
-                            )
+                            ),
                         ],
                     },
                 )
             ],
         )
         self.assertEqual(str(info), str(want))
+
+    def test_volume_mounts(self) -> None:
+        app = _test_app()
+        app.roles[0].mounts = [
+            specs.VolumeMount(src="name", dst_path="/tmp", read_only=True),
+        ]
+
+        info = self.scheduler._submit_dryrun(app, cfg={})
+        want = [
+            Mount(
+                target="/tmp",
+                source="name",
+                read_only=True,
+                type="volume",
+            ),
+        ]
+        self.assertEqual(info.request.containers[0].kwargs["mounts"], want)
 
     @patch("os.environ", {"FOO_1": "f1", "BAR_1": "b1", "FOOBAR_1": "fb1"})
     def test_copy_env(self) -> None:

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -27,6 +27,7 @@ from .api import (  # noqa: F401 F403
     AppState,
     AppStatus,
     BindMount,
+    VolumeMount,
     CfgVal,
     InvalidRunConfigException,
     MalformedAppHandleException,

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -38,6 +38,7 @@ from torchx.specs.api import (
     runopts,
     parse_mounts,
     BindMount,
+    VolumeMount,
 )
 
 
@@ -805,15 +806,16 @@ class MountsTest(unittest.TestCase):
                     "source=foo1",
                     "readonly",
                     "target=dst1",
-                    "type=bind",
+                    "type=volume",
                     "destination=dst2",
                     "source=foo2",
+                    "readonly",
                 ]
             ),
             [
                 BindMount(src_path="foo", dst_path="dst"),
                 BindMount(src_path="foo1", dst_path="dst1", read_only=True),
-                BindMount(src_path="foo2", dst_path="dst2"),
+                VolumeMount(src="foo2", dst_path="dst2", read_only=True),
             ],
         )
 
@@ -827,6 +829,6 @@ class MountsTest(unittest.TestCase):
         with self.assertRaisesRegex(KeyError, "src"):
             parse_mounts(["type=bind"])
         with self.assertRaisesRegex(
-            AssertionError, "only bind mounts are currently supported"
+            ValueError, "invalid mount type.*must be one of.*bind"
         ):
             parse_mounts(["type=foo"])


### PR DESCRIPTION
<!-- Change Summary -->
This adds a new mount type `volume` which allows mounting named volumes onto the container environment. It also updates the documentation for each scheduler to include mount support.

Per scheduler:
* Docker: named volume
* Kubernetes: PersistentVolumeClaimVolume
* AWS Batch: EFS ID - I'm a little hesitant on this since batch may add other volume types such as FSx etc

Closes https://github.com/pytorch/torchx/issues/422

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

added unit tests

CI

```
(torchx) tristanr@tristanr-arch2 ~/D/torchx-proj> torchx run --scheduler local_docker --wait --log dist.ddp -j 1x1 --script foo.py --mount type=volume,src=fo
o2,dst=/tmp
torchx 2022-03-15 17:23:42 INFO     loaded configs from /home/tristanr/Developer/torchx-proj/.torchxconfig
torchx 2022-03-15 17:23:42 INFO     Building workspace: file:///home/tristanr/Developer/torchx-proj for role[0]: foo, image: ghcr.io/pytorch/torchx:0.1.2dev0
torchx 2022-03-15 17:23:44 INFO     Done building workspace
torchx 2022-03-15 17:23:44 INFO     New image: sha256:82c6b984bd64c9c38aa86c4cb855b88ce3d62c65c50519372cd63f382d4bb71c built from workspace
local_docker://torchx/foo-nn5vkq7sc2xz9c
torchx 2022-03-15 17:23:45 INFO     Waiting for the app to finish...
foo/0 [0]:hello
torchx 2022-03-15 17:23:51 INFO     Job finished: SUCCEEDED
(torchx) tristanr@tristanr-arch2 ~/D/torchx-proj> docker volume ls | rg foo2
local     foo2
```
