### PR TITLE
torchx: add metadata_urls to allow printing user links from the CLI

### DIFF
--- a/torchx/cli/cmd_status.py
+++ b/torchx/cli/cmd_status.py
@@ -25,7 +25,9 @@ logger: logging.Logger = logging.getLogger(__name__)
 _APP_STATUS_FORMAT_TEMPLATE = """AppDef:
   State: ${state}
   Num Restarts: ${num_restarts}
-Roles:${roles}"""
+Roles:${roles}
+UI URL: ${ui_url}
+Metadata URLs:${metadata_urls}"""
 
 _ROLE_FORMAT_TEMPLATE = "\n  ${role}:${replicas}"
 
@@ -137,6 +139,10 @@ def format_app_status(
         state=app_status.state,
         num_restarts=app_status.num_restarts,
         roles=roles_data,
+        ui_url=app_status.ui_url,
+        metadata_urls="".join(
+            f"\n  {k}: {v}" for k, v in app_status.metadata_urls.items()
+        ),
     )
 
 
@@ -160,7 +166,7 @@ class CmdStatus(SubCommand):
     def run(self, args: argparse.Namespace) -> None:
         app_handle = args.app_handle
         scheduler, session_name, app_id = parse_app_handle(app_handle)
-        runner = get_runner(name=session_name)
+        runner = get_runner()
         app_status = runner.status(app_handle)
         filter_roles = parse_list_arg(args.roles)
         if app_status:

--- a/torchx/cli/test/cmd_status_test.py
+++ b/torchx/cli/test/cmd_status_test.py
@@ -76,7 +76,15 @@ Traceback (most recent call last):
         )
 
         role_status = RoleStatus(role="worker", replicas=[replica1, replica2])
-        return AppStatus(state=AppState.RUNNING, roles=[role_status])
+        return AppStatus(
+            state=AppState.RUNNING,
+            roles=[role_status],
+            ui_url="https://ui",
+            metadata_urls={
+                "a": "http://...",
+                "b": "https://...",
+            },
+        )
 
     def test_format_app_status(self) -> None:
         os.environ["TZ"] = "Europe/London"
@@ -93,5 +101,9 @@ Roles:
     timestamp: 1970-01-16 00:13:02
     hostname: localhost
     error_msg: error
-  worker[1]:RUNNING"""
+  worker[1]:RUNNING
+UI URL: https://ui
+Metadata URLs:
+  a: http://...
+  b: https://..."""
         self.assertEqual(expected_message, actual_message)

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -356,6 +356,11 @@ class Runner:
             )
             if app_status:
                 app_status.ui_url = desc.ui_url
+            for k, v in desc.metadata.items():
+                if not isinstance(v, str):
+                    continue
+                if v.startswith("http://") or v.startswith("https://"):
+                    app_status.metadata_urls[k] = v
             return app_status
 
     def wait(
@@ -459,7 +464,7 @@ class Runner:
             if not app:
                 desc = scheduler.describe(app_id)
                 if desc:
-                    app = AppDef(name=app_id, roles=desc.roles)
+                    app = AppDef(name=app_id, roles=desc.roles, metadata=desc.metadata)
             return app
 
     def log_lines(

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -327,10 +327,9 @@ class RunnerTest(unittest.TestCase):
             status = none_throws(runner.status(app_handle))
             self.assertEquals(resp.ui_url, status.ui_url)
 
-    @patch("json.dumps")
+    @patch("json.dumps", return_value="{}")
     def test_status_structured_msg(self, json_dumps_mock: MagicMock, _) -> None:
         app_id = "test_app"
-        json_dumps_mock.return_value = "{}"
         mock_scheduler = MagicMock()
         resp = DescribeAppResponse()
         resp.structured_error_msg = '{"message": "test error"}'
@@ -349,6 +348,39 @@ class RunnerTest(unittest.TestCase):
             app_handle = runner.run(AppDef(app_id, roles=[role]), scheduler="local_dir")
             status = none_throws(runner.status(app_handle))
             self.assertEquals(resp.structured_error_msg, status.structured_error_msg)
+
+    @patch("json.dumps", return_value="{}")
+    def test_status_metadata_urls(self, json_dumps_mock: MagicMock, _) -> None:
+        app_id = "test_app"
+        mock_scheduler = MagicMock()
+        resp = DescribeAppResponse()
+        resp.metadata = {
+            "var": "1",
+            "http": "http://...",
+            "https": "https://...",
+            "s3": "s3://...",
+        }
+        mock_scheduler.submit.return_value = app_id
+        mock_scheduler.describe.return_value = resp
+
+        with Runner(
+            name="test_structured_msg", schedulers={"local_dir": mock_scheduler}
+        ) as runner:
+            role = Role(
+                "ignored",
+                image=self.test_dir,
+                resource=resource.SMALL,
+                entrypoint="/bin/echo",
+            )
+            app_handle = runner.run(AppDef(app_id, roles=[role]), scheduler="local_dir")
+            status = none_throws(runner.status(app_handle))
+            self.assertEquals(
+                status.metadata_urls,
+                {
+                    "http": "http://...",
+                    "https": "https://...",
+                },
+            )
 
     def test_wait_unknown_app(self, _) -> None:
         with Runner(

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -10,7 +10,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Generic, Iterable, List, Optional, TypeVar
+from typing import Dict, Generic, Iterable, List, Optional, TypeVar
 
 from torchx.specs import (
     AppDef,
@@ -59,6 +59,7 @@ class DescribeAppResponse:
 
     roles_statuses: List[RoleStatus] = field(default_factory=list)
     roles: List[Role] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
 
 
 T = TypeVar("T")

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -461,6 +461,7 @@ class AppStatus:
     msg: str = ""
     structured_error_msg: str = NONE
     ui_url: Optional[str] = None
+    metadata_urls: Dict[str, str] = field(default_factory=dict)
     roles: List[RoleStatus] = field(default_factory=list)
 
     def is_terminal(self) -> bool:

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -60,6 +60,7 @@ class AppDefStatusTest(unittest.TestCase):
         self.assertEqual(
             serialized,
             """AppStatus:
+  metadata_urls: {}
   msg: ''
   num_restarts: 0
   roles: []
@@ -77,6 +78,7 @@ class AppDefStatusTest(unittest.TestCase):
         self.assertEqual(
             serialized,
             """AppStatus:
+  metadata_urls: {}
   msg: ''
   num_restarts: 0
   roles: []


### PR DESCRIPTION
Summary:
This adds a new `metadata_urls` to AppStatus and `metadata` to DescribeAppResponse. Metadata URLs are automatically returned from metadata values if they start with `http://` or `https://`. This isn't quite as clean as a dedicated URLs field that we discussed in https://github.com/pytorch/torchx/issues/509 but can work when calling status and not just during launch time.

This also enables a way for schedulers to return extra UI links and services that are scheduler specific but not available at launch time.

Differential Revision: D37353646

