### PR TITLE
torchx/specs,schedulers: add new DeviceMount for mounting host devices

### DIFF
--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -116,6 +116,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                                 ],
                                 "linuxParameters": {
                                     "sharedMemorySize": 3000,
+                                    "devices": [],
                                 },
                                 "logConfiguration": {"logDriver": "awslogs"},
                                 "mountPoints": [
@@ -161,6 +162,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                                 ],
                                 "linuxParameters": {
                                     "sharedMemorySize": 3000,
+                                    "devices": [],
                                 },
                                 "logConfiguration": {"logDriver": "awslogs"},
                                 "mountPoints": [
@@ -226,6 +228,34 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                     "containerPath": "/dst",
                     "readOnly": True,
                     "sourceVolume": "mount_0",
+                }
+            ],
+        )
+
+    def test_device_mounts(self) -> None:
+        role = specs.Role(
+            name="foo",
+            image="",
+            mounts=[
+                specs.DeviceMount(
+                    src_path="/dev/foo", dst_path="/dev/bar", permissions="rwm"
+                )
+            ],
+            resource=specs.Resource(
+                cpu=1,
+                memMB=1000,
+                gpu=0,
+            ),
+        )
+        props = _role_to_node_properties(0, role)
+        self.assertEqual(
+            # pyre-fixme[16]: `object` has no attribute `__getitem__`.
+            props["container"]["linuxParameters"]["devices"],
+            [
+                {
+                    "hostPath": "/dev/foo",
+                    "containerPath": "/dev/bar",
+                    "permissions": ["READ", "WRITE", "MKNOD"],
                 }
             ],
         )

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -28,6 +28,7 @@ from .api import (  # noqa: F401 F403
     AppStatus,
     BindMount,
     VolumeMount,
+    DeviceMount,
     CfgVal,
     InvalidRunConfigException,
     MalformedAppHandleException,

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -39,6 +39,7 @@ from torchx.specs.api import (
     parse_mounts,
     BindMount,
     VolumeMount,
+    DeviceMount,
 )
 
 
@@ -810,12 +811,20 @@ class MountsTest(unittest.TestCase):
                     "destination=dst2",
                     "source=foo2",
                     "readonly",
+                    "type=device",
+                    "src=duck",
+                    "type=device",
+                    "src=foo",
+                    "dst=bar",
+                    "perm=rw",
                 ]
             ),
             [
                 BindMount(src_path="foo", dst_path="dst"),
                 BindMount(src_path="foo1", dst_path="dst1", read_only=True),
                 VolumeMount(src="foo2", dst_path="dst2", read_only=True),
+                DeviceMount(src_path="duck", dst_path="duck", permissions="rwm"),
+                DeviceMount(src_path="foo", dst_path="bar", permissions="rw"),
             ],
         )
 


### PR DESCRIPTION
<!-- Change Summary -->

This adds in a new mount type `DeviceMount` that allows mounting a host device into a container in the supported schedulers. Docker provides this as a special "devices" field but that generalizes to just mounting a host device into a container as you would with `mount --bind` so we call it a mount. It also avoids adding any new concepts to the CLI.

* Docker: sets the devices parameter https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run
* AWS Batch: sets the devices parameter https://docs.aws.amazon.com/batch/latest/APIReference/API_LinuxParameters.html
* Kubernetes: does a bind mount w/ privileged mode since devices isn't supported https://stackoverflow.com/questions/59290752/how-to-use-device-dev-video0-with-kubernetes


Closes #438

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Added unit tests for docker, batch, k8s

CI

```
$ torchx run --scheduler aws_batch -c queue=torchx-p3dn --wait --log dist.ddp --memMB 16000 --env NCCL_DEBUG=INFO,LOGLEVEL=INFO,NCCL_SOCKET_IFNAME=eth0 -j 2x1 --image 763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:1.10.2-gpu-py38-cu113-ubuntu20.04-e3 --mount type=device,src=/dev/infiniband/uverbs0 --gpu 8 --script dist_app.py
```

dist_app.py
```
(torchx) tristanr@tristanr-arch2 ~/D/torchx (devices) [1]> cat ../torchx-proj/dist_app.py
import torch
import torch.distributed as dist

if torch.cuda.is_available():
    dist.init_process_group(backend="nccl")
    device = torch.device('cuda')
else:
    dist.init_process_group(backend="gloo")
    device = torch.device('cpu')

print(f"I am worker {dist.get_rank()} of {dist.get_world_size()}!")


a = torch.tensor([dist.get_rank()], device=device)
dist.all_reduce(a)
print(f"all_reduce output = {a}")

import os

os.system("ls -lah /dev/infiniband")
os.system("find /dev")
```
