### PR TITLE
Try setting pyre's site-packages search strategy to "none"

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -6,7 +6,7 @@
     ".*/IPython/core/tests/nonascii.*",
     ".*/torchx/examples/apps/compute_world_size/.*"
   ],
-  "site_package_search_strategy": "all",
+  "site_package_search_strategy": "none",
   "source_directories": [
     "typestubs",
     "."


### PR DESCRIPTION
Again, making a PR to help me understand why pyre is failing and narrow my search for where we fail to read a file when trying to type check trunk.

I think that no site package search strategy should actually work okay here - we're explicitly putting site-packages on the search paths list, which makes me think we don't need site-packages handling.
