### PR TITLE
Update black

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 aiobotocore==2.1.0
 ax-platform[mysql]==0.2.3
-black==21.10b0
+black==22.3.0
 boto3==1.20.24
 captum>=0.4.0
 classy-vision>=0.6.0


### PR DESCRIPTION
If you try and run `scripts/lint.sh` it'll fail with

```
if [ ! "$(black --version)" ]
then
    echo "Please install black."
    exit 1
```

which is failing because it used to use a now deprecated hidden function

```
(ray) ubuntu@ip-172-31-16-198:~/torchx$ black .
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/envs/ray/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/ubuntu/anaconda3/envs/ray/lib/python3.8/site-packages/black/__init__.py", line 1322, in patched_main
    patch_click()
  File "/home/ubuntu/anaconda3/envs/ray/lib/python3.8/site-packages/black/__init__.py", line 1308, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/home/ubuntu/anaconda3/envs/ray/lib/python3.8/site-packages/click/__init__.py)
```

Tons of people have this issue here https://github.com/pallets/click/issues/2225

<!-- Change Summary -->

Test plan:
1. `pip install black==22.3.0`
2. `./scripts/lint.sh` succeeds
