### PR TITLE
Add warning message when 'name' parameter is specified. It is used as part of Session name, which is deprecated so makes 'name' obsolete.

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -8,6 +8,7 @@
 import json
 import logging
 import time
+import warnings
 from datetime import datetime
 from types import TracebackType
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Type
@@ -607,6 +608,14 @@ def get_runner(
 
 
     """
+    if name:
+        warnings.warn(
+            f"Custom session names are deprecated (detected explicitly set session name={name}). \
+            To prevent this warning from showing again call `get_runner()` without the `name` param. \
+            As an alternative, you can prefix the app name with the session name.",
+            FutureWarning,
+        )
+
     if not name:
         name = "torchx"
 


### PR DESCRIPTION
Summary:
Add a deprecation message for `name` argument in runner factory method.

Ideally we should remove session_name completely, however MAST has number of call sites that will require updating.

https://fburl.com/code/j0zlnghr

Reviewed By: kiukchung

Differential Revision: D36421303

