### PR TITLE
Fix nbsphinx requirejs config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -375,5 +375,7 @@ nbsphinx_epilog = r"""
     <div id="is-nbsphinx"></div>
 """
 
+nbsphinx_requirejs_path = ""
+
 if os.environ.get("SKIP_NB"):
     nbsphinx_execute = "never"


### PR DESCRIPTION
NBSphinx introduce its own `requirejs`, while PyTorch sphinx theme already has one.
This causes JS script to hit `Uncaught ReferenceError: collapsedSections is not defined`, and 
some UI initialization steps are never executed.

One outcome is that the right side bar no longer sticks. like https://pytorch.org/torchx/latest/basics.html

The fix is simply tell NBSphinx to not bring its requirejs.

Test plan:
n/a
