### PR TITLE
Support k8s device plugins/resource limits (#443)

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -59,6 +59,7 @@ from torchx.schedulers.api import (
     Stream,
     filter_regex,
 )
+from torchx.schedulers.devices import get_device_mounts
 from torchx.schedulers.ids import make_unique
 from torchx.specs.api import (
     AppDef,
@@ -104,6 +105,8 @@ def _role_to_node_properties(idx: int, role: Role) -> Dict[str, object]:
 
     if resource.gpu > 0:
         reqs.append({"type": "GPU", "value": str(resource.gpu)})
+
+    role.mounts += get_device_mounts(resource.devices)
 
     mount_points = []
     volumes = []

--- a/torchx/schedulers/devices.py
+++ b/torchx/schedulers/devices.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Mapping, Tuple, Callable
+
+from torchx.specs.api import DeviceMount
+
+DEVICES: Mapping[str, Callable] = {
+    "vpc.amazonaws.com/efa": lambda device_index: DeviceMount(
+        src_path="/dev/infiniband/uverbs" + str(device_index),
+        dst_path="/dev/infiniband/uverbs" + str(device_index),
+    ),
+}
+
+
+def get_device_mounts(devices: Tuple[str, int]) -> list[DeviceMount]:
+    """
+    Takes in a list of named devices/quantities, and returns a list of DeviceMount objects
+    based on the mappings defined in DEVICES
+    """
+    device_mounts = []
+    for device in devices:
+        [device_name, num_devices] = device
+        if device_name not in DEVICES:
+            continue
+        device_mounts+=list(map(DEVICES[device_name], range(0, num_devices)))
+    return device_mounts

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -22,6 +22,7 @@ from torchx.schedulers.api import (
     filter_regex,
     split_lines,
 )
+from torchx.schedulers.devices import get_device_mounts
 from torchx.schedulers.ids import make_unique
 from torchx.specs.api import (
     AppDef,
@@ -209,6 +210,7 @@ class DockerScheduler(Scheduler, DockerWorkspace):
         for role in app.roles:
             mounts = []
             devices = []
+            role.mounts += get_device_mounts(role.resource.devices)
             for mount in role.mounts:
                 if isinstance(mount, BindMount):
                     mounts.append(

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -207,6 +207,9 @@ def role_to_pod(name: str, role: Role, service_account: Optional[str]) -> "V1Pod
     if resource.gpu > 0:
         requests["nvidia.com/gpu"] = limits["nvidia.com/gpu"] = str(resource.gpu)
 
+    for [device_name, device_limit] in resource.devices:
+        limits[device_name] = str(device_limit)
+
     resources = V1ResourceRequirements(
         limits=limits,
         requests=requests,

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -260,6 +260,38 @@ class AWSBatchSchedulerTest(unittest.TestCase):
             ],
         )
 
+    def test_resource_devices(self) -> None:
+        role = specs.Role(
+            name="foo",
+            image="",
+            mounts=[],
+            resource=specs.Resource(
+                cpu=1,
+                memMB=1000,
+                gpu=0,
+                devices=[
+                    ("vpc.amazonaws.com/efa", 2)
+                ]
+            ),
+        )
+        props = _role_to_node_properties(0, role)
+        self.assertEqual(
+            # pyre-fixme[16]: `object` has no attribute `__getitem__`.
+            props["container"]["linuxParameters"]["devices"],
+            [
+                {
+                    "hostPath": "/dev/infiniband/uverbs0",
+                    "containerPath": "/dev/infiniband/uverbs0",
+                    "permissions": ["READ", "WRITE", "MKNOD"],
+                },
+                {
+                    "hostPath": "/dev/infiniband/uverbs1",
+                    "containerPath": "/dev/infiniband/uverbs1",
+                    "permissions": ["READ", "WRITE", "MKNOD"],
+                }
+            ],
+        )
+
     def _mock_scheduler(self) -> AWSBatchScheduler:
         scheduler = AWSBatchScheduler(
             "test",

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -154,6 +154,16 @@ class DockerSchedulerTest(unittest.TestCase):
         info = self.scheduler._submit_dryrun(app, cfg={})
         self.assertEqual(info.request.containers[0].kwargs["devices"], ["foo:bar:rwm"])
 
+    def test_resource_devices(self) -> None:
+        app = _test_app()
+        app.roles[0].resource.devices = [
+            ("vpc.amazonaws.com/efa", 1)
+        ]
+
+        info = self.scheduler._submit_dryrun(app, cfg={})
+        self.assertEqual(info.request.containers[0].kwargs["devices"],
+                         ["/dev/infiniband/uverbs0:/dev/infiniband/uverbs0:rwm"])
+
     @patch("os.environ", {"FOO_1": "f1", "BAR_1": "b1", "FOOBAR_1": "fb1"})
     def test_copy_env(self) -> None:
         app = _test_app()

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -69,15 +69,15 @@ class KubernetesSchedulerTest(unittest.TestCase):
         app = _test_app()
         unique_app_name = "app-name-42"
         with patch(
-            "torchx.schedulers.kubernetes_scheduler.make_unique"
+                "torchx.schedulers.kubernetes_scheduler.make_unique"
         ) as make_unique_ctx:
             make_unique_ctx.return_value = unique_app_name
             resource = app_to_resource(app, "test_queue", service_account=None)
             actual_cmd = (
                 # pyre-ignore [16]
                 resource["spec"]["tasks"][0]["template"]
-                .spec.containers[0]
-                .command
+                    .spec.containers[0]
+                    .command
             )
             expected_cmd = [
                 "main",
@@ -220,7 +220,7 @@ class KubernetesSchedulerTest(unittest.TestCase):
         app = _test_app()
         cfg = {"queue": "testqueue"}
         with patch(
-            "torchx.schedulers.kubernetes_scheduler.make_unique"
+                "torchx.schedulers.kubernetes_scheduler.make_unique"
         ) as make_unique_ctx:
             make_unique_ctx.return_value = "app-name-42"
             info = scheduler._submit_dryrun(app, cfg)
@@ -410,6 +410,35 @@ spec:
         )
         self.assertTrue(pod.spec.containers[0].security_context.privileged)
 
+    def test_resource_devices(self) -> None:
+        scheduler = create_scheduler("test")
+
+        role = specs.Role(
+            name="foo",
+            image="",
+            resource=specs.Resource(
+                cpu=2,
+                memMB=3000,
+                gpu=4,
+                devices=[
+                    ("vpc.amazonaws.com/efa", 4),
+                    ("vpc.amazonaws.com/neuron", 1)
+                ]
+            ),
+        )
+        pod = role_to_pod("foo", role, service_account="")
+        self.assertEqual(
+            pod.spec.containers[0].resources.limits,
+            {
+                "cpu": "2000m",
+                "memory": "3000M",
+                "nvidia.com/gpu": "4",
+                "vpc.amazonaws.com/efa": "4",
+                "vpc.amazonaws.com/neuron": "1",
+            }
+        )
+        self.assertFalse(pod.spec.containers[0].security_context.privileged)
+
     def test_instance_type(self) -> None:
         scheduler = create_scheduler("test")
         role = specs.Role(
@@ -442,7 +471,7 @@ spec:
         app = _test_app(num_replicas=2)
         cfg = {"queue": "testqueue"}
         with patch(
-            "torchx.schedulers.kubernetes_scheduler.make_unique"
+                "torchx.schedulers.kubernetes_scheduler.make_unique"
         ) as make_unique_ctx:
             make_unique_ctx.return_value = "app-name-42"
             info = scheduler._submit_dryrun(app, cfg)
@@ -466,7 +495,7 @@ spec:
             "image_repo": "example.com/some/repo",
         }
         with patch(
-            "torchx.schedulers.kubernetes_scheduler.make_unique"
+                "torchx.schedulers.kubernetes_scheduler.make_unique"
         ) as make_unique_ctx:
             make_unique_ctx.return_value = "app-name-42"
             info = scheduler._submit_dryrun(app, cfg)
@@ -523,7 +552,7 @@ spec:
 
     @patch("kubernetes.client.CustomObjectsApi.create_namespaced_custom_object")
     def test_submit_job_name_conflict(
-        self, create_namespaced_custom_object: MagicMock
+            self, create_namespaced_custom_object: MagicMock
     ) -> None:
         from kubernetes.client.rest import ApiException
 
@@ -591,7 +620,7 @@ spec:
 
     @patch("kubernetes.client.CustomObjectsApi.get_namespaced_custom_object_status")
     def test_describe_unknown(
-        self, get_namespaced_custom_object_status: MagicMock
+            self, get_namespaced_custom_object_status: MagicMock
     ) -> None:
         get_namespaced_custom_object_status.return_value = {}
         app_id = "testnamespace:testid"

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -52,6 +52,7 @@ class Resource:
             CPU core maps to physical cores and threads.
         gpu: number of gpus
         memMB: MB of ram
+        devices: a list of named devices with their quantities
         capabilities: additional hardware specs (interpreted by scheduler)
 
     Note: you should prefer to use named_resources instead of specifying the raw
@@ -61,6 +62,7 @@ class Resource:
     cpu: int
     gpu: int
     memMB: int
+    devices: list[Tuple[str, int]] = field(default_factory=list)
     capabilities: Dict[str, Any] = field(default_factory=dict)
 
     @staticmethod
@@ -76,6 +78,7 @@ class Resource:
             cpu=original.cpu,
             gpu=original.gpu,
             memMB=original.memMB,
+            devices=original.devices,
             capabilities=res_capabilities,
         )
 


### PR DESCRIPTION
Added "devices" list of (str, int) tuples to role/resource

Added devices.py to map from named devices to DeviceMounts

Added logic in kubernetes_scheduler to add devices from resource to resource limits

Added logic in aws_batch_scheduler and docker_scheduler to add DeviceMounts for any devices from resource

Test plan:
Unit tests in kubernetes_scheduler, aws_batch_scheduler, and docker_scheduler
