### PR TITLE
Set the --noninteractive field in pyre

### DIFF
--- a/scripts/pyre.sh
+++ b/scripts/pyre.sh
@@ -9,4 +9,4 @@ set -eux
 
 SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
 pyre --version
-pyre --search-path "${SITE_PACKAGES}" check
+pyre --noninteractive --search-path "${SITE_PACKAGES}" check


### PR DESCRIPTION
This is a good change to have in general - the extra logging can be very helpful for understanding when pyre misunderstands configuration (either because of pyre bugs or config bugs); we almost always set it for CI runs.