### PR TITLE
Update oss Pyre configuration to preemptively guard again upcoming semantic changes (#294)

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -6,6 +6,7 @@
     ".*/IPython/core/tests/nonascii.*",
     ".*/torchx/examples/apps/compute_world_size/.*"
   ],
+  "site_package_search_strategy": "all",
   "source_directories": [
     "typestubs",
     "."


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcp/pull/294

X-link: https://github.com/facebookresearch/recipes/pull/19

Pyre is going to have a semantic change in its configuration: D35695552.

Basically, we are changing the default behavior on how search paths are discovered. Pre-existing configurations need to explicitly opt-in to the old behavior -- otherwise, they may risk breaking their type check setups.

The added option will lead to a Pyre warning for now, but that warning would go away on the next Pyre upgrade.

Reviewed By: stroxler

Differential Revision: D35724336

