### PR TITLE
resources: k8s integration tests can access logs

### DIFF
--- a/resources/torchx_integration_tests_role.yaml
+++ b/resources/torchx_integration_tests_role.yaml
@@ -15,6 +15,9 @@ rules:
   resources: ["jobs","jobs/status"]
   verbs:
   - "*"
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- Change Summary -->

Currently the integration tests can't access the logs for k8s jobs. This updates the config yaml to allow it.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
kubectl apply -f resources/torchx_integration_tests_role.yaml
```
