### PR TITLE
Docs cleanup

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -31,7 +31,7 @@ In TorchX an ``AppDef`` is simply a struct with the *definition* of
 the actual application. In scheduler lingo, this is a ``JobDefinition`` and a
 similar concept in Kubernetes is the ``spec.yaml``. To disambiguate between the
 application binary (logic) and the spec, we typically refer to a TorchX
-``AppDef`` as an "app spec" or ``specs.AppDef``. ``specs.AppDef``
+``AppDef`` as an "app spec" or ``specs.AppDef``. It
 is the common interface understood by ``torchx.runner``
 and ``torchx.pipelines`` allowing you to run your app as a standalone job
 or as a stage in an ML pipeline.

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -222,7 +222,7 @@ automatically build the image with the newly provided Dockerfile instead of the
 default one.
 
 ```sh
-torchx run --scheduler local_docker utils.python --script timm_app.py "your name"
+torchx run --scheduler local_docker utils.python --script timm_app.py
 ```
 
 ### Slurm

--- a/torchx/cli/__init__.py
+++ b/torchx/cli/__init__.py
@@ -122,8 +122,8 @@ Putting everything together, running ``echo`` with the ``local_cwd`` scheduler:
 
  $ torchx run --scheduler local_cwd --scheduler_args log_dir=/tmp utils.echo --msg "hello $USER"
  === RUN RESULT ===
-torchx 2022-06-15 16:08:57 INFO     Log files located in: /tmp/torchx/echo-crls3hcpwjmhc/echo/0
-local_cwd://torchx/echo-crls3hcpwjmhc
+ torchx 2022-06-15 16:08:57 INFO     Log files located in: /tmp/torchx/echo-crls3hcpwjmhc/echo/0
+ local_cwd://torchx/echo-crls3hcpwjmhc
 
 By default the ``run`` subcommand does not block for the job to finish, instead it simply
 schedules the job on the specified scheduler and prints an ``app handle``

--- a/torchx/cli/__init__.py
+++ b/torchx/cli/__init__.py
@@ -26,9 +26,9 @@ If so, no need to even author an app spec!
 
  $ torchx builtins
  Found <n> builtin configs:
-  1. echo
-  2. simple_example
-  3. touch
+  1. metrics.tensorboard
+  2. serve.torchserve
+  3. utils.binary
   ... <omitted for brevity>
 
 Listing the supported schedulers and arguments
@@ -57,8 +57,9 @@ The ``run``  subcommand takes either one of:
 
    .. code-block:: shell-session
 
-    $ torchx run --scheduler <sched_name> echo
+    $ torchx run --scheduler <sched_name> utils.echo
 
+#doesn't work
 2. full python module path of the component function
 
    .. code-block:: shell-session
@@ -122,16 +123,18 @@ Putting everything together, running ``echo`` with the ``local_cwd`` scheduler:
 
  $ torchx run --scheduler local_cwd --scheduler_args log_dir=/tmp utils.echo --msg "hello $USER"
  === RUN RESULT ===
- Launched app: local://torchx_kiuk/echo_ecd30f74
+torchx 2022-06-15 16:08:57 INFO     Log files located in: /tmp/torchx/echo-crls3hcpwjmhc/echo/0
+local_cwd://torchx/echo-crls3hcpwjmhc
+...
 
 By default the ``run`` subcommand does not block for the job to finish, instead it simply
 schedules the job on the specified scheduler and prints an ``app handle``
-which is a URL of the form: ``$scheduler_name://torchx_$user/$job_id``.
+which is a URL of the form: ``$scheduler_name://torchx/$job_id``.
 Keep note of this handle since this is what you'll need to provide to other
 subcommands to identify your job.
 
 .. note:: If the ``--scheduler`` option is not provided, then it defaults to
-          the scheduler backend ``default`` which points to ``local``. To change
+          the scheduler backend ``default`` which points to ``local_cwd``. To change
           the default scheduler, see: :ref:`advanced:Registering Custom Schedulers`.
 
 

--- a/torchx/cli/__init__.py
+++ b/torchx/cli/__init__.py
@@ -59,7 +59,6 @@ The ``run``  subcommand takes either one of:
 
     $ torchx run --scheduler <sched_name> utils.echo
 
-#doesn't work
 2. full python module path of the component function
 
    .. code-block:: shell-session
@@ -125,7 +124,6 @@ Putting everything together, running ``echo`` with the ``local_cwd`` scheduler:
  === RUN RESULT ===
 torchx 2022-06-15 16:08:57 INFO     Log files located in: /tmp/torchx/echo-crls3hcpwjmhc/echo/0
 local_cwd://torchx/echo-crls3hcpwjmhc
-...
 
 By default the ``run`` subcommand does not block for the job to finish, instead it simply
 schedules the job on the specified scheduler and prints an ``app handle``

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -77,7 +77,7 @@ def resource(
     Convenience method to create a ``Resource`` object from either the
     raw resource specs (cpu, gpu, memMB) or the registered named resource (``h``).
     Note that the (cpu, gpu, memMB) is mutually exclusive with ``h``
-    with ``h`` taking predecence if specified.
+    taking predecence if specified.
 
     If ``h`` is specified then it is used to look up the
     resource specs from the list of registered named resources.


### PR DESCRIPTION
Update docs to reflect current verbiage/outputs for builtins, default scheduler and app handles. Also removes some unnecessary arguments in examples and fixes some typos. 

Test:
cd docs && make html
(with airflow.md commented out)