### PR TITLE
Hydra integration concept

### DIFF
--- a/torchx/components/hydra.py
+++ b/torchx/components/hydra.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import os.path
+
+import torchx.specs as specs
+from hydra import compose, initialize_config_dir
+from torchx.specs.finder import get_component
+from omegaconf import OmegaConf
+
+
+def run(
+    config_path: str,
+    config_name: str,
+    *overrides: str,
+) -> specs.AppDef:
+    """
+    run executes a component using a hydra loaded arguments.
+
+    This replaces .torchxconfig
+    """
+    initialize_config_dir(config_dir=os.path.join(os.getcwd(), config_path))
+    cfg = compose(config_name=config_name, overrides=overrides)
+
+    torchx_cfg = cfg["torchx"]
+    comp = get_component(torchx_cfg["component"]).fn
+
+    kwargs = dict(torchx_cfg["args"].items())
+    args = list(overrides)
+    if "script_args" in kwargs:
+        args = kwargs["script_args"] + args
+        del kwargs["script_args"]
+
+    return comp(*args, **kwargs)
+
+def app(
+    config_path: str,
+    config_name: str,
+    *overrides: str,
+) -> specs.AppDef:
+    """
+    app runs a appdef specified in the hydra config.
+
+    This replaces .torchxconfig and components.
+    """
+    initialize_config_dir(config_dir=os.path.join(os.getcwd(), config_path))
+    cfg = compose(config_name=config_name, overrides=overrides)
+
+    torchx_cfg = cfg["torchx"]
+    app_cfg = torchx_cfg["app"]
+
+    from dacite import from_dict
+
+    return from_dict(data_class=specs.AppDef, data=OmegaConf.to_object(app_cfg))
+


### PR DESCRIPTION
<!-- Change Summary -->

This contains two possible hydra aware TorchX components. One is a proxy to a different component and can be used instead of `.torchxconfig` and the other allows full control and specifying a app def entirely from the Hydra config.

## run example

This is a proxy to a different component so it's easy to launch things like dist.ddp. This has a bit less flexibility than the full appdef approach.

```yaml
torchx:
  component: dist.ddp
  args:
    j: 1x2
    script: foo.py
```

```shell
torchx run --scheduler local_cwd --workspace= --wait --log hydra.run --config_path conf --config_name run
```

## app example

This loads the yaml into the `AppDef` dataclass directly allowing for full control.

```yaml
torchx:
  app:
    name: hydra-app
    roles:
    - name: foo
      image: alpine
      entrypoint: python
      args: ["foo.py"]

```

```shell
torchx run --scheduler local_cwd --workspace= --wait --log hydra.app --config_path conf --config_name app
```



It might be useful to add some fancier features like blah: "$FOO" to access
env variables values or something like "dataset: *yes.bar" to point to a different part of the config when integrating with a preexisting config.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->



