### PR TITLE
dist.ddp: tweaks to make torchelastic + lightning behave better on slurm

### DIFF
--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -155,6 +155,8 @@ def ddp(
         str(nnodes),
         "--nproc_per_node",
         str(nproc_per_node),
+        "--node_rank",
+        f"{macros.replica_id}",
         "--tee",
         "3",
         "--role",


### PR DESCRIPTION
<!-- Change Summary -->

This changes `dist.ddp` so the torchelastic rank matches the `replica_id`. 

This is important when using slurm w/ lightning and NCCL+IB since NCCL errors can occur leading to crashes or deadlocks. It's not fully clear why this is the case.

This also updates `compute_world_size` to support running with NCCL since the tensors need to be on a GPU device.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI

https://docs.google.com/document/d/10VSIVBlnmQ8na4pNXc9bS-HKvKco7JGDXiUsF9h3zwE/edit?usp=sharing
