### PR TITLE
torchx/specs,schedulers: add TPU named resources + support in kubernetes_scheduler

### DIFF
--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -14,6 +14,7 @@ scheduler or pipeline adapter.
 from typing import Dict, Optional
 
 from torchx.specs.named_resources_aws import NAMED_RESOURCES as AWS_NAMED_RESOURCES
+from torchx.specs.named_resources_tpu import NAMED_RESOURCES as TPU_NAMED_RESOURCES
 from torchx.util.entrypoints import load_group
 
 from .api import (  # noqa: F401 F403
@@ -58,7 +59,10 @@ GiB: int = 1024
 def _load_named_resources() -> Dict[str, Resource]:
     resource_methods = load_group("torchx.named_resources", default={})
     materialized_resources = {}
-    default = AWS_NAMED_RESOURCES
+    default = {
+        **AWS_NAMED_RESOURCES,
+        **TPU_NAMED_RESOURCES,
+    }
     for name, resource in default.items():
         materialized_resources[name] = resource()
     for resource_name, resource_method in resource_methods.items():

--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -19,7 +19,7 @@ the equvalent resource in mem, cpu and gpu numbers.
 
 Usage:
 
-    ::
+.. doctest::
 
      from torchx.specs import named_resources
      print(named_resources["aws_t3.medium"])

--- a/torchx/specs/named_resources_tpu.py
+++ b/torchx/specs/named_resources_tpu.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+`torchx.specs.named_resources_tpu` contains resource definitions that represent
+corresponding Google Cloud TPU VMs.
+
+TPUs require a matching torch version so the named resources will read the local
+Torch version to set the `tf-version.cloud-tpus.google.com` annotation correctly.
+
+.. note::
+    These resource definitions may change in future. It is expected for each user to
+    manage their own resources. Follow https://pytorch.org/torchx/latest/specs.html#torchx.specs.get_named_resources
+    to set up named resources.
+
+Usage:
+
+.. doctest::
+
+     from torchx.specs import named_resources
+     print(named_resources["tpu_v2_8"])
+     print(named_resources["tpu_v3_8"])
+     print(named_resources["tpu_preemptible_v3_8"])
+     print(named_resources["tpu_v3_2048"])
+"""
+
+from typing import Dict, Callable, Optional
+
+from torchx.specs.api import Resource
+
+NAMED_RESOURCES: Dict[str, Callable[[], Resource]] = {}
+
+
+def _get_tf_version(version: Optional[str] = None) -> str:
+    if version is None:
+        try:
+            from torch.version import __version__
+
+            version = __version__
+        except ImportError:
+            version = "1.11"
+    if "dev" in version:
+        return "pytorch-nightly"
+    short_ver = ".".join(version.split(".")[:2])
+    return f"pytorch-{short_ver}"
+
+
+def _register_type(ver: str, cores: int) -> Callable[[], Resource]:
+    device: str = "cloud-tpus.google.com/" + ver
+
+    def resource() -> Resource:
+        return Resource(
+            cpu=0,
+            memMB=0,
+            gpu=0,
+            capabilities={
+                "tf-version.cloud-tpus.google.com": _get_tf_version(),
+            },
+            devices={
+                device: int(cores),
+            },
+        )
+
+    resource_name = f"tpu_{ver.replace('-', '_')}_{cores}"
+    NAMED_RESOURCES[resource_name] = resource
+    return resource
+
+
+tpu_v2_8: Callable[[], Resource] = _register_type("v2", 8)
+tpu_preemptible_v2_8: Callable[[], Resource] = _register_type("preemptible-v2", 8)
+tpu_v2_32: Callable[[], Resource] = _register_type("v2", 32)
+tpu_v2_128: Callable[[], Resource] = _register_type("v2", 128)
+tpu_v2_256: Callable[[], Resource] = _register_type("v2", 256)
+tpu_v2_512: Callable[[], Resource] = _register_type("v2", 512)
+
+tpu_v3_8: Callable[[], Resource] = _register_type("v3", 8)
+tpu_preemptible_v3_8: Callable[[], Resource] = _register_type("preemptible-v3", 8)
+tpu_v3_32: Callable[[], Resource] = _register_type("v3", 32)
+tpu_v3_64: Callable[[], Resource] = _register_type("v3", 64)
+tpu_v3_128: Callable[[], Resource] = _register_type("v3", 128)
+tpu_v3_256: Callable[[], Resource] = _register_type("v3", 256)
+tpu_v3_512: Callable[[], Resource] = _register_type("v3", 512)
+tpu_v3_1024: Callable[[], Resource] = _register_type("v3", 1024)
+tpu_v3_2048: Callable[[], Resource] = _register_type("v3", 2048)

--- a/torchx/specs/test/named_resource_tpu_test.py
+++ b/torchx/specs/test/named_resource_tpu_test.py
@@ -1,0 +1,94 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+from torchx.specs import Resource
+from torchx.specs import named_resources_tpu as tpu
+
+
+class NamedResourcesTest(unittest.TestCase):
+    def test_tf_version(self) -> None:
+        self.assertEqual(tpu._get_tf_version("2.123.0+cu102"), "pytorch-2.123")
+        self.assertEqual(
+            tpu._get_tf_version("1.12.0.dev20220419+cu113"), "pytorch-nightly"
+        )
+
+    def test_tpu_v3_8(self) -> None:
+        want = Resource(
+            cpu=0,
+            memMB=0,
+            gpu=0,
+            capabilities={
+                "tf-version.cloud-tpus.google.com": "pytorch-1.11",
+            },
+            devices={
+                "cloud-tpus.google.com/v3": 8,
+            },
+        )
+        self.assertEqual(tpu.tpu_v3_8(), want)
+        self.assertEqual(tpu.NAMED_RESOURCES["tpu_v3_8"](), want)
+
+    def test_tpu_v3_2048(self) -> None:
+        want = Resource(
+            cpu=0,
+            memMB=0,
+            gpu=0,
+            capabilities={
+                "tf-version.cloud-tpus.google.com": "pytorch-1.11",
+            },
+            devices={
+                "cloud-tpus.google.com/v3": 2048,
+            },
+        )
+        self.assertEqual(tpu.tpu_v3_2048(), want)
+        self.assertEqual(tpu.NAMED_RESOURCES["tpu_v3_2048"](), want)
+
+    def test_tpu_v2_8(self) -> None:
+        want = Resource(
+            cpu=0,
+            memMB=0,
+            gpu=0,
+            capabilities={
+                "tf-version.cloud-tpus.google.com": "pytorch-1.11",
+            },
+            devices={
+                "cloud-tpus.google.com/v2": 8,
+            },
+        )
+        self.assertEqual(tpu.tpu_v2_8(), want)
+        self.assertEqual(tpu.NAMED_RESOURCES["tpu_v2_8"](), want)
+
+    def test_tpu_preemptible_v2_8(self) -> None:
+        want = Resource(
+            cpu=0,
+            memMB=0,
+            gpu=0,
+            capabilities={
+                "tf-version.cloud-tpus.google.com": "pytorch-1.11",
+            },
+            devices={
+                "cloud-tpus.google.com/preemptible-v2": 8,
+            },
+        )
+        self.assertEqual(tpu.tpu_preemptible_v2_8(), want)
+        self.assertEqual(tpu.NAMED_RESOURCES["tpu_preemptible_v2_8"](), want)
+
+    def test_tpu_preemptible_v3_8(self) -> None:
+        want = Resource(
+            cpu=0,
+            memMB=0,
+            gpu=0,
+            capabilities={
+                "tf-version.cloud-tpus.google.com": "pytorch-1.11",
+            },
+            devices={
+                "cloud-tpus.google.com/preemptible-v3": 8,
+            },
+        )
+        self.assertEqual(tpu.tpu_preemptible_v3_8(), want)
+        self.assertEqual(tpu.NAMED_RESOURCES["tpu_preemptible_v3_8"](), want)


### PR DESCRIPTION
<!-- Change Summary -->

This adds in TPU support when launching jobs via the `kubernetes_scheduler` on GKE.

* Volcano doesn't understand the Kubernetes device plugin so when launching we need to set `minAvailable: 0` and `schedulerName: default-scheduler` which forces Volcano to create the pods without waiting for the resources to be available.
* It also fixes a race condition in reporting Volcano status where it reports RUNNING before the pods have been created.
* XLA and torchelastic don't play well together so it requires launching via `utils.python`.

Closes #410

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

added unit tests

```
# imports pytorch
import torch

# imports the torch_xla package
import torch_xla
import torch_xla.core.xla_model as xm

# Creates a random tensor on xla:1 (a Cloud TPU core)
dev = xm.xla_device()
t1 = torch.ones(3, 3, device = dev)
print(t1)

# Creating a tensor on the second Cloud TPU core
second_dev = xm.xla_device(n=2, devkind='TPU')
t2 = torch.zeros(3, 3, device = second_dev)
print(t2)

# Creates random filters and inputs to a 1D convolution
filters = torch.randn(33, 16, 3, device = dev)
inputs = torch.randn(20, 16, 50, device = dev)
t3 = torch.nn.functional.conv1d(inputs, filters)
print(t3)
```

```
(torchx) tristanr@tristanr-arch2 ~/D/torchx-proj [2]> torchx run --scheduler kubernetes --wait --log utils.python -h tpu_v3_8 --script tpu.py --image gcr.io/tpu-pytorch/xla:r1.11_3.7
```