### PR TITLE
No search path

### DIFF
--- a/scripts/pyre.sh
+++ b/scripts/pyre.sh
@@ -7,6 +7,5 @@
 
 set -eux
 
-SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
 pyre --version
-pyre --noninteractive --search-path "${SITE_PACKAGES}" check
+pyre --noninteractive check

--- a/scripts/pyre.sh
+++ b/scripts/pyre.sh
@@ -9,4 +9,4 @@ set -eux
 
 SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
 pyre --version
-pyre --search-path "${SITE_PACKAGES}" check
+pyre --noninteractive --search-path "${SITE_PACKAGES}" check


### PR DESCRIPTION
With --noninteractive flag set, let's see what happens if we keep using the site packages search strategy of "all" but we don't set the search path.

This is the recommended way to run pyre, assuming it works correctly (but it is also new so we may discover a bug)
