### PR TITLE
Use generic TypedDict for runcfg

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -49,6 +49,7 @@ class Runner:
     def __init__(
         self,
         name: str,
+        # pyre-ignore: Scheduler opts
         schedulers: Dict[str, Scheduler],
         component_defaults: Optional[Dict[str, Dict[str, str]]] = None,
     ) -> None:
@@ -539,6 +540,7 @@ class Runner:
             )
             return log_iter
 
+    # pyre-ignore: Scheduler opts
     def _scheduler(self, scheduler: str) -> Scheduler:
         sched = self._schedulers.get(scheduler)
         if not sched:
@@ -548,7 +550,10 @@ class Runner:
         return sched
 
     def _scheduler_app_id(
-        self, app_handle: AppHandle, check_session: bool = True
+        self,
+        app_handle: AppHandle,
+        check_session: bool = True
+        # pyre-ignore: Scheduler opts
     ) -> Tuple[Scheduler, str, str]:
         """
         Returns the scheduler and app_id from the app_handle.

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -18,6 +18,7 @@ from typing_extensions import Protocol
 
 
 class SchedulerFactory(Protocol):
+    # pyre-ignore: Scheduler opts
     def __call__(self, session_name: str, **kwargs: object) -> Scheduler:
         ...
 
@@ -71,7 +72,9 @@ def get_default_scheduler_name() -> str:
 
 
 def get_schedulers(
-    session_name: str, **scheduler_params: object
+    session_name: str,
+    **scheduler_params: object
+    # pyre-ignore: Scheduler opts
 ) -> Dict[str, Scheduler]:
     """
     get_schedulers returns all available schedulers.

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -10,7 +10,16 @@ import os.path
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Union,
+    TypedDict,
+)
 
 import torchx
 import yaml
@@ -27,7 +36,6 @@ from torchx.schedulers.ids import make_unique
 from torchx.specs.api import (
     AppDef,
     AppState,
-    CfgVal,
     ReplicaStatus,
     Role,
     RoleStatus,
@@ -93,7 +101,11 @@ def has_docker() -> bool:
         return False
 
 
-class DockerScheduler(Scheduler, DockerWorkspace):
+class DockerOpts(TypedDict, total=False):
+    copy_env: Optional[List[str]]
+
+
+class DockerScheduler(Scheduler[DockerOpts], DockerWorkspace):
     """
     DockerScheduler is a TorchX scheduling interface to Docker.
 
@@ -187,9 +199,7 @@ class DockerScheduler(Scheduler, DockerWorkspace):
 
         return req.app_id
 
-    def _submit_dryrun(
-        self, app: AppDef, cfg: Mapping[str, CfgVal]
-    ) -> AppDryRunInfo[DockerJob]:
+    def _submit_dryrun(self, app: AppDef, cfg: DockerOpts) -> AppDryRunInfo[DockerJob]:
         from docker.types import DeviceRequest, Mount
 
         default_env = {}
@@ -301,6 +311,7 @@ class DockerScheduler(Scheduler, DockerWorkspace):
 
         info = AppDryRunInfo(req, repr)
         info._app = app
+        # pyre-ignore: AppDryRunInfo
         info._cfg = cfg
         return info
 

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -8,7 +8,7 @@
 
 import unittest
 from datetime import datetime
-from typing import Iterable, Mapping, Optional, Union
+from typing import Iterable, Mapping, Optional, Union, TypeVar
 from unittest.mock import MagicMock, patch
 
 from torchx.schedulers.api import (
@@ -29,9 +29,11 @@ from torchx.specs.api import (
 )
 from torchx.workspace.api import Workspace
 
+T = TypeVar("T")
+
 
 class SchedulerTest(unittest.TestCase):
-    class MockScheduler(Scheduler, Workspace):
+    class MockScheduler(Scheduler[T], Workspace):
         def __init__(self, session_name: str) -> None:
             super().__init__("mock", session_name)
 

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -15,6 +15,7 @@ from torchx import specs
 from torchx.schedulers.aws_batch_scheduler import (
     create_scheduler,
     AWSBatchScheduler,
+    AWSBatchOpts,
     _role_to_node_properties,
     _local_session,
 )
@@ -71,7 +72,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
     def test_submit_dryrun(self) -> None:
         scheduler = create_scheduler("test")
         app = _test_app()
-        cfg = {"queue": "testqueue"}
+        cfg = AWSBatchOpts({"queue": "testqueue"})
         info = scheduler._submit_dryrun(app, cfg)
 
         req = info.request
@@ -423,9 +424,11 @@ class AWSBatchSchedulerTest(unittest.TestCase):
     def test_submit(self) -> None:
         scheduler = self._mock_scheduler()
         app = _test_app()
-        cfg = {
-            "queue": "testqueue",
-        }
+        cfg = AWSBatchOpts(
+            {
+                "queue": "testqueue",
+            }
+        )
 
         info = scheduler._submit_dryrun(app, cfg)
         id = scheduler.schedule(info)

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -22,6 +22,7 @@ from torchx.schedulers.docker_scheduler import (
     DockerScheduler,
     create_scheduler,
     has_docker,
+    DockerOpts,
 )
 from torchx.schedulers.test.local_scheduler_test import LocalSchedulerTestUtil
 from torchx.specs.api import AppDef, AppState, Role
@@ -168,7 +169,7 @@ class DockerSchedulerTest(unittest.TestCase):
     @patch("os.environ", {"FOO_1": "f1", "BAR_1": "b1", "FOOBAR_1": "fb1"})
     def test_copy_env(self) -> None:
         app = _test_app()
-        cfg = {"copy_env": ["FOO_*", "BAR_*"]}
+        cfg = DockerOpts({"copy_env": ["FOO_*", "BAR_*"]})
         with patch("torchx.schedulers.docker_scheduler.make_unique") as make_unique_ctx:
             make_unique_ctx.return_value = "app_name_42"
             info = self.scheduler._submit_dryrun(app, cfg)

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -23,6 +23,7 @@ from torchx.schedulers.kubernetes_scheduler import (
     create_scheduler,
     KubernetesJob,
     KubernetesScheduler,
+    KubernetesOpts,
     LABEL_INSTANCE_TYPE,
     role_to_pod,
 )
@@ -218,7 +219,7 @@ class KubernetesSchedulerTest(unittest.TestCase):
     def test_submit_dryrun(self) -> None:
         scheduler = create_scheduler("test")
         app = _test_app()
-        cfg = {"queue": "testqueue"}
+        cfg = KubernetesOpts({"queue": "testqueue"})
         with patch(
             "torchx.schedulers.kubernetes_scheduler.make_unique"
         ) as make_unique_ctx:
@@ -465,7 +466,7 @@ spec:
 
         scheduler = create_scheduler("test")
         app = _test_app(num_replicas=2)
-        cfg = {"queue": "testqueue"}
+        cfg = KubernetesOpts({"queue": "testqueue"})
         with patch(
             "torchx.schedulers.kubernetes_scheduler.make_unique"
         ) as make_unique_ctx:
@@ -486,10 +487,12 @@ spec:
         scheduler = create_scheduler("test")
         app = _test_app()
         app.roles[0].image = "sha256:testhash"
-        cfg = {
-            "queue": "testqueue",
-            "image_repo": "example.com/some/repo",
-        }
+        cfg = KubernetesOpts(
+            {
+                "queue": "testqueue",
+                "image_repo": "example.com/some/repo",
+            }
+        )
         with patch(
             "torchx.schedulers.kubernetes_scheduler.make_unique"
         ) as make_unique_ctx:
@@ -511,11 +514,12 @@ spec:
         scheduler = create_scheduler("test")
         self.assertIn("service_account", scheduler.run_opts()._opts)
         app = _test_app()
-        cfg = {
-            "queue": "testqueue",
-            "service_account": "srvacc",
-        }
-
+        cfg = KubernetesOpts(
+            {
+                "queue": "testqueue",
+                "service_account": "srvacc",
+            }
+        )
         info = scheduler._submit_dryrun(app, cfg)
         self.assertIn("'service_account_name': 'srvacc'", str(info.request.resource))
 
@@ -527,10 +531,12 @@ spec:
         scheduler = create_scheduler("test")
         self.assertIn("priority_class", scheduler.run_opts()._opts)
         app = _test_app()
-        cfg = {
-            "queue": "testqueue",
-            "priority_class": "high",
-        }
+        cfg = KubernetesOpts(
+            {
+                "queue": "testqueue",
+                "priority_class": "high",
+            }
+        )
 
         info = scheduler._submit_dryrun(app, cfg)
         self.assertIn("'priorityClassName': 'high'", str(info.request.resource))
@@ -546,10 +552,12 @@ spec:
         }
         scheduler = create_scheduler("test")
         app = _test_app()
-        cfg = {
-            "namespace": "testnamespace",
-            "queue": "testqueue",
-        }
+        cfg = KubernetesOpts(
+            {
+                "namespace": "testnamespace",
+                "queue": "testqueue",
+            }
+        )
 
         info = scheduler._submit_dryrun(app, cfg)
         id = scheduler.schedule(info)
@@ -574,10 +582,12 @@ spec:
 
         scheduler = create_scheduler("test")
         app = _test_app()
-        cfg = {
-            "namespace": "testnamespace",
-            "queue": "testqueue",
-        }
+        cfg = KubernetesOpts(
+            {
+                "namespace": "testnamespace",
+                "queue": "testqueue",
+            }
+        )
         info = scheduler._submit_dryrun(app, cfg)
         with self.assertRaises(ValueError):
             scheduler.schedule(info)
@@ -780,10 +790,12 @@ class KubernetesSchedulerNoImportTest(unittest.TestCase):
     def test_dryrun(self) -> None:
         scheduler = kubernetes_scheduler.create_scheduler("foo")
         app = _test_app()
-        cfg = {
-            "namespace": "testnamespace",
-            "queue": "testqueue",
-        }
+        cfg = KubernetesOpts(
+            {
+                "namespace": "testnamespace",
+                "queue": "testqueue",
+            }
+        )
 
         with self.assertRaises(ModuleNotFoundError):
             scheduler._submit_dryrun(app, cfg)

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -29,6 +29,7 @@ from torchx.schedulers.local_scheduler import (
     CWDImageProvider,
     LocalDirectoryImageProvider,
     LocalScheduler,
+    LocalOpts,
     ReplicaParam,
     _join_PATH,
     create_cwd_scheduler,
@@ -63,7 +64,7 @@ def start_sleep_processes(
     )
 
     app = AppDef(name="test_app", roles=[role])
-    cfg = {"log_dir": test_dir}
+    cfg = LocalOpts({"log_dir": test_dir})
 
     scheduler = LocalScheduler(
         session_name="test_session", image_provider_class=LocalDirectoryImageProvider
@@ -445,7 +446,7 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         for std_stream in ["stdout", "stderr"]:
             with self.subTest(std_stream=std_stream):
                 log_dir = join(self.test_dir, f"test_{std_stream}_log")
-                cfg = {"log_dir": log_dir}
+                cfg = LocalOpts({"log_dir": log_dir})
 
                 role = Role(
                     "role1",
@@ -634,7 +635,7 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         )
 
         log_dir = join(self.test_dir, "log")
-        cfg = {"log_dir": log_dir}
+        cfg = LocalOpts({"log_dir": log_dir})
         app = AppDef(name="test_app", roles=[role])
         app_id = self.scheduler.submit(app, cfg)
 

--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -20,6 +20,7 @@ from torchx.schedulers.slurm_scheduler import (
     SlurmBatchRequest,
     SlurmReplicaRequest,
     SlurmScheduler,
+    SlurmOpts,
     create_scheduler,
     _save_job_dir,
     _get_job_dirs,
@@ -168,10 +169,12 @@ class SlurmSchedulerTest(unittest.TestCase):
             entrypoint="echo",
             args=["hello"],
         )
-        cfg = {
-            "partition": "bubblegum",
-            "time": "5:13",
-        }
+        cfg = SlurmOpts(
+            {
+                "partition": "bubblegum",
+                "time": "5:13",
+            }
+        )
 
         sbatch, _ = SlurmReplicaRequest.from_role(
             "role-name", role, cfg, nomem=False

--- a/torchx/workspace/docker_workspace.py
+++ b/torchx/workspace/docker_workspace.py
@@ -98,7 +98,7 @@ class DockerWorkspace(Workspace):
             context.close()
 
     def _update_app_images(
-        self, app: AppDef, cfg: Mapping[str, CfgVal]
+        self, app: AppDef, image_repo: Optional[str] = None
     ) -> Dict[str, Tuple[str, str]]:
         """
         _update_app_images replaces the local Docker images (identified via
@@ -116,7 +116,6 @@ class DockerWorkspace(Workspace):
         images_to_push = {}
         for role in app.roles:
             if role.image.startswith(HASH_PREFIX):
-                image_repo = cfg.get("image_repo")
                 if not image_repo:
                     raise KeyError(
                         f"must specify the image repository via `image_repo` config to be able to upload local image {role.image}"

--- a/torchx/workspace/test/docker_workspace_test.py
+++ b/torchx/workspace/test/docker_workspace_test.py
@@ -82,14 +82,9 @@ class DockerWorkspaceMockTest(unittest.TestCase):
         )
         # no image_repo
         with self.assertRaisesRegex(KeyError, "image_repo"):
-            DockerWorkspace()._update_app_images(app, {})
+            DockerWorkspace()._update_app_images(app)
         # with image_repo
-        images_to_push = DockerWorkspace()._update_app_images(
-            app,
-            {
-                "image_repo": "example.com/repo",
-            },
-        )
+        images_to_push = DockerWorkspace()._update_app_images(app, "example.com/repo")
         self.assertEqual(
             images_to_push,
             {


### PR DESCRIPTION
Summary: Use generic TypedDict for runcfg rather than Mapping. This eliminates the need for casts and type asserts to use the values.

Differential Revision: D36072685

