### PR TITLE
(torchx/specs+cli) clean up parsing run cfg from a string literal

### DIFF
--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -248,7 +248,9 @@ def dump(
 
 
 def apply(
-    scheduler: str, cfg: Dict[str, CfgVal], dirs: Optional[List[str]] = None
+    scheduler: str,
+    cfg: Dict[str, CfgVal],
+    dirs: Optional[List[str]] = None,
 ) -> None:
     """
     Loads a ``.torchxconfig`` INI file from the specified directories in


### PR DESCRIPTION
Summary:
1. Moved parsing cfg from str literal to `runopts` class to keep everything together. Documented the semantics of passing cfg as string in `runopts.cfg_from_str()` method.

2. Added support to delimit kv-pairs and list values with "," and ";" interchangeably (to support passing cfg list values as `-cfg tags=foo,bar` instead of the current `-cfg tags=foo;bar`).

3. inlined `specs.api._get_function_args` into the caller function since it was only being used in one place.

4. updated documentation for `runtopts.resolve()` since it no longer mutates the passed cfg object.

Reviewed By: d4l3k

Differential Revision: D35387798

