### PR TITLE
(torchx/components) simplify rendezvous parameters for dist.ddp, allow users to pass custom port, always use c10d rendezvous, and pick a free random port for single node

### DIFF
--- a/torchx/components/__init__.py
+++ b/torchx/components/__init__.py
@@ -91,7 +91,7 @@ the :py:func:`torchx.components.dist.ddp` builtin.
                 args=[
                     "-m",
                     "torch.distributed.run",
-                    "--rdzv_backend=etcd",
+                    "--rdzv_backend=c10d",
                     "--rdzv_endpoint=localhost:5900",
                     f"--nnodes={nnodes}",
                     f"--nprocs_per_node={nprocs_per_node}",


### PR DESCRIPTION
Summary:
Currently the rdzv_backend, rdzv_endpoint and their respective defaults only work in a specific combination.

Example: `--rdzv_backend="etcd"` won't work with the default `--rdzv_endpoint` since the user needs to run etcd server on the rank0's host, which isn't known at launch time.

This PR simplifies rdzv parameters by:

1. always using c10d (for both single and multi-node) - we were defaulting to this anyways and I doubt rdzv_backend != c10d worked for anyone out of the box.
1. breaking `rdzv_endpoint` into `rdzv_host`  and `rdzv_port`  and hard coding rdzv_host to `TORCHX_RANK0_HOST`, while defaulting `rdzv_port=29500` and still giving the user a way to override it based on their firewall settings.
1. Ignore `rdzv_port` for single node launches and use `localhost:0` which lets elastic chose a free random port. Enables running multiple single node jobs locally without a port conflict. (e.g. four jobs of -j 1x2 on a devgpu with 8 gpus)
1. Improves documentation of the component

Differential Revision: D35085959

