### PR TITLE
slurm_scheduler: autodetect nomem setting

### DIFF
--- a/scripts/slurmtest.sh
+++ b/scripts/slurmtest.sh
@@ -33,7 +33,6 @@ cat <<EOT > .torchxconfig
 partition=compute
 time=10
 comment=hello
-nomem=true
 job_dir=$JOB_DIR
 EOT
 


### PR DESCRIPTION
<!-- Change Summary -->

This automatically infers `nomem` by using `sinfo` to get the `Memory` setting for the specified partition. If we can't determine the memory setting or its <= 1000 MB we disable memory allocation checks.

 #405

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI

Slurm integration tests w/ `nomem` removed
