### PR TITLE
Make `walk_workspace` ignore subdirs of dir to be ignored.

### DIFF
--- a/torchx/workspace/test/dir_workspace_test.py
+++ b/torchx/workspace/test/dir_workspace_test.py
@@ -48,7 +48,7 @@ class DirWorkspaceTest(unittest.TestCase):
         fs = fsspec.filesystem("memory")
         files = [
             "ignoredir/bar",
-            "ignoredir/recursive/ignorefile",
+            "ignoredir/recursive/bar",
             "dir1/bar",
             "dir/ignorefileglob1",
             "dir/recursive/ignorefileglob2",

--- a/torchx/workspace/test/dir_workspace_test.py
+++ b/torchx/workspace/test/dir_workspace_test.py
@@ -48,6 +48,7 @@ class DirWorkspaceTest(unittest.TestCase):
         fs = fsspec.filesystem("memory")
         files = [
             "ignoredir/bar",
+            "ignoredir/recursive/ignorefile",
             "dir1/bar",
             "dir/ignorefileglob1",
             "dir/recursive/ignorefileglob2",

--- a/torchx/workspace/test/docker_workspace_test.py
+++ b/torchx/workspace/test/docker_workspace_test.py
@@ -125,6 +125,7 @@ class DockerWorkspaceMockTest(unittest.TestCase):
         fs = fsspec.filesystem("memory")
         files = [
             "dockerignore/ignoredir/bar",
+            "dockerignore/ignoredir/recursive/bar",
             "dockerignore/dir1/bar",
             "dockerignore/dir/ignorefileglob1",
             "dockerignore/dir/recursive/ignorefileglob2",


### PR DESCRIPTION
Fixes #457

Test plan:

The modified tests fail because "ignoredir", "ignoredir/recursive", and "ignoredir/recursive/ignorefile" are included in the walk results. With the modified implementation, they are no longer included and tests pass.

Local test suite passes except `ray_scheduler_test`, which was failing before adding these changes. 