### PR TITLE
ray: fixes for distributed training + cancel command

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,4 +23,4 @@ ts==0.5.1
 usort==1.0.2
 
 # Ray doesn't support Python 3.10
-ray[default]==1.12.0; python_version < '3.10'
+ray[default]==1.12.1; python_version < '3.10'

--- a/scripts/component_integration_tests.py
+++ b/scripts/component_integration_tests.py
@@ -100,7 +100,9 @@ def main() -> None:
                 component_provider,
             ],
             "image": torchx_image,
-            "cfg": {},
+            "cfg": {
+                "working_dir": ".",
+            },
         },
     }
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         extras_require={
             "kfp": ["kfp==1.6.2"],
             "kubernetes": ["kubernetes>=11"],
-            "ray": ["ray>=1.6.0"],
+            "ray": ["ray>=1.12.1"],
             "dev": dev_reqs,
             ':python_version < "3.8"': [
                 "importlib-metadata",

--- a/torchx/cli/cmd_cancel.py
+++ b/torchx/cli/cmd_cancel.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import logging
+
+from torchx.cli.cmd_base import SubCommand
+from torchx.runner import get_runner
+from torchx.specs import api
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class CmdCancel(SubCommand):
+    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "app_handle",
+            type=str,
+            help="torchx app handle (e.g. local://session-name/app-id)",
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+        app_handle = args.app_handle
+        _, session_name, _ = api.parse_app_handle(app_handle)
+        runner = get_runner(name=session_name)
+        runner.stop(app_handle)

--- a/torchx/cli/main.py
+++ b/torchx/cli/main.py
@@ -11,6 +11,7 @@ from typing import Dict, List
 
 import torchx
 from torchx.cli.cmd_base import SubCommand
+from torchx.cli.cmd_cancel import CmdCancel
 from torchx.cli.cmd_configure import CmdConfigure
 from torchx.cli.cmd_describe import CmdDescribe
 from torchx.cli.cmd_log import CmdLog
@@ -28,13 +29,14 @@ torchx run ${JOB_NAME}
 
 def get_default_sub_cmds() -> Dict[str, SubCommand]:
     return {
+        "builtins": CmdBuiltins(),
+        "cancel": CmdCancel(),
+        "configure": CmdConfigure(),
         "describe": CmdDescribe(),
         "log": CmdLog(),
         "run": CmdRun(),
-        "builtins": CmdBuiltins(),
         "runopts": CmdRunopts(),
         "status": CmdStatus(),
-        "configure": CmdConfigure(),
     }
 
 

--- a/torchx/cli/test/cmd_cancel_test.py
+++ b/torchx/cli/test/cmd_cancel_test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import unittest
+from unittest.mock import MagicMock, patch
+
+from torchx.cli.cmd_cancel import CmdCancel
+
+
+class CmdCancelTest(unittest.TestCase):
+    @patch("torchx.runner.api.Runner.stop")
+    def test_run(self, stop: MagicMock) -> None:
+        parser = argparse.ArgumentParser()
+        cmd_runopts = CmdCancel()
+        cmd_runopts.add_arguments(parser)
+
+        args = parser.parse_args(["foo://session/id"])
+        cmd_runopts.run(args)
+
+        self.assertEqual(stop.call_count, 1)
+        stop.assert_called_with("foo://session/id")

--- a/torchx/schedulers/ray/ray_common.py
+++ b/torchx/schedulers/ray/ray_common.py
@@ -5,32 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, List
+
+TORCHX_RANK0_HOST: str = "TORCHX_RANK0_HOST"
 
 
 @dataclass
 class RayActor:
-    """Describes an actor (a.k.a. role in TorchX terms).
-
-    Attributes:
-        name:
-            The name of the actor.
-        command:
-            The command that the actor should run as a subprocess.
-        env:
-            The environment variables to set before executing the command.
-        num_replicas:
-            The number of replicas (i.e. Ray actors) to run.
-        num_cpus:
-            The number of CPUs to allocate.
-        num_gpus:
-            The number of GPUs to allocate.
-    """
+    """Describes an actor (a.k.a. worker/replica in TorchX terms)."""
 
     name: str
-    command: str
+    command: List[str]
     env: Dict[str, str] = field(default_factory=dict)
-    num_replicas: int = 1
     num_cpus: int = 1
     num_gpus: int = 0
-    # TODO: memory_size, max_retries, retry_policy

--- a/torchx/schedulers/ray/ray_driver.py
+++ b/torchx/schedulers/ray/ray_driver.py
@@ -19,10 +19,10 @@ from ray.util.placement_group import PlacementGroup
 # For tests the `torchx.schedulers.ray.ray_common` import must be used
 # For running ray jobs `ray_common` import must be used
 try:
-    # pyre-ignore[21]: Could not find a module corresponding to import `ray_common`
-    from ray_common import RayActor
+    from torchx.schedulers.ray.ray_common import RayActor, TORCHX_RANK0_HOST
 except ModuleNotFoundError:
-    from torchx.schedulers.ray.ray_common import RayActor
+    # pyre-ignore[21]: Could not find a module corresponding to import `ray_common`
+    from ray_common import RayActor, TORCHX_RANK0_HOST
 
 _logger: logging.Logger = logging.getLogger(__name__)
 _logger.setLevel(logging.getLevelName(os.environ.get("LOGLEVEL", "INFO")))
@@ -31,8 +31,8 @@ logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
 
 @ray.remote
 class CommandActor:  # pragma: no cover
-    def __init__(self, command: str, env: Dict[str, str]) -> None:
-        self.cmd: List[str] = command.split(" ")
+    def __init__(self, command: List[str], env: Dict[str, str]) -> None:
+        self.cmd: List[str] = command
         self.env = env
         self.master_addr: Optional[str] = None
         self.master_port: Optional[int] = None
@@ -46,8 +46,7 @@ class CommandActor:  # pragma: no cover
         worker_evn = {}
         worker_evn.update(os.environ)
         worker_evn.update(self.env)
-        worker_evn["MASTER_ADDR"] = self.master_addr
-        worker_evn["MASTER_PORT"] = str(self.master_port)
+        worker_evn[TORCHX_RANK0_HOST] = self.master_addr
         popen = subprocess.Popen(self.cmd, env=worker_evn)
 
         returncode = popen.wait()
@@ -64,8 +63,7 @@ class CommandActor:  # pragma: no cover
         self.master_port = port
 
 
-# pyre-ignore[11]
-def load_actor_json(filename: str) -> List["RayActor"]:
+def load_actor_json(filename: str) -> List[RayActor]:
     with open(filename) as f:
         actors: List[RayActor] = []
         # Yes this is gross but it works
@@ -76,65 +74,51 @@ def load_actor_json(filename: str) -> List["RayActor"]:
         return actors
 
 
-def create_placement_groups(actors: List[RayActor]) -> List[PlacementGroup]:
-    pgs: List[PlacementGroup] = []
-    for actor in actors:
-        bundle = {"CPU": actor.num_cpus, "GPU": actor.num_gpus}
-        bundles = [bundle] * actor.num_replicas
+def create_placement_group(replicas: List[RayActor]) -> PlacementGroup:
+    bundles = []
+    for replica in replicas:
+        bundles.append({"CPU": replica.num_cpus, "GPU": replica.num_gpus})
 
-        # To change the strategy type
-        # refer to available options here https://docs.ray.io/en/latest/placement-group.html#pgroup-strategy
-        pg = ray.util.placement_group(bundles, strategy="SPREAD")
-        pgs.append(pg)
+    # To change the strategy type
+    # refer to available options here https://docs.ray.io/en/latest/placement-group.html#pgroup-strategy
+    pg = ray.util.placement_group(bundles, strategy="SPREAD")
 
-        _logger.info("Waiting for placement group to start.")
-        ready = pg.wait(timeout_seconds=100)
+    _logger.info("Waiting for placement group to start.")
+    ready = pg.wait(timeout_seconds=100)
 
-        if not ready:  # pragma: no cover
-            raise TimeoutError(
-                "Placement group creation timed out. Make sure "
-                "your cluster either has enough resources or use "
-                "an autoscaling cluster. Current resources "
-                "available: {}, resources requested by the "
-                "placement group: {}".format(ray.available_resources(), pg.bundle_specs)
-            )
-    return pgs
+    if not ready:  # pragma: no cover
+        raise TimeoutError(
+            "Placement group creation timed out. Make sure "
+            "your cluster either has enough resources or use "
+            "an autoscaling cluster. Current resources "
+            "available: {}, resources requested by the "
+            "placement group: {}".format(ray.available_resources(), pg.bundle_specs)
+        )
+    return pg
 
 
 def create_command_actors(
-    actors: List[RayActor], pgs: List[PlacementGroup]
+    actors: List[RayActor], pg: PlacementGroup
 ) -> List[CommandActor]:
     cmd_actors: List[CommandActor] = []
-    for i in range(len(actors)):
-        world_size = actors[i].num_replicas
-        actor_group = []
+    for i, replica in enumerate(actors):
+        # Environment variables for distributed training
+        actor = CommandActor.options(  # pyre-ignore[16]
+            placement_group=pg,
+            num_cpus=replica.num_cpus,
+            num_gpus=replica.num_gpus,
+        ).remote(replica.command, replica.env)
+        cmd_actors.append(actor)
 
-        for rank in range(world_size):
-
-            # Environment variables for distributed training
-            rank_env = {
-                "WORLD_SIZE": str(world_size),
-                "RANK": str(rank),
-            }
-
-            actor_and_rank_env = {**actors[i].env, **rank_env}
-
-            actor_group.append(
-                CommandActor.options(  # pyre-ignore[16]
-                    placement_group=pgs[i],
-                    num_cpus=actors[i].num_cpus,
-                    num_gpus=actors[i].num_gpus,
-                ).remote(actors[i].command, actor_and_rank_env)
-            )
-
+        if i == 0:
+            rank_0_address = "localhost"
+            rank_0_port = 0
+        else:
             rank_0_address, rank_0_port = ray.get(
-                actor_group[0].get_actor_address_and_port.remote()
+                # pyre-ignore[16]
+                cmd_actors[0].get_actor_address_and_port.remote()
             )
-
-            for actor in actor_group:
-                ray.get(actor.set_address_and_port.remote(rank_0_address, rank_0_port))
-
-            cmd_actors.extend(actor_group)
+        ray.get(actor.set_address_and_port.remote(rank_0_address, rank_0_port))
 
     return cmd_actors
 
@@ -143,8 +127,8 @@ def main() -> None:  # pragma: no cover
     actors: List[RayActor] = load_actor_json("actors.json")
     # pyre-fixme[16]: Module `worker` has no attribute `init`.
     ray.init(address="auto", namespace="torchx-ray")
-    pgs: List[PlacementGroup] = create_placement_groups(actors)
-    command_actors: List[CommandActor] = create_command_actors(actors, pgs)
+    pg: PlacementGroup = create_placement_group(actors)
+    command_actors: List[CommandActor] = create_command_actors(actors, pg)
 
     active_workers = [
         command_actor.exec_module.remote()  # pyre-ignore


### PR DESCRIPTION
<!-- Change Summary -->

This fixes the RayScheduler so distributed jobs using the normal `dist.ddp` work correctly. This redid how the actors where scheduled and how arguments are handled for correctness.

This also adds a `torchx cancel` command since it's handy for killing stuck jobs

* Adds in app name to job ID
* Fixes multiple workers being launched
* Fixes role handling to correctly have replica ID and set rank0_env correctly
* Explicitly uses python3 instead of python to avoid system python2.7


Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
torchx run -s ray -c working_dir=.,requirements=./requirements.txt  --wait --log dist.ddp --env LOGLEVEL=INFO -j 2x1 -m scripts.compute_world_size
```
