### PR TITLE
Try changing search strategy

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -6,7 +6,7 @@
     ".*/IPython/core/tests/nonascii.*",
     ".*/torchx/examples/apps/compute_world_size/.*"
   ],
-  "site_package_search_strategy": "all",
+  "site_package_search_strategy": "pep561",
   "source_directories": [
     "typestubs",
     "."


### PR DESCRIPTION
This should only be merged if CI comes back clean.

I'm seeing what happens if we change the search strategy for pyre, which will narrow my search for why pyre is failing to open a file on trunk.
