### PR TITLE
slurmint: made the script more robust to different system configurations

### DIFF
--- a/scripts/slurmint.sh
+++ b/scripts/slurmint.sh
@@ -20,7 +20,7 @@ if [[ -z "${SLURM_INSTANCE_MASTER}" ]]; then
 fi
 
 JOB="$USER-$(uuidgen)"
-DIR="/home/ubuntu/integ-tests/$JOB"
+DIR="integ-tests/$JOB"
 VENV="$DIR/venv"
 
 function run_cmd {
@@ -45,7 +45,7 @@ SCRIPT="scripts/slurmtest.sh"
 REMOTE_SCRIPT="$DIR/$(basename "$SCRIPT")"
 
 run_cmd mkdir -p "$DIR"
-run_cmd virtualenv -p /home/ubuntu/miniconda3/bin/python "$VENV"
+run_cmd miniconda3/bin/python -m venv "$VENV"
 run_scp "$WHEEL" "$REMOTE_WHEEL"
 run_scp "$SCRIPT" "$REMOTE_SCRIPT"
 run_cmd "$REMOTE_SCRIPT" "$REMOTE_WHEEL" "$VENV"

--- a/scripts/slurmtest.sh
+++ b/scripts/slurmtest.sh
@@ -7,8 +7,8 @@
 
 set -ex
 
-REMOTE_WHEEL="$1"
-VENV="$2"
+REMOTE_WHEEL="$(realpath $1)"
+VENV="$(realpath $2)"
 
 BASE_DIR="$(dirname "$REMOTE_WHEEL")"
 DIR="$BASE_DIR/project"
@@ -30,7 +30,7 @@ pip install torch==1.10.2+cpu -f https://download.pytorch.org/whl/cpu/torch_stab
 
 cat <<EOT > .torchxconfig
 [slurm]
-partition=compute
+partition=queue1
 time=10
 comment=hello
 job_dir=$JOB_DIR


### PR DESCRIPTION
<!-- Change Summary -->

This updates the slurmint script to be more robust to environment changes since we switched to a new slurm cluster.

It removes the hardcoded `/home/ubuntu` and uses venv provided by miniconda so we don't need virtualenv installed on the host.

See https://www.internalfb.com/intern/wiki/PyTorch_R2P/Development/Slurm/ for more information

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
env SLURM_INSTANCE_MASTER=... scripts/slurmint.sh
```