### PR TITLE
schedulers/kubernetes_scheduler: add support for resource instance-type node selectors

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,5 @@ ipykernel
 nbsphinx
 jupytext
 ipython_genutils
+# https://github.com/jupyter/nbconvert/issues/1736
+jinja2<=3.0.3

--- a/scripts/kube_dist_trainer.py
+++ b/scripts/kube_dist_trainer.py
@@ -32,6 +32,9 @@ def register_gpu_resource() -> None:
         cpu=2,
         gpu=1,
         memMB=8 * GiB,
+        capabilities={
+            "node.kubernetes.io/instance-type": "p3.2xlarge",
+        },
     )
     print(f"Registering resource: {res}")
     named_resources["GPU_X1"] = res

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -85,6 +85,9 @@ if TYPE_CHECKING:
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+RESERVED_MILLICPU = 100
+RESERVED_MEMMB = 1024
+
 RETRY_POLICIES: Mapping[str, Iterable[Mapping[str, str]]] = {
     RetryPolicy.REPLICA: [],
     RetryPolicy.APPLICATION: [
@@ -152,6 +155,8 @@ LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
 
 ANNOTATION_ISTIO_SIDECAR = "sidecar.istio.io/inject"
 
+LABEL_INSTANCE_TYPE = "node.kubernetes.io/instance-type"
+
 
 def sanitize_for_serialization(obj: object) -> object:
     from kubernetes import client
@@ -176,20 +181,34 @@ def role_to_pod(name: str, role: Role, service_account: Optional[str]) -> "V1Pod
         V1EmptyDirVolumeSource,
     )
 
+    # limits puts an upper cap on the resources a pod may consume.
+    # requests is how much the scheduler allocates. We assume that the jobs will
+    # be allocation the whole machine so requests is slightly lower than the
+    # requested resources to account for the Kubernetes node reserved resources.
+    limits = {}
     requests = {}
 
     resource = role.resource
-    if resource.cpu >= 0:
-        requests["cpu"] = f"{int(resource.cpu * 1000)}m"
-    if resource.memMB >= 0:
-        requests["memory"] = f"{int(resource.memMB)}M"
-    if resource.gpu >= 0:
-        requests["nvidia.com/gpu"] = str(resource.gpu)
+    if resource.cpu > 0:
+        mcpu = int(resource.cpu * 1000)
+        limits["cpu"] = f"{mcpu}m"
+        request_mcpu = max(mcpu - RESERVED_MILLICPU, 0)
+        requests["cpu"] = f"{request_mcpu}m"
+    if resource.memMB > 0:
+        limits["memory"] = f"{int(resource.memMB)}M"
+        request_memMB = max(int(resource.memMB) - RESERVED_MEMMB, 0)
+        requests["memory"] = f"{request_memMB}M"
+    if resource.gpu > 0:
+        requests["nvidia.com/gpu"] = limits["nvidia.com/gpu"] = str(resource.gpu)
 
     resources = V1ResourceRequirements(
-        limits=requests,
+        limits=limits,
         requests=requests,
     )
+
+    node_selector: Dict[str, str] = {}
+    if LABEL_INSTANCE_TYPE in resource.capabilities:
+        node_selector[LABEL_INSTANCE_TYPE] = resource.capabilities[LABEL_INSTANCE_TYPE]
 
     # To support PyTorch dataloaders we need to set /dev/shm to larger than the
     # 64M default so we mount an unlimited sized tmpfs directory on it.
@@ -264,6 +283,7 @@ def role_to_pod(name: str, role: Role, service_account: Optional[str]) -> "V1Pod
             restart_policy="Never",
             service_account_name=service_account,
             volumes=volumes,
+            node_selector=node_selector,
         ),
         metadata=V1ObjectMeta(
             annotations={
@@ -415,6 +435,29 @@ class KubernetesScheduler(Scheduler, DockerWorkspace):
     See :py:func:`torchx.specs.parse_mounts` for more info.
 
     External docs: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+
+    **Resources / Allocation**
+
+    To select a specific machine type you can add a capability to your resources
+    with ``node.kubernetes.io/instance-type`` which will constrain the launched
+    jobs to nodes of that instance type.
+
+    >>> from torchx import specs
+    >>> specs.Resource(
+    ...     cpu=4,
+    ...     memMB=16000,
+    ...     gpu=2,
+    ...     capabilities={
+    ...         "node.kubernetes.io/instance-type": "<cloud instance type>",
+    ...     },
+    ... )
+    Resource(...)
+
+    Kubernetes may reserve some memory for the host. TorchX assumes you're
+    scheduling on whole hosts and thus will automatically reduce the resource
+    request by a small amount to account for the node reserved CPU and memory.
+    If you run into scheduling issues you may need to reduce the requested CPU
+    and memory from the host values.
 
     **Compatibility**
 

--- a/torchx/schedulers/test/.gitignore
+++ b/torchx/schedulers/test/.gitignore
@@ -1,0 +1,1 @@
+actors.json

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -13,7 +13,7 @@ scheduler or pipeline adapter.
 
 from typing import Dict, Optional
 
-import torchx.specs.named_resources_aws as aws_resources
+import torchx.specs.named_resources_aws as named_resources_aws
 from torchx.util.entrypoints import load_group
 
 from .api import (  # noqa: F401 F403
@@ -58,14 +58,9 @@ GiB: int = 1024
 def _load_named_resources() -> Dict[str, Resource]:
     resource_methods = load_group("torchx.named_resources", default={})
     materialized_resources = {}
-    default = {
-        "aws_t3.medium": aws_resources.aws_t3_medium(),
-        "aws_m5.2xlarge": aws_resources.aws_m5_2xlarge(),
-        "aws_p3.2xlarge": aws_resources.aws_p3_2xlarge(),
-        "aws_p3.8xlarge": aws_resources.aws_p3_8xlarge(),
-    }
+    default = named_resources_aws.NAMED_RESOURCES
     for name, resource in default.items():
-        materialized_resources[name] = resource
+        materialized_resources[name] = resource()
     for resource_name, resource_method in resource_methods.items():
         materialized_resources[resource_name] = resource_method()
     materialized_resources["NULL"] = NULL_RESOURCE

--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -29,6 +29,8 @@ Usage:
 
 """
 
+from typing import Mapping, Callable
+
 from torchx.specs.api import Resource
 
 GiB: int = 1024
@@ -39,7 +41,9 @@ def aws_p3_2xlarge() -> Resource:
         cpu=8,
         gpu=1,
         memMB=61 * GiB,
-        capabilities={},
+        capabilities={
+            "node.kubernetes.io/instance-type": "p3.2xlarge",
+        },
     )
 
 
@@ -48,7 +52,9 @@ def aws_p3_8xlarge() -> Resource:
         cpu=32,
         gpu=4,
         memMB=244 * GiB,
-        capabilities={},
+        capabilities={
+            "node.kubernetes.io/instance-type": "p3.8xlarge",
+        },
     )
 
 
@@ -57,7 +63,9 @@ def aws_t3_medium() -> Resource:
         cpu=2,
         gpu=0,
         memMB=4 * GiB,
-        capabilities={},
+        capabilities={
+            "node.kubernetes.io/instance-type": "t3.medium",
+        },
     )
 
 
@@ -66,5 +74,27 @@ def aws_m5_2xlarge() -> Resource:
         cpu=8,
         gpu=0,
         memMB=32 * GiB,
-        capabilities={},
+        capabilities={
+            "node.kubernetes.io/instance-type": "m5.2xlarge",
+        },
     )
+
+
+def aws_g4dn_xlarge() -> Resource:
+    return Resource(
+        cpu=4,
+        gpu=1,
+        memMB=16 * GiB,
+        capabilities={
+            "node.kubernetes.io/instance-type": "g4dn.xlarge",
+        },
+    )
+
+
+NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = {
+    "aws_t3.medium": aws_t3_medium,
+    "aws_m5.2xlarge": aws_m5_2xlarge,
+    "aws_p3.2xlarge": aws_p3_2xlarge,
+    "aws_p3.8xlarge": aws_p3_8xlarge,
+    "aws_g4dn.xlarge": aws_g4dn_xlarge,
+}

--- a/torchx/specs/test/named_resources_test_aws.py
+++ b/torchx/specs/test/named_resources_test_aws.py
@@ -13,6 +13,7 @@ from torchx.specs.named_resources_aws import (
     aws_m5_2xlarge,
     aws_t3_medium,
     GiB,
+    NAMED_RESOURCES,
 )
 
 
@@ -40,3 +41,8 @@ class NamedResourcesTest(unittest.TestCase):
         self.assertEqual(2, resource.cpu)
         self.assertEqual(0, resource.gpu)
         self.assertEqual(4 * GiB, resource.memMB)
+
+    def test_capabilities(self) -> None:
+        for name, func in NAMED_RESOURCES.items():
+            resource = func()
+            self.assertIn("node.kubernetes.io/instance-type", resource.capabilities)


### PR DESCRIPTION
<!-- Change Summary -->

This allows specifying specific instance types when scheduling kubernetes jobs. It uses `node_selectors` and the `node.kubernetes.io/instance-type` label on nodes to limit pods to specific instances.

To avoid instance type cpu and memory hitting issues with the node reserved cpu/mem this will subtract a small amount of CPU and memory from the requested resources. Limits remains the same.

Also adds g4dn.xlarge resource type.

* https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
* https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Unit tests, updated kube dist integration test to specify instance type

```
spec:
  containers:
  - command:
    - python
    - -m
    - torch.distributed.run
    - --rdzv_backend
    - etcd
    - --rdzv_endpoint
    - etcd-server:2379
    - --rdzv_id
    - cv-trainer-smvh1095z11h5
    - --nnodes
    - "2"
    - --nproc_per_node
    - "1"
    - -m
    - torchx.examples.apps.lightning_classy_vision.train
    - --load_path
    - ""
    - --log_path
    - /tmp/logs
    - --epochs
    - "1"
    - --output_path
    - s3://torchx-test/integration-tests/runner_wh5wn4cz4b7fcd/output
    env:
    - name: TORCHX_RANK0_HOST
      value: localhost
    - name: VC_WORKER_0_HOSTS
      valueFrom:
        configMapKeyRef:
          key: VC_WORKER_0_HOSTS
          name: cv-trainer-smvh1095z11h5-svc
    - name: VC_WORKER_0_NUM
      valueFrom:
        configMapKeyRef:
          key: VC_WORKER_0_NUM
          name: cv-trainer-smvh1095z11h5-svc
    - name: VC_WORKER_1_HOSTS
      valueFrom:
        configMapKeyRef:
          key: VC_WORKER_1_HOSTS
          name: cv-trainer-smvh1095z11h5-svc
    - name: VC_WORKER_1_NUM
      valueFrom:
        configMapKeyRef:
          key: VC_WORKER_1_NUM
          name: cv-trainer-smvh1095z11h5-svc
    - name: VK_TASK_INDEX
      value: "0"
    - name: VC_TASK_INDEX
      value: "0"
    image: 495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/integration-tests:canary_runner_wh5wn4cz4b7fcd_torchx
    imagePullPolicy: IfNotPresent
    name: worker-0
    resources:
      limits:
        cpu: "2"
        memory: 8192M
        nvidia.com/gpu: "1"
      requests:
        cpu: 1900m
        memory: 7168M
        nvidia.com/gpu: "1"
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /dev/shm
      name: dshm
    - mountPath: /etc/volcano
      name: cv-trainer-smvh1095z11h5-svc
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-z8vb9
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  hostname: cv-trainer-smvh1095z11h5-worker-0-0
  nodeName: ip-192-168-16-165.us-west-2.compute.internal
  nodeSelector:
    node.kubernetes.io/instance-type: p3.2xlarge
```

https://github.com/pytorch/torchx/runs/5698855673?check_suite_focus=true