### PR TITLE
Add a debug flag to dist component

### DIFF
--- a/docs/source/components/distributed.rst
+++ b/docs/source/components/distributed.rst
@@ -6,6 +6,9 @@ Distributed
 
 .. autofunction:: torchx.components.dist.ddp
 
+.. autodata:: torchx.components.dist._TORCH_DEBUG_FLAGS
+   :annotation:
+
 .. fbcode::
 
   .. automodule:: torchx.components.fb.dist

--- a/torchx/components/test/dist_test.py
+++ b/torchx/components/test/dist_test.py
@@ -17,3 +17,9 @@ class DistributedComponentTest(ComponentTestCase):
             script="foo.py", mounts=["type=bind", "src=/dst", "dst=/dst", "readonly"]
         )
         self.assertEqual(len(app.roles[0].mounts), 1)
+
+    def test_ddp_debug(self) -> None:
+        app = dist.ddp(script="foo.py", debug=True)
+        env = app.roles[0].env
+        for k, v in dist._TORCH_DEBUG_FLAGS.items():
+            self.assertEqual(env[k], v)


### PR DESCRIPTION
Summary: Add a debug flag to the component to set commonly used environment variables used for debugging. These can't be enabled by default because of the performance hit they incur.

Differential Revision: D37229266

