### PR TITLE
torch.x -- document dict argument parsing failure case when value contains "="

### DIFF
--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -111,7 +111,7 @@ class DockerScheduler(Scheduler, DockerWorkspace):
     **Config Options**
 
     .. runopts::
-        class: torchx.schedulers.kubernetes_scheduler.KubernetesScheduler
+        class: torchx.schedulers.docker_scheduler.DockerScheduler
 
     **Mounts**
 

--- a/torchx/util/test/types_test.py
+++ b/torchx/util/test/types_test.py
@@ -136,6 +136,19 @@ class TypesTest(unittest.TestCase):
         self.assertDictEqual({"FOO": "v1,v2", "BAR": "v3"}, to_dict("FOO=v1,v2;BAR=v3"))
         self.assertDictEqual({"FOO": "v1;v2", "BAR": "v3"}, to_dict("FOO=v1;v2,BAR=v3"))
 
+        # Parser cannot appropriately handle the cases where
+        # value contains "=". Create test for this to keep record. This especially can
+        # be a problem for some base64 encoded values with trailing "=" or "=="
+        # For some components (dist.ddp), an `env_file` option is provided to read env
+        # from file
+        with self.assertRaises(AssertionError):
+            self.assertDictEqual(
+                {"FOO": "v1;v2", "BAR": "v3=="}, to_dict("FOO=v1;v2,BAR=v3==")
+            )
+            self.assertDictEqual(
+                {"FOO": "v1;v2", "BAR": "v3="}, to_dict("FOO=v1;v2,BAR=v3=")
+            )
+
         # test some non-trivial + edge cases
         self.assertDictEqual(
             {


### PR DESCRIPTION
Summary:
in some cases, the value can contain "=". For example, some base64 encoded values as environment variable. torch.x parser currently does not support this case.

adding a test to capture this failure. wonder if we should consider support this. An example use case can be parsing temp AWS token credential to ddp

also correct a documentation copy-pasta

Reviewed By: kiukchung

Differential Revision: D35560931

