### PR TITLE
(torchx/cli) allow the default scheduler to be specified via .torchxconfig

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -122,8 +122,9 @@ class CmdRun(SubCommand):
             "-s",
             "--scheduler",
             type=str,
-            help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]",
             default=get_default_scheduler_name(),
+            action=torchxconfig_run,
+            help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]",
         )
         subparser.add_argument(
             "-cfg",


### PR DESCRIPTION
Summary: Lets users specify their choice of default scheduler via `.torchxconfig` (similar to how they can specify the default component in `.torchxconfig`)

Differential Revision: D36849694

