### PR TITLE
(torchx/examples) move compute_world_size from fb dir to oss

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -3,7 +3,8 @@
     ".*/build/.*",
     ".*/docs/.*",
     ".*/setup.py",
-    ".*/IPython/core/tests/nonascii.*"
+    ".*/IPython/core/tests/nonascii.*",
+    ".*/torchx/examples/apps/compute_world_size/.*"
   ],
   "source_directories": [
     "typestubs",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ captum>=0.4.0
 classy-vision>=0.6.0
 flake8==3.9.0
 fsspec[s3]==2022.1.0
+hydra-core
 importlib-metadata
 ipython
 kfp==1.8.9

--- a/torchx/examples/apps/.torchxconfig
+++ b/torchx/examples/apps/.torchxconfig
@@ -27,13 +27,13 @@ component = fb.dist.hpc
 # TODO need to add hydra to bento_kernel_torchx and make that the default img
 [component:fb.dist.ddp]
 img = bento_kernel_pytorch_lightning
-m = fb/compute_world_size/main.py
+m = compute_world_size/main.py
 
 [component:fb.dist.ddp2]
 img = bento_kernel_pytorch_lightning
-m = fb/compute_world_size/main.py
+m = compute_world_size/main.py
 
 [component:fb.dist.hpc]
 img = bento_kernel_pytorch_lightning
-m = fb/compute_world_size/main.py
+m = compute_world_size/main.py
 

--- a/torchx/examples/apps/compute_world_size/README.rst
+++ b/torchx/examples/apps/compute_world_size/README.rst
@@ -1,0 +1,15 @@
+Compute World Size Example
+############################
+
+This is a minimal "hello world" style  example application that uses
+PyTorch Distributed to compute the world size. It is a minimal example
+in that it initializes the ``torch.distributed`` process group and
+performs a single collective operation (all_reduce) which is enough to
+validate the infrastructure and scheduler setup.
+
+This example is compatible with the ``dist.ddp``. To run from CLI:
+
+.. code-block:: shell-session
+
+ $ cd $torchx-git-repo-root/torchx/examples/apps
+ $ torchx run dist.ddp --script compute_world_size/main.py -j 1x2

--- a/torchx/examples/apps/compute_world_size/config/defaults.yaml
+++ b/torchx/examples/apps/compute_world_size/config/defaults.yaml
@@ -1,0 +1,10 @@
+hydra:
+  run:
+    dir: /tmp
+main:
+  backend: gloo
+  rank: 0
+  world_size: 1
+  master_addr: localhost
+  master_port: 29500
+  throws: False

--- a/torchx/examples/apps/compute_world_size/main.py
+++ b/torchx/examples/apps/compute_world_size/main.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""
+Compute World Size Example
+============================
+
+This is a minimal "hello world" style  example application that uses
+PyTorch Distributed to compute the world size. It does not do ML training
+but it does initialize process groups and performs a single collective operation (all_reduce)
+which is enough to validate the infrastructure and scheduler setup.
+
+As simple as this application is, the actual ``compute_world_size()`` function is
+split into a separate submodule (``.module.util.compute_world_size``) to double
+as a E2E test for workspace patching logic, which typically diff-patches a full project
+directory rather than a single file. This application also uses `Hydra <https://hydra.cc/docs/intro/>`_
+configs as an expository example of how to use Hydra configs in an application that launches with TorchX.
+
+Run it with the ``dist.ddp`` builtin component to use as a validation application
+to ensure that the stack has been setup properly for more serious distributed training jobs.
+"""
+
+import hydra
+from omegaconf import DictConfig, OmegaConf
+from torch.distributed.elastic.multiprocessing.errors import record
+from torchx.examples.apps.compute_world_size.module.util import compute_world_size
+
+
+@record  # pyre-ignore[56]
+def run(cfg: DictConfig) -> None:
+    print(OmegaConf.to_yaml(cfg))
+
+    if cfg.main.throws:
+        raise RuntimeError(f"raising error because cfg.main.throws={cfg.main.throws}")
+    compute_world_size(cfg)
+
+
+if __name__ == "__main__":
+    # use compose API to make this compatible with ipython notebooks
+    # need to initialize the config directory as a module to make it
+    # not depends on rel path (PWD) or abs path (torchx install dir)
+    # see: https://hydra.cc/docs/advanced/jupyter_notebooks/
+    with hydra.initialize_config_module(
+        config_module="torchx.examples.apps.compute_world_size.config"
+    ):
+        cfg: DictConfig = hydra.compose(config_name="defaults")
+        run(cfg)

--- a/torchx/examples/apps/compute_world_size/module/util.py
+++ b/torchx/examples/apps/compute_world_size/module/util.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from omegaconf import DictConfig
+
+
+def compute_world_size(cfg: DictConfig) -> int:
+
+    rank = int(os.getenv("RANK", cfg.main.rank))
+    world_size = int(os.getenv("WORLD_SIZE", cfg.main.world_size))
+    master_addr = os.getenv("MASTER_ADDR", cfg.main.master_addr)
+    master_port = int(os.getenv("MASTER_PORT", cfg.main.master_port))
+    backend = cfg.main.backend
+
+    print(f"initializing `{backend}` process group")
+    dist.init_process_group(
+        backend=backend,
+        init_method=f"tcp://{master_addr}:{master_port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    print("successfully initialized process group")
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    t = F.one_hot(torch.tensor(rank), num_classes=world_size)
+    dist.all_reduce(t)
+    computed_world_size = int(torch.sum(t).item())
+    print(
+        f"rank: {rank}, actual world_size: {world_size}, computed world_size: {computed_world_size}"
+    )
+    return computed_world_size


### PR DESCRIPTION
Summary: Simply moves the compute world size example to oss

Reviewed By: d4l3k

Differential Revision: D35301076

