### PR TITLE
container: bump container version to Torch 1.12

### DIFF
--- a/torchx/runtime/container/Dockerfile
+++ b/torchx/runtime/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime
+FROM pytorch/pytorch:1.12.0-cuda11.3-cudnn8-runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
<!-- Change Summary -->

This updates the docker container to use PyTorch 1.12.

This should also fix the flakiness in the Kubernetes integration tests.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
torchx/runtime/container/build.sh
```

CI