### PR TITLE
(torchx/fb) make it possible to run python tests with fb.python.unittest

### DIFF
--- a/torchx/examples/apps/compute_world_size/module/test/util_test.py
+++ b/torchx/examples/apps/compute_world_size/module/test/util_test.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+import unittest
+
+from omegaconf import DictConfig
+from torchx.examples.apps.compute_world_size.module.util import compute_world_size
+
+
+class UtilTest(unittest.TestCase):
+    def test_compute_world_size(self) -> None:
+        cfg = DictConfig(
+            content={
+                "main": {
+                    "rank": 0,
+                    "world_size": 1,
+                    "master_addr": "localhost",
+                    # ephemeral port range in linux
+                    "master_port": random.randint(32768, 60999),
+                    "backend": "gloo",
+                }
+            }
+        )
+
+        self.assertEqual(1, compute_world_size(cfg))


### PR DESCRIPTION
Summary:
Makes it possible to run python unittest modules w.r.t the penv par (image).

Usage:

```
# by module
$ torchx run fb.python.unittest --img YOUR_FBPKG:VER -m fully.qualified.test.module

# by relative file path to test module
$ cd ~/fbsource/fbcode/YOUR/PROJECT
$ torchx run fb.python.unittest --img YOUR_FBPKG:VER -m test/foo_test.py
```

NOTE: If using jetter (aka --workspace) make sure the `//*/*test-library` test library's buck target is added to your main python_binary (penv)'s buck dependency (see example `//torchx/examples/apps/TARGET` below)

Differential Revision: D36252548

