### PR TITLE
docs: fix docpush by adding airflow

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -81,6 +81,13 @@ jobs:
         run: |
           set -eux
           sudo apt-get install -y pandoc
+          pip install -r docs/requirements.txt
+      - name: Start Airflow
+        run: |
+          # start airflow in background
+          airflow standalone &
+          # wait 5 seconds for airflow to start
+          sleep 5
       - name: Build
         run: |
           set -ex


### PR DESCRIPTION
<!-- Change Summary -->

This adds airflow to the docpush build so it can complete successfully.

https://github.com/pytorch/torchx/commit/a55174135e9b44de1860d113bb78efecacd031c6 added Airflow to the docbuild but not to docpush.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

PR CI w/ main branch check temporarily disabled

https://github.com/pytorch/torchx/runs/6921732557?check_suite_focus=true
