### PR TITLE
torchx/docs: improve Meta specific documentation

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -9,13 +9,15 @@
 {% endblock %}
 
 {%- block extrabody %}
-  <div id="redirect-banner" style="display: none">
-    <p>
-      This is the public documentation. There's an internal wiki with extra
-      information for Meta employees at
-      <a href="https://fburl.com/torchx">https://fburl.com/torchx</a>
-    </p>
-  </div>
+  {% if not fbcode %}
+    <div id="redirect-banner" style="display: none">
+      <p>
+        This is the public documentation. There's an internal wiki with extra
+        information for Meta employees at
+        <a href="https://fburl.com/torchx">https://fburl.com/torchx</a>
+      </p>
+    </div>
+  {% endif %}
 {%- endblock %}
 
 {%- block content %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,6 +74,8 @@ if not FBCODE:
 if FBCODE:
     nbsphinx_execute = "never"
 
+html_context = {"fbcode": FBCODE}
+
 # coverage options
 
 coverage_ignore_modules = [

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,6 +46,14 @@ Documentation
    advanced
    custom_components.md
 
+.. fbcode::
+
+   .. toctree::
+      :maxdepth: 1
+      :caption: Usage (Meta)
+
+      fb/named_resources
+
 
 Works With
 ---------------
@@ -79,7 +87,13 @@ Works With
    pipelines/kfp
    pipelines/airflow.md
 
+.. fbcode::
 
+   .. toctree::
+      :maxdepth: 1
+      :caption: Pipelines (Meta)
+
+      pipelines/fb/flow
 
 
 Examples


### PR DESCRIPTION
Summary: This adds Meta specific documentation for schedulers/pipelines/named_resources and hides the banner for internal builds.

Differential Revision: D37298737

