### PR TITLE
Support k8s device plugins/resource limits (#443)

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -59,6 +59,7 @@ from torchx.schedulers.api import (
     Stream,
     filter_regex,
 )
+from torchx.schedulers.devices import get_device_mounts
 from torchx.schedulers.ids import make_unique
 from torchx.specs.api import (
     AppDef,
@@ -104,6 +105,8 @@ def _role_to_node_properties(idx: int, role: Role) -> Dict[str, object]:
 
     if resource.gpu > 0:
         reqs.append({"type": "GPU", "value": str(resource.gpu)})
+
+    role.mounts += get_device_mounts(resource.devices)
 
     mount_points = []
     volumes = []

--- a/torchx/schedulers/devices.py
+++ b/torchx/schedulers/devices.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import warnings
+from typing import Mapping, Callable, List, Dict
+
+from torchx.specs.api import DeviceMount
+
+
+def efa_to_devicemounts(num_devices: int) -> List[DeviceMount]:
+    device_mounts = []
+    for device_index in range(0, num_devices):
+        device_mounts.append(
+            DeviceMount(
+                src_path="/dev/infiniband/uverbs" + str(device_index),
+                dst_path="/dev/infiniband/uverbs" + str(device_index),
+            )
+        )
+    return device_mounts
+
+
+DEVICES: Mapping[str, Callable[[int], List[DeviceMount]]] = {
+    "vpc.amazonaws.com/efa": efa_to_devicemounts,
+}
+
+
+def get_device_mounts(devices: Dict[str, int]) -> List[DeviceMount]:
+    """
+    Takes in a list of named devices/quantities, and returns a list of DeviceMount objects
+    based on the mappings defined in DEVICES
+    """
+    device_mounts = []
+    for device_name, num_devices in devices.items():
+        if device_name not in DEVICES:
+            warnings.warn(f"Could not find named device: {device_name}")
+            continue
+        device_mounts += DEVICES[device_name](num_devices)
+    return device_mounts

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -22,6 +22,7 @@ from torchx.schedulers.api import (
     filter_regex,
     split_lines,
 )
+from torchx.schedulers.devices import get_device_mounts
 from torchx.schedulers.ids import make_unique
 from torchx.specs.api import (
     AppDef,
@@ -209,6 +210,7 @@ class DockerScheduler(Scheduler, DockerWorkspace):
         for role in app.roles:
             mounts = []
             devices = []
+            role.mounts += get_device_mounts(role.resource.devices)
             for mount in role.mounts:
                 if isinstance(mount, BindMount):
                     mounts.append(

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -207,6 +207,9 @@ def role_to_pod(name: str, role: Role, service_account: Optional[str]) -> "V1Pod
     if resource.gpu > 0:
         requests["nvidia.com/gpu"] = limits["nvidia.com/gpu"] = str(resource.gpu)
 
+    for device_name, device_limit in resource.devices.items():
+        limits[device_name] = str(device_limit)
+
     resources = V1ResourceRequirements(
         limits=limits,
         requests=requests,

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -260,6 +260,33 @@ class AWSBatchSchedulerTest(unittest.TestCase):
             ],
         )
 
+    def test_resource_devices(self) -> None:
+        role = specs.Role(
+            name="foo",
+            image="",
+            mounts=[],
+            resource=specs.Resource(
+                cpu=1, memMB=1000, gpu=0, devices={"vpc.amazonaws.com/efa": 2}
+            ),
+        )
+        props = _role_to_node_properties(0, role)
+        self.assertEqual(
+            # pyre-fixme[16]: `object` has no attribute `__getitem__`.
+            props["container"]["linuxParameters"]["devices"],
+            [
+                {
+                    "hostPath": "/dev/infiniband/uverbs0",
+                    "containerPath": "/dev/infiniband/uverbs0",
+                    "permissions": ["READ", "WRITE", "MKNOD"],
+                },
+                {
+                    "hostPath": "/dev/infiniband/uverbs1",
+                    "containerPath": "/dev/infiniband/uverbs1",
+                    "permissions": ["READ", "WRITE", "MKNOD"],
+                },
+            ],
+        )
+
     def _mock_scheduler(self) -> AWSBatchScheduler:
         scheduler = AWSBatchScheduler(
             "test",

--- a/torchx/schedulers/test/devices_test.py
+++ b/torchx/schedulers/test/devices_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+from torchx.schedulers.devices import get_device_mounts
+from torchx.specs import DeviceMount
+
+
+class DevicesTest(unittest.TestCase):
+    def test_get_efa(self) -> None:
+        devices = {"vpc.amazonaws.com/efa": 2}
+        self.assertEqual(
+            get_device_mounts(devices),
+            [
+                DeviceMount(
+                    src_path="/dev/infiniband/uverbs0",
+                    dst_path="/dev/infiniband/uverbs0",
+                ),
+                DeviceMount(
+                    src_path="/dev/infiniband/uverbs1",
+                    dst_path="/dev/infiniband/uverbs1",
+                ),
+            ],
+        )
+
+    def test_not_found_device_name(self) -> None:
+        devices = {"shouldWarn": 1}
+        self.assertEqual(get_device_mounts(devices), [])
+        self.assertWarns(UserWarning, get_device_mounts, devices)

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -154,6 +154,17 @@ class DockerSchedulerTest(unittest.TestCase):
         info = self.scheduler._submit_dryrun(app, cfg={})
         self.assertEqual(info.request.containers[0].kwargs["devices"], ["foo:bar:rwm"])
 
+    def test_resource_devices(self) -> None:
+        app = _test_app()
+        app.roles[0].mounts = []
+        app.roles[0].resource.devices = {"vpc.amazonaws.com/efa": 1}
+
+        info = self.scheduler._submit_dryrun(app, cfg={})
+        self.assertEqual(
+            info.request.containers[0].kwargs["devices"],
+            ["/dev/infiniband/uverbs0:/dev/infiniband/uverbs0:rwm"],
+        )
+
     @patch("os.environ", {"FOO_1": "f1", "BAR_1": "b1", "FOOBAR_1": "fb1"})
     def test_copy_env(self) -> None:
         app = _test_app()

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -410,6 +410,33 @@ spec:
         )
         self.assertTrue(pod.spec.containers[0].security_context.privileged)
 
+    def test_resource_devices(self) -> None:
+        scheduler = create_scheduler("test")
+
+        role = specs.Role(
+            name="foo",
+            image="",
+            resource=specs.Resource(
+                cpu=2,
+                memMB=3000,
+                gpu=4,
+                devices={
+                    "vpc.amazonaws.com/efa": 4,
+                },
+            ),
+        )
+        pod = role_to_pod("foo", role, service_account="")
+        self.assertEqual(
+            pod.spec.containers[0].resources.limits,
+            {
+                "cpu": "2000m",
+                "memory": "3000M",
+                "nvidia.com/gpu": "4",
+                "vpc.amazonaws.com/efa": "4",
+            },
+        )
+        self.assertFalse(pod.spec.containers[0].security_context.privileged)
+
     def test_instance_type(self) -> None:
         scheduler = create_scheduler("test")
         role = specs.Role(

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -53,6 +53,7 @@ class Resource:
         gpu: number of gpus
         memMB: MB of ram
         capabilities: additional hardware specs (interpreted by scheduler)
+        devices: a list of named devices with their quantities
 
     Note: you should prefer to use named_resources instead of specifying the raw
     resource requirement directly.
@@ -62,6 +63,7 @@ class Resource:
     gpu: int
     memMB: int
     capabilities: Dict[str, Any] = field(default_factory=dict)
+    devices: Dict[str, int] = field(default_factory=dict)
 
     @staticmethod
     def copy(original: "Resource", **capabilities: Any) -> "Resource":
@@ -77,6 +79,7 @@ class Resource:
             gpu=original.gpu,
             memMB=original.memMB,
             capabilities=res_capabilities,
+            devices=original.devices,
         )
 
 


### PR DESCRIPTION
Added "devices" list of (str, int) tuples to role/resource

Added devices.py to map from named devices to DeviceMounts

Added logic in kubernetes_scheduler to add devices from resource to resource limits

Added logic in aws_batch_scheduler and docker_scheduler to add DeviceMounts for any devices from resource

Test plan:
Unit tests in kubernetes_scheduler, aws_batch_scheduler, and docker_scheduler
