### PR TITLE
(torchx/fb-image-provider)(bugfix) penv_parname should only be inferred if role.entrypoint is penv python, should equal role.entrypoint for everything else

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -279,16 +279,18 @@ class Runner:
             if workspace and isinstance(sched, Workspace):
                 role = app.roles[0]
                 old_img = role.image
-                logger.info(
-                    f"Building workspace: {workspace} for role[0]: {role.name}, image: {old_img}"
-                )
+
+                logger.info(f"Checking for changes in workspace `{workspace}`...")
                 sched.build_workspace_and_update_role(role, workspace, cfg)
-                logger.info("Done building workspace")
+
                 if old_img != role.image:
-                    logger.info(f"New image: {role.image} built from workspace")
+                    logger.info(
+                        f"Built new image `{role.image}` based on original image `{old_img}`"
+                        f" and changes in workspace `{workspace}` for role[0]={role.name}."
+                    )
                 else:
                     logger.info(
-                        f"Reusing original image: {old_img} for role[0]: {role.name}."
+                        f"Reusing original image `{old_img}` for role[0]={role.name}."
                         " Either a patch was built or no changes to workspace was detected."
                     )
 


### PR DESCRIPTION
Summary:
Fixes this repro diff D35531168.

TL;DR when using `local_penv` with DPP (data preproc) roles, the dpp_master and dpp_worker roles also go through the `PenvImageProvider` to fetch the fbpkg. The issue is that `PenvImageProvider` was written prior to workspaces (jetter integration) and implicitly assumes that `role.entrypoint="python"` (penv python). So when a non-python entrypoint was specified there were unexpected behaviors.

Specificially running:

```
$ cd ~/fbcode/torchx/examples/apps
$ torchx run -- -j 1x1 -h t1 --num_dpp_workers=2 --num_dpp_masters=1
```

Results in the PenvImageProvider NOT downloading the fbpkgs for dpp_master and dpp_worker roles when there exists a `buck-out/opt/torchx/examples/apps/penv.par`, which happens if jetter decides to rebuild the fbpkg

Reviewed By: dracifer, aivanou

Differential Revision: D35636351

