### PR TITLE
ray_scheduler: workspace + fixed no role logging

### DIFF
--- a/.torchxignore
+++ b/.torchxignore
@@ -1,0 +1,1 @@
+.dockerignore

--- a/scripts/component_integration_tests.py
+++ b/scripts/component_integration_tests.py
@@ -101,8 +101,9 @@ def main() -> None:
             ],
             "image": torchx_image,
             "cfg": {
-                "working_dir": ".",
+                "requirements": "",
             },
+            "workspace": f"file://{os.getcwd()}",
         },
     }
 
@@ -115,6 +116,7 @@ def main() -> None:
             image=params["image"],
             cfg=params["cfg"],
             dryrun=dryrun,
+            workspace=params.get("workspace"),
         )
 
 

--- a/torchx/components/integration_tests/integ_tests.py
+++ b/torchx/components/integration_tests/integ_tests.py
@@ -10,7 +10,7 @@ import sys
 from dataclasses import asdict
 from json import dumps
 from types import ModuleType
-from typing import Callable, cast, Dict, List, Type
+from typing import Callable, cast, Dict, List, Optional, Type
 
 from pyre_extensions import none_throws
 from torchx.cli.cmd_log import get_logs
@@ -45,6 +45,7 @@ class IntegComponentTest:
         scheduler: str,
         cfg: Dict[str, CfgVal],
         dryrun: bool = False,
+        workspace: Optional[str] = None,
     ) -> None:
         component_providers = [
             cast(Callable[..., ComponentProvider], cls)(scheduler, image)
@@ -68,7 +69,9 @@ class IntegComponentTest:
             log.info(f"Submitting AppDef... (dryrun={dryrun})")
             # get the dryrun info to log the scheduler request
             # then use the schedule (intead of the run API) for job submission
-            dryrun_info = runner.dryrun(app_def, scheduler, cfg=cfg)
+            dryrun_info = runner.dryrun(
+                app_def, scheduler, cfg=cfg, workspace=workspace
+            )
             log.info(f"\nAppDef:\n{dumps(asdict(app_def), indent=4)}")
             log.info(f"\nScheduler Request:\n{dryrun_info}")
 

--- a/torchx/schedulers/test/.gitignore
+++ b/torchx/schedulers/test/.gitignore
@@ -1,1 +1,3 @@
 actors.json
+ray_common.py
+ray_driver.py

--- a/torchx/workspace/dir_workspace.py
+++ b/torchx/workspace/dir_workspace.py
@@ -8,11 +8,27 @@
 import os
 import posixpath
 import shutil
+from tempfile import mkdtemp
 from typing import Mapping
 
 import fsspec
 from torchx.specs import CfgVal, Role
 from torchx.workspace.api import walk_workspace, Workspace
+
+
+class TmpDirWorkspace(Workspace):
+    def build_workspace_and_update_role(
+        self, role: Role, workspace: str, cfg: Mapping[str, CfgVal]
+    ) -> None:
+        """
+        Creates a new temp directory from the workspace. Role image fields will
+        be set to the ``job_dir``.
+
+        Any files listed in the ``.torchxignore`` folder will be skipped.
+        """
+        job_dir = mkdtemp(prefix="torchx_workspace")
+        _copy_to_dir(workspace, job_dir)
+        role.image = job_dir
 
 
 class DirWorkspace(Workspace):

--- a/torchx/workspace/test/dir_workspace_test.py
+++ b/torchx/workspace/test/dir_workspace_test.py
@@ -6,12 +6,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import os.path
+import shutil
 import tempfile
 import unittest
 
 import fsspec
 from torchx.specs import Role
-from torchx.workspace.dir_workspace import _copy_to_dir, DirWorkspace
+from torchx.workspace.dir_workspace import _copy_to_dir, DirWorkspace, TmpDirWorkspace
 
 
 class DirWorkspaceTest(unittest.TestCase):
@@ -103,3 +104,20 @@ class DirWorkspaceTest(unittest.TestCase):
                 "unignore",
             },
         )
+
+
+class TmpDirWorkspaceTest(unittest.TestCase):
+    def test_build_workspace(self) -> None:
+        w = TmpDirWorkspace()
+        role = Role(
+            name="role",
+            image="blah",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            w.build_workspace_and_update_role(
+                role,
+                workspace=f"file://{tmpdir}",
+                cfg={},
+            )
+        self.assertIn(tempfile.gettempdir(), role.image)
+        shutil.rmtree(role.image)


### PR DESCRIPTION
<!-- Change Summary -->

This updates Ray to have proper workspace support.

* `-c working_dir=...` is deprecated in favor of `torchx run --workspace=...`
* `-c requirements=...` is optional and requirements.txt will be automatically read from the workspace if present
* `torchx log ray://foo/bar` works without requiring `/ray/0`

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
(torchx) tristanr@tristanr-arch2 ~/D/t/e/ray (ray)> torchx run -s ray --wait --log dist.ddp --env LOGLEVEL=INFO -j 2x1 -m scripts.compute_world_size
torchx 2022-05-18 16:55:31 INFO     Checking for changes in workspace `file:///home/tristanr/Developer/torchrec/examples/ray`...
torchx 2022-05-18 16:55:31 INFO     To disable workspaces pass: --workspace="" from CLI or workspace=None programmatically.
torchx 2022-05-18 16:55:31 INFO     Built new image `/tmp/torchx_workspacebe6331jv` based on original image `ghcr.io/pytorch/torchx:0.2.0dev0` and changes in workspace `file:///home/tristanr/Developer/torch
rec/examples/ray` for role[0]=compute_world_size.
torchx 2022-05-18 16:55:31 WARNING  The Ray scheduler does not support port mapping.
torchx 2022-05-18 16:55:31 INFO     Uploading package gcs://_ray_pkg_63a39f7096dfa0bd.zip.
torchx 2022-05-18 16:55:31 INFO     Creating a file package for local directory '/tmp/torchx_workspacebe6331jv'.
ray://torchx/127.0.0.1:8265-compute_world_size-mpr03nzqvvg3td
torchx 2022-05-18 16:55:31 INFO     Launched app: ray://torchx/127.0.0.1:8265-compute_world_size-mpr03nzqvvg3td
torchx 2022-05-18 16:55:31 INFO     AppStatus:
  msg: PENDING
  num_restarts: -1
  roles:
  - replicas:
    - hostname: <NONE>
      id: 0
      role: ray
      state: !!python/object/apply:torchx.specs.api.AppState
      - 2
      structured_error_msg: <NONE>
    role: ray
  state: PENDING (2)
  structured_error_msg: <NONE>
  ui_url: null

torchx 2022-05-18 16:55:31 INFO     Job URL: None
torchx 2022-05-18 16:55:31 INFO     Waiting for the app to finish...
torchx 2022-05-18 16:55:31 INFO     Waiting for app to start before logging...
torchx 2022-05-18 16:55:43 INFO     Job finished: SUCCEEDED
(torchx) tristanr@tristanr-arch2 ~/D/t/e/ray (ray)> torchx log ray://torchx/127.0.0.1:8265-compute_world_size-mpr03nzqvvg3td
ray/0 Waiting for placement group to start.
ray/0 running ray.wait on [ObjectRef(8f2664c081ffc268e1c4275021ead9801a8d33861a00000001000000), ObjectRef(afe9f14f5a927c04b8e247b9daca5a9348ef61061a00000001000000)]
ray/0 (CommandActor pid=494377) INFO:torch.distributed.launcher.api:Starting elastic_operator with launch configs:
ray/0 (CommandActor pid=494377)   entrypoint       : scripts.compute_world_size
ray/0 (CommandActor pid=494377)   min_nodes        : 2
ray/0 (CommandActor pid=494377)   max_nodes        : 2
ray/0 (CommandActor pid=494377)   nproc_per_node   : 1
ray/0 (CommandActor pid=494377)   run_id           : compute_world_size-mpr03nzqvvg3td
ray/0 (CommandActor pid=494377)   rdzv_backend     : c10d
ray/0 (CommandActor pid=494377)   rdzv_endpoint    : localhost:29500
ray/0 (CommandActor pid=494377)   rdzv_configs     : {'timeout': 900}
ray/0 (CommandActor pid=494377)   max_restarts     : 0
ray/0 (CommandActor pid=494377)   monitor_interval : 5
ray/0 (CommandActor pid=494377)   log_dir          : None
ray/0 (CommandActor pid=494377)   metrics_cfg      : {}
ray/0 (CommandActor pid=494377)
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.agent.server.local_elastic_agent:log directory set to: /tmp/torchelastic_vyq136c_/compute_world_size-mpr03nzqvvg3td_nu4r0f6t
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.agent.server.api:[] starting workers for entrypoint: python
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.agent.server.api:[] Rendezvous'ing worker group
ray/0 (CommandActor pid=494406) INFO:torch.distributed.launcher.api:Starting elastic_operator with launch configs:
ray/0 (CommandActor pid=494406)   entrypoint       : scripts.compute_world_size
ray/0 (CommandActor pid=494406)   min_nodes        : 2
ray/0 (CommandActor pid=494406)   max_nodes        : 2
ray/0 (CommandActor pid=494406)   nproc_per_node   : 1
ray/0 (CommandActor pid=494406)   run_id           : compute_world_size-mpr03nzqvvg3td
ray/0 (CommandActor pid=494406)   rdzv_backend     : c10d
ray/0 (CommandActor pid=494406)   rdzv_endpoint    : 172.26.20.254:29500
ray/0 (CommandActor pid=494406)   rdzv_configs     : {'timeout': 900}
ray/0 (CommandActor pid=494406)   max_restarts     : 0
ray/0 (CommandActor pid=494406)   monitor_interval : 5
ray/0 (CommandActor pid=494406)   log_dir          : None
ray/0 (CommandActor pid=494406)   metrics_cfg      : {}
ray/0 (CommandActor pid=494406)
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.agent.server.local_elastic_agent:log directory set to: /tmp/torchelastic_t38mo11i/compute_world_size-mpr03nzqvvg3td_ehvp80_p
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.agent.server.api:[] starting workers for entrypoint: python
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.agent.server.api:[] Rendezvous'ing worker group
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.agent.server.api:[] Rendezvous complete for workers. Result:
ray/0 (CommandActor pid=494377)   restart_count=0
ray/0 (CommandActor pid=494377)   master_addr=tristanr-arch2
ray/0 (CommandActor pid=494377)   master_port=48089
ray/0 (CommandActor pid=494377)   group_rank=1
ray/0 (CommandActor pid=494377)   group_world_size=2
ray/0 (CommandActor pid=494377)   local_ranks=[0]
ray/0 (CommandActor pid=494377)   role_ranks=[1]
ray/0 (CommandActor pid=494377)   global_ranks=[1]
ray/0 (CommandActor pid=494377)   role_world_sizes=[2]
ray/0 (CommandActor pid=494377)   global_world_sizes=[2]
ray/0 (CommandActor pid=494377)
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.agent.server.api:[] Starting worker group
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.multiprocessing:Setting worker0 reply file to: /tmp/torchelastic_vyq136c_/compute_world_size-mpr03nzqvvg3td_nu4r0f6t/attempt_0/0/error.json
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.agent.server.api:[] Rendezvous complete for workers. Result:
ray/0 (CommandActor pid=494406)   restart_count=0
ray/0 (CommandActor pid=494406)   master_addr=tristanr-arch2
ray/0 (CommandActor pid=494406)   master_port=48089
ray/0 (CommandActor pid=494406)   group_rank=0
ray/0 (CommandActor pid=494406)   group_world_size=2
ray/0 (CommandActor pid=494406)   local_ranks=[0]
ray/0 (CommandActor pid=494406)   role_ranks=[0]
ray/0 (CommandActor pid=494406)   global_ranks=[0]
ray/0 (CommandActor pid=494406)   role_world_sizes=[2]
ray/0 (CommandActor pid=494406)   global_world_sizes=[2]
ray/0 (CommandActor pid=494406)
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.agent.server.api:[] Starting worker group
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.multiprocessing:Setting worker0 reply file to: /tmp/torchelastic_t38mo11i/compute_world_size-mpr03nzqvvg3td_ehvp80_p/attempt_0/0/error.json
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.agent.server.api:[] worker group successfully finished. Waiting 300 seconds for other agents to finish.
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.agent.server.api:Local worker group finished (SUCCEEDED). Waiting 300 seconds for other agents to finish
ray/0 (CommandActor pid=494377) INFO:torch.distributed.elastic.agent.server.api:Done waiting for other agents. Elapsed: 0.000942230224609375 seconds
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.agent.server.api:[] worker group successfully finished. Waiting 300 seconds for other agents to finish.
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.agent.server.api:Local worker group finished (SUCCEEDED). Waiting 300 seconds for other agents to finish
ray/0 (CommandActor pid=494406) INFO:torch.distributed.elastic.agent.server.api:Done waiting for other agents. Elapsed: 0.0013003349304199219 seconds
ray/0 (CommandActor pid=494377) [0]:initializing `gloo` process group
ray/0 (CommandActor pid=494377) [0]:successfully initialized process group
ray/0 (CommandActor pid=494377) [0]:rank: 1, actual world_size: 2, computed world_size: 2
ray/0 (CommandActor pid=494406) [0]:initializing `gloo` process group
ray/0 (CommandActor pid=494406) [0]:successfully initialized process group
ray/0 (CommandActor pid=494406) [0]:rank: 0, actual world_size: 2, computed world_size: 2
ray/0 running ray.wait on [ObjectRef(afe9f14f5a927c04b8e247b9daca5a9348ef61061a00000001000000)]
```
