### PR TITLE
API to list jobs by scheduler

### DIFF
--- a/torchx/cli/cmd_list.py
+++ b/torchx/cli/cmd_list.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import logging
+
+from torchx.cli.cmd_base import SubCommand
+from torchx.runner import get_runner
+from torchx.schedulers import get_default_scheduler_name, get_scheduler_factories
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class CmdList(SubCommand):
+    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        scheduler_names = get_scheduler_factories().keys()
+        subparser.add_argument(
+            "-s",
+            "--scheduler",
+            type=str,
+            default=get_default_scheduler_name(),
+            choices=list(scheduler_names),
+            help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]",
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+        with get_runner() as runner:
+            jobs = runner.list(args.scheduler)
+            print(*jobs, sep="\n")

--- a/torchx/cli/main.py
+++ b/torchx/cli/main.py
@@ -14,6 +14,7 @@ from torchx.cli.cmd_base import SubCommand
 from torchx.cli.cmd_cancel import CmdCancel
 from torchx.cli.cmd_configure import CmdConfigure
 from torchx.cli.cmd_describe import CmdDescribe
+from torchx.cli.cmd_list import CmdList
 from torchx.cli.cmd_log import CmdLog
 from torchx.cli.cmd_run import CmdBuiltins, CmdRun
 from torchx.cli.cmd_runopts import CmdRunopts
@@ -33,6 +34,7 @@ def get_default_sub_cmds() -> Dict[str, SubCommand]:
         "cancel": CmdCancel(),
         "configure": CmdConfigure(),
         "describe": CmdDescribe(),
+        "list": CmdList(),
         "log": CmdLog(),
         "run": CmdRun(),
         "runopts": CmdRunopts(),

--- a/torchx/cli/test/cmd_list_test.py
+++ b/torchx/cli/test/cmd_list_test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import unittest
+from unittest.mock import MagicMock, patch
+
+from torchx.cli.cmd_list import CmdList
+
+
+class CmdListTest(unittest.TestCase):
+    @patch("torchx.runner.api.Runner.list")
+    def test_run(self, list: MagicMock) -> None:
+        parser = argparse.ArgumentParser()
+        cmd_list = CmdList()
+        cmd_list.add_arguments(parser)
+
+        args = parser.parse_args(
+            [
+                "--scheduler",
+                "kubernetes",
+            ]
+        )
+        cmd_list.run(args)
+
+        self.assertEqual(list.call_count, 1)
+        list.assert_called_with("kubernetes")

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -394,17 +394,6 @@ class Runner:
                 else:
                     time.sleep(wait_interval)
 
-    def list(self) -> Dict[AppHandle, AppDef]:
-        """
-        Returns the applications that were run with this session mapped by the app handle.
-        The persistence of the session is implementation dependent.
-        """
-        with log_event("list"):
-            app_ids = list(self._apps.keys())
-            for app_id in app_ids:
-                self.status(app_id)
-            return self._apps
-
     def cancel(self, app_handle: AppHandle) -> None:
         """
         Stops the application, effectively directing the scheduler to cancel
@@ -554,6 +543,18 @@ class Runner:
                 streams=streams,
             )
             return log_iter
+
+    def list(
+        self,
+        scheduler: str,
+    ) -> List[str]:
+        """
+        Returns the list of app handles launched by the scheduler.
+        Note: This API is in prototype phase and is subject to change.
+        """
+        with log_event("list", scheduler):
+            sched = self._scheduler(scheduler)
+            return sched.list()
 
     # pyre-fixme: Scheduler opts
     def _scheduler(self, scheduler: str) -> Scheduler:

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -59,6 +59,9 @@ class TestScheduler(Scheduler):
     ) -> Iterable[str]:
         raise NotImplementedError()
 
+    def list(self) -> List[str]:
+        raise NotImplementedError()
+
     def run_opts(self) -> runopts:
         opts = runopts()
         opts.add(

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -171,6 +171,14 @@ class Scheduler(abc.ABC, Generic[T]):
         """
         raise NotImplementedError()
 
+    @abc.abstractmethod
+    def list(self) -> List[str]:
+        """
+        Lists the app handles launched on the scheduler.
+        Note: This API is in prototype phase and is subject to change.
+        """
+        raise NotImplementedError()
+
     def exists(self, app_id: str) -> bool:
         """
         Returns:

--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -43,6 +43,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    List,
     Optional,
     Tuple,
     TYPE_CHECKING,
@@ -517,6 +518,9 @@ class AWSBatchScheduler(Scheduler[AWSBatchOpts], DockerWorkspace):
             return filter_regex(regex, iterator)
         else:
             return iterator
+
+    def list(self) -> List[str]:
+        raise NotImplementedError()
 
     def _stream_events(
         self,

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -447,6 +447,9 @@ class DockerScheduler(Scheduler[DockerOpts], DockerWorkspace):
         else:
             return logs
 
+    def list(self) -> List[str]:
+        raise NotImplementedError()
+
 
 def _to_str(a: Union[str, bytes]) -> str:
     if isinstance(a, bytes):

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -972,6 +972,9 @@ class LocalScheduler(Scheduler[LocalOpts]):
 
         return LogIterator(app_id, regex or ".*", log_file, self)
 
+    def list(self) -> List[str]:
+        raise NotImplementedError()
+
     def _cancel_existing(self, app_id: str) -> None:
         # can assume app_id exists
         local_app = self._apps[app_id]

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -396,6 +396,9 @@ if _has_ray:
                 return filter_regex(regex, iterator)
             return iterator
 
+        def list(self) -> List[str]:
+            raise NotImplementedError()
+
     def create_scheduler(session_name: str, **kwargs: Any) -> RayScheduler:
         if not has_ray():  # pragma: no cover
             raise RuntimeError(

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -556,6 +556,9 @@ class SlurmScheduler(Scheduler[SlurmOpts], DirWorkspace):
             app_id, regex or ".*", log_file, self, should_tail=should_tail
         )
 
+    def list(self) -> List[str]:
+        raise NotImplementedError()
+
 
 def create_scheduler(session_name: str, **kwargs: Any) -> SlurmScheduler:
     return SlurmScheduler(

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -8,7 +8,7 @@
 
 import unittest
 from datetime import datetime
-from typing import Iterable, Mapping, Optional, TypeVar, Union
+from typing import Iterable, List, Mapping, Optional, TypeVar, Union
 from unittest.mock import MagicMock, patch
 
 from torchx.schedulers.api import DescribeAppResponse, Scheduler, split_lines, Stream
@@ -62,6 +62,9 @@ class SchedulerTest(unittest.TestCase):
             streams: Optional[Stream] = None,
         ) -> Iterable[str]:
             return iter([])
+
+        def list(self) -> List[str]:
+            return []
 
         def run_opts(self) -> runopts:
             opts = runopts()


### PR DESCRIPTION
Given a scheduler, `torchx list -s <scheduler_name>` lists the jobs scheduled on it. 
MVP that supports listing jobs for kubernetes scheduler to address https://github.com/pytorch/torchx/issues/503
More features like listing just jobs started by torchx, listing active jobs, filtering options to be implemented in following PRs

Test plan:
```
(venv38) ubuntu@ip:~/wp/torchx$ torchx list -s kubernetes
cifar-trainer-a5qvfhe1hyb1b
cifar-trainer-d796ei2tdf4bc
cifar-trainer-em0iao2m9agog
cifar-trainer-ew33oxmdg7t0c
cifar-trainer-grjsnfxeinqbd
cifar-trainer-p4bwlewvwmt1f
cifar-trainer-pwy4c4omfufff
cifar-trainer-qyan5cp6vz5od
cifar-trainer-rbrd5krzkyz3c
cifar-trainer-rw9kn5rtau6se
.
.
.
.
train-zhqz9fhr7h0tsc
trainer-bwhcp3vw2khftc
trainer-m3mxh6dcxgwtv
```

