### PR TITLE
docs: bump sphinx and ray versions to support Python 3.10

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,5 +22,4 @@ torchvision>=0.11.1
 ts==0.5.1
 usort==1.0.2
 
-# Ray doesn't support Python 3.10
-ray[default]==1.12.1; python_version < '3.10'
+ray[default]>=1.12.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==4.0.2
+sphinx==5.0.1
 -e git+http://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinx-gallery<=0.7.0
 sphinxcontrib.katex

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -119,7 +119,7 @@ release = "main"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
<!-- Change Summary -->

This bumps the sphinx version to 5.0.1 as the previous version didn't support Python 3.10.

Bumps the ray version allowed since Python 3.10 is only supported in Ray 1.13.0+

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
make -C docs clean html
```
CI docs build

![Screenshot 2022-06-15 at 16-37-43 Quickstart — PyTorch_TorchX main documentation](https://user-images.githubusercontent.com/909104/173959785-5da26526-954f-4545-9c93-d6c983760084.png)
