### PR TITLE
torchx/docs: internal build

### DIFF
--- a/docs/source/components/distributed.rst
+++ b/docs/source/components/distributed.rst
@@ -5,3 +5,10 @@ Distributed
 .. currentmodule:: torchx.components.dist
 
 .. autofunction:: torchx.components.dist.ddp
+
+.. fbcode::
+
+  .. automodule:: torchx.components.fb.dist
+  .. currentmodule:: torchx.components.fb.dist
+
+  .. autofunction:: torchx.components.fb.dist.hpc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ if True:  # stop isort from reordering
     sys.path.append(os.path.abspath("../.."))
     import torchx
 
+FBCODE = "fbcode" in os.getcwd()
 
 # -- General configuration ------------------------------------------------
 
@@ -52,19 +53,26 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-    "sphinxcontrib.katex",
     "sphinx.ext.autosectionlabel",
-    "sphinx_gallery.gen_gallery",
     "compatibility",
     "runopts",
+    "fbcode",
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
 ]
+if not FBCODE:
+    extensions += [
+        "sphinx.ext.intersphinx",
+        "sphinxcontrib.katex",
+        "sphinx_gallery.gen_gallery",
+    ]
+
+if FBCODE:
+    nbsphinx_execute = "never"
 
 # coverage options
 
@@ -313,8 +321,11 @@ TypedField.make_field = patched_make_field
 
 # -- Options for Sphinx-Gallery -----
 
-tags_raw = subprocess.check_output(["git", "tag", "-l"])
-tags = set(tags_raw.decode("utf-8").strip().split("\n"))
+if FBCODE:
+    tags = []
+else:
+    tags_raw = subprocess.check_output(["git", "tag", "-l"])
+    tags = set(tags_raw.decode("utf-8").strip().split("\n"))
 
 if version in tags:
     notebook_version = version

--- a/docs/source/ext/fbcode.py
+++ b/docs/source/ext/fbcode.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from sphinx.util.nodes import nested_parse_with_titles
+
+
+class FbcodeDirective(SphinxDirective):
+    # this enables content in the directive
+    has_content = True
+
+    def run(self):
+        if "fbcode" not in os.getcwd():
+            return []
+        node = nodes.section()
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, self.content, node)
+        return node.children
+
+
+def setup(app):
+    app.add_directive("fbcode", FbcodeDirective)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,6 +62,15 @@ Works With
    schedulers/ray
    schedulers/aws_batch
 
+.. fbcode::
+
+   .. toctree::
+      :maxdepth: 1
+      :caption: Schedulers (Meta)
+
+      schedulers/fb/mast
+      schedulers/fb/flow
+
 .. _Pipelines:
 .. toctree::
    :maxdepth: 1
@@ -69,6 +78,8 @@ Works With
 
    pipelines/kfp
    pipelines/airflow.md
+
+
 
 
 Examples

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -18,6 +18,14 @@ All Schedulers
 
    schedulers/*
 
+.. fbcode::
+
+   .. toctree::
+      :maxdepth: 1
+      :glob:
+
+      schedulers/fb/*
+
 Scheduler Functions
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/workspace.rst
+++ b/docs/source/workspace.rst
@@ -31,3 +31,14 @@ torchx.workspace.dir_workspace
 
 .. autoclass:: DirWorkspace
   :members:
+
+.. fbcode::
+
+   torchx.workspace.fb.jetter_workspace
+   #######################################
+
+   .. automodule:: torchx.workspace.fb.jetter_workspace
+   .. currentmodule:: torchx.workspace.fb.jetter_workspace
+
+   .. autoclass:: JetterWorkspace
+     :members:


### PR DESCRIPTION
Summary: This includes all the changes to build the TorchX documentation site internally. This tweaks the OSS build with some Meta specific config (i.e. no external network requests, no jupyter execution) as well as adds a `.. fbcode::` directive that allows linking additional internal files and documentation.

Reviewed By: kiukchung

Differential Revision: D37256289

