### PR TITLE
Ray Integration test fix

### DIFF
--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -16,8 +16,7 @@ jobs:
          - scheduler: "kubernetes"
          - scheduler: "local_cwd"
          - scheduler: "local_docker"
-         # TODO uncomment when https://github.com/pytorch/torchx/issues/455 is resolved
-         # - scheduler: "ray"
+         - scheduler: "ray"
       fail-fast: false
     permissions:
       id-token: write

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,4 +23,4 @@ ts==0.5.1
 usort==0.6.4
 
 # Ray doesn't support Python 3.10
-ray[default]==1.11.0; python_version < '3.10'
+ray[default]==1.12.0; python_version < '3.10'

--- a/scripts/component_integration_tests.py
+++ b/scripts/component_integration_tests.py
@@ -101,7 +101,6 @@ def main() -> None:
             ],
             "image": torchx_image,
             "cfg": {},
-
         },
     }
 

--- a/scripts/component_integration_tests.py
+++ b/scripts/component_integration_tests.py
@@ -100,6 +100,8 @@ def main() -> None:
                 component_provider,
             ],
             "image": torchx_image,
+            "cfg": {},
+
         },
     }
 

--- a/torchx/components/integration_tests/component_provider.py
+++ b/torchx/components/integration_tests/component_provider.py
@@ -104,7 +104,7 @@ class CopyComponentProvider(ComponentProvider):
         self._dst_path = "<None>"
 
     def setUp(self) -> None:
-        if self._scheduler == "local_cwd":
+        if self._scheduler in ["local_cwd", "ray"]:
             fname = "torchx_copy_test.txt"
             self._src_path: str = os.path.join(tempfile.gettempdir(), fname)
             self._dst_path: str = os.path.join(tempfile.gettempdir(), f"{fname}.copy")
@@ -121,7 +121,7 @@ class CopyComponentProvider(ComponentProvider):
     def tearDown(self) -> None:
         if os.path.exists(self._dst_path):
             os.remove(self._dst_path)
-        if self._scheduler == "local_cwd" and os.path.exists(self._dst_path):
+        if self._scheduler in ["local_cwd", "ray"] and os.path.exists(self._dst_path):
             os.remove(self._dst_path)
 
     def get_app_def(self) -> AppDef:

--- a/torchx/schedulers/ray/ray_driver.py
+++ b/torchx/schedulers/ray/ray_driver.py
@@ -49,7 +49,7 @@ class CommandActor:  # pragma: no cover
         worker_evn["MASTER_ADDR"] = self.master_addr
         worker_evn["MASTER_PORT"] = str(self.master_port)
         popen = subprocess.Popen(self.cmd, env=worker_evn)
-        
+
         returncode = popen.wait()
         _logger.info(f"Finished with code {returncode}")
 
@@ -161,7 +161,6 @@ def main() -> None:  # pragma: no cover
         # Calling ray.get will expose the failure as a RayActorError.
         for object_ref in completed_workers:
             ray.get(object_ref)
-
 
 
 if __name__ == "__main__":

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -308,7 +308,7 @@ if _has_ray:
             start = time.time()
             while time.time() - start <= timeout:
                 status_info = client.get_job_status(app_id)
-                status = status_info.status
+                status = status_info
                 if status in {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}:
                     break
                 time.sleep(1)

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -321,7 +321,7 @@ if _has_ray:
         def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
             addr, app_id = app_id.split("-")
             client = JobSubmissionClient(f"http://{addr}")
-            job_status_info = client.get_job_status(app_id)
+            job_status_info = client.get_job_status(app_id) # pyre-ignore[6]
             state = _ray_status_to_torchx_appstate[job_status_info]
             roles = [Role(name="ray", num_replicas=-1, image="<N/A>")]
 
@@ -343,7 +343,7 @@ if _has_ray:
             return DescribeAppResponse(
                 app_id=app_id,
                 state=state,
-                msg=job_status_info,
+                msg=job_status_info, # pyre-ignore[6]
                 roles_statuses=roles_statuses,
                 roles=roles,
             )

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -326,7 +326,7 @@ if _has_ray:
             roles = [Role(name="ray", num_replicas=-1, image="<N/A>")]
 
             # get ip_address and put it in hostname
-            
+
             roles_statuses = [
                 RoleStatus(
                     role="ray",
@@ -343,7 +343,7 @@ if _has_ray:
             return DescribeAppResponse(
                 app_id=app_id,
                 state=state,
-                msg=job_status_info or NONE,
+                msg=job_status_info,
                 roles_statuses=roles_statuses,
                 roles=roles,
             )

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -322,8 +322,11 @@ if _has_ray:
             addr, app_id = app_id.split("-")
             client = JobSubmissionClient(f"http://{addr}")
             job_status_info = client.get_job_status(app_id)
-            state = _ray_status_to_torchx_appstate[job_status_info.status]
+            state = _ray_status_to_torchx_appstate[job_status_info]
             roles = [Role(name="ray", num_replicas=-1, image="<N/A>")]
+
+            # get ip_address and put it in hostname
+            
             roles_statuses = [
                 RoleStatus(
                     role="ray",
@@ -340,7 +343,7 @@ if _has_ray:
             return DescribeAppResponse(
                 app_id=app_id,
                 state=state,
-                msg=job_status_info.message or NONE,
+                msg=job_status_info or NONE,
                 roles_statuses=roles_statuses,
                 roles=roles,
             )

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -321,7 +321,7 @@ if _has_ray:
         def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
             addr, app_id = app_id.split("-")
             client = JobSubmissionClient(f"http://{addr}")
-            job_status_info = client.get_job_status(app_id) # pyre-ignore[6]
+            job_status_info = client.get_job_status(app_id)  # pyre-ignore[6]
             state = _ray_status_to_torchx_appstate[job_status_info]
             roles = [Role(name="ray", num_replicas=-1, image="<N/A>")]
 
@@ -343,7 +343,7 @@ if _has_ray:
             return DescribeAppResponse(
                 app_id=app_id,
                 state=state,
-                msg=job_status_info, # pyre-ignore[6]
+                msg=job_status_info,  # pyre-ignore[6]
                 roles_statuses=roles_statuses,
                 roles=roles,
             )

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -321,7 +321,7 @@ if _has_ray:
         def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
             addr, app_id = app_id.split("-")
             client = JobSubmissionClient(f"http://{addr}")
-            job_status_info = client.get_job_status(app_id)  # pyre-ignore[6]
+            job_status_info = client.get_job_status(app_id)
             state = _ray_status_to_torchx_appstate[job_status_info]
             roles = [Role(name="ray", num_replicas=-1, image="<N/A>")]
 
@@ -343,7 +343,7 @@ if _has_ray:
             return DescribeAppResponse(
                 app_id=app_id,
                 state=state,
-                msg=job_status_info,  # pyre-ignore[6]
+                msg=job_status_info,
                 roles_statuses=roles_statuses,
                 roles=roles,
             )


### PR DESCRIPTION
<!-- Change Summary -->
Fixes https://github.com/pytorch/torchx/issues/455
* Re-enabled component integration test
* Fixed a regression where Ray Job API changed what their status return function printed
* Added error handling code in `ray_driver.py` that now makes failed scripts, fail - h/t @d4l3k 
* Fixed broken `CopyComponentProvider` for Ray

Test plan:
Ran below locally and everything was green 
* `python scripts/component_integration_tests.py --scheduler "ray"` 
* `pytest schedulers/test/ray_integration_test.py`

I'll send a followup PR for the other 2 issues https://github.com/pytorch/torchx/issues?q=is%3Aissue+is%3Aopen+label%3Aray