### PR TITLE
schedulers: set /dev/shm size for docker based schedulers to bypass 64M default

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -85,10 +85,10 @@ def _role_to_node_properties(idx: int, role: Role) -> Dict[str, object]:
         cpu = 1
     reqs.append({"type": "VCPU", "value": str(cpu)})
 
-    mem = resource.memMB
-    if mem <= 0:
-        mem = 1000
-    reqs.append({"type": "MEMORY", "value": str(mem)})
+    memMB = resource.memMB
+    if memMB <= 0:
+        memMB = 1000
+    reqs.append({"type": "MEMORY", "value": str(memMB)})
 
     if resource.gpu > 0:
         reqs.append({"type": "GPU", "value": str(resource.gpu)})
@@ -130,6 +130,11 @@ def _role_to_node_properties(idx: int, role: Role) -> Dict[str, object]:
         "image": role.image,
         "environment": [{"name": k, "value": v} for k, v in role.env.items()],
         "resourceRequirements": reqs,
+        "linuxParameters": {
+            # To support PyTorch dataloaders we need to set /dev/shm to larger
+            # than the 64M default.
+            "sharedMemorySize": memMB,
+        },
         "logConfiguration": {
             "logDriver": "awslogs",
         },

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -269,7 +269,11 @@ class DockerScheduler(Scheduler, DockerWorkspace):
                     }
                 resource = replica_role.resource
                 if resource.memMB >= 0:
-                    c.kwargs["mem_limit"] = f"{int(resource.memMB)}m"
+                    # To support PyTorch dataloaders we need to set /dev/shm to
+                    # larger than the 64M default.
+                    c.kwargs["mem_limit"] = c.kwargs[
+                        "shm_size"
+                    ] = f"{int(resource.memMB)}m"
                 if resource.cpu >= 0:
                     c.kwargs["nano_cpus"] = int(resource.cpu * 1e9)
                 if resource.gpu > 0:

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -112,6 +112,9 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                                     {"type": "MEMORY", "value": "3000"},
                                     {"type": "GPU", "value": "4"},
                                 ],
+                                "linuxParameters": {
+                                    "sharedMemorySize": 3000,
+                                },
                                 "logConfiguration": {"logDriver": "awslogs"},
                                 "mountPoints": [
                                     {
@@ -154,6 +157,9 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                                     {"type": "MEMORY", "value": "3000"},
                                     {"type": "GPU", "value": "4"},
                                 ],
+                                "linuxParameters": {
+                                    "sharedMemorySize": 3000,
+                                },
                                 "logConfiguration": {"logDriver": "awslogs"},
                                 "mountPoints": [
                                     {

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -100,6 +100,7 @@ class DockerSchedulerTest(unittest.TestCase):
                             "torchx.pytorch.org/version": "0.1.2dev0",
                         },
                         "mem_limit": "3000m",
+                        "shm_size": "3000m",
                         "name": "app_name_42-trainer-0",
                         "hostname": "app_name_42-trainer-0",
                         "nano_cpus": int(2e9),

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -118,6 +118,7 @@ class KubernetesSchedulerTest(unittest.TestCase):
             V1Volume,
             V1VolumeMount,
             V1HostPathVolumeSource,
+            V1EmptyDirVolumeSource,
         )
 
         app = _test_app()
@@ -149,10 +150,14 @@ class KubernetesSchedulerTest(unittest.TestCase):
             ports=[V1ContainerPort(name="foo", container_port=1234)],
             volume_mounts=[
                 V1VolumeMount(
+                    name="dshm",
+                    mount_path="/dev/shm",
+                ),
+                V1VolumeMount(
                     name="mount-0",
                     mount_path="/dst",
                     read_only=True,
-                )
+                ),
             ],
         )
         want = V1Pod(
@@ -161,6 +166,12 @@ class KubernetesSchedulerTest(unittest.TestCase):
                 restart_policy="Never",
                 service_account_name="srvacc",
                 volumes=[
+                    V1Volume(
+                        name="dshm",
+                        empty_dir=V1EmptyDirVolumeSource(
+                            medium="Memory",
+                        ),
+                    ),
                     V1Volume(
                         name="mount-0",
                         host_path=V1HostPathVolumeSource(
@@ -272,11 +283,16 @@ spec:
               memory: 3000M
               nvidia.com/gpu: '4'
           volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
           - mountPath: /dst
             name: mount-0
             readOnly: true
         restartPolicy: Never
         volumes:
+        - emptyDir:
+            medium: Memory
+          name: dshm
         - hostPath:
             path: /src
           name: mount-0
@@ -289,6 +305,7 @@ spec:
             V1Volume,
             V1VolumeMount,
             V1PersistentVolumeClaimVolumeSource,
+            V1EmptyDirVolumeSource,
         )
 
         role = specs.Role(
@@ -303,6 +320,12 @@ spec:
             pod.spec.volumes,
             [
                 V1Volume(
+                    name="dshm",
+                    empty_dir=V1EmptyDirVolumeSource(
+                        medium="Memory",
+                    ),
+                ),
+                V1Volume(
                     name="mount-0",
                     persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
                         claim_name="name",
@@ -314,10 +337,14 @@ spec:
             pod.spec.containers[0].volume_mounts,
             [
                 V1VolumeMount(
+                    name="dshm",
+                    mount_path="/dev/shm",
+                ),
+                V1VolumeMount(
                     name="mount-0",
                     mount_path="/dst",
                     read_only=True,
-                )
+                ),
             ],
         )
 


### PR DESCRIPTION
<!-- Change Summary -->

PyTorch dataloaders use `/dev/shm` to transfer data between processes. The default in docker containers is 64MB so we need to increase this for more complex models.

* DockerScheduler: sets `shm_size` to mem request
* AWSBatchScheduler: sets sharedMemorySize to mem request
* KubernetesScheduler: mounts an unlimited tmpfs onto `/dev/shm`

Fixes #428 

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```py
import torch
from torch.utils.data import Dataset, DataLoader

class BigDataset(Dataset):
    def __init__(self, size):
        self.size = size

    def __len__(self):
        return 20

    def __getitem__(self, idx):
        return torch.zeros((1,self.size))

dataset = BigDataset(100_000_000)
dataloader = DataLoader(dataset, batch_size=1, num_workers=1)

for i, x in enumerate(dataloader):
    print(i, x.shape)
```

```shell
torchx run --scheduler {local_docker,kubernetes,aws_batch} --wait --log dist.ddp --memMB 2000 -j 1x1 --script large-shm.py
```
