### PR TITLE
Invalid Scheduler Exception

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -123,6 +123,7 @@ class CmdRun(SubCommand):
             "--scheduler",
             type=str,
             default=get_default_scheduler_name(),
+            choices=list(scheduler_names),
             action=torchxconfig_run,
             help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]",
         )


### PR DESCRIPTION
Summary: Fixes https://github.com/pytorch/torchx/issues/512 which reports an KeyError thrown when providing an invalid scheduler to the torchx CLI.

Differential Revision: D37043441

