### PR TITLE
Get logs from running job with aws_batch scheduler

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -505,13 +505,16 @@ class AWSBatchScheduler(Scheduler[AWSBatchOpts], DockerWorkspace):
         if not job:
             return []
 
-        attempts = job["attempts"]
-        if len(attempts) == 0:
-            return []
+        if "status" in job and job["status"] == "RUNNING":
+            stream_name = job["container"]["logStreamName"]
+        else:
+            attempts = job["attempts"]
+            if len(attempts) == 0:
+                return []
 
-        attempt = attempts[-1]
-        container = attempt["container"]
-        stream_name = container["logStreamName"]
+            attempt = attempts[-1]
+            container = attempt["container"]
+            stream_name = container["logStreamName"]
 
         iterator = self._stream_events(stream_name, since=since, until=until)
         if regex:


### PR DESCRIPTION
Running jobs return information about the logStream in a different
location than completed jobs. In a running job, the `attempts` list is
empty. This patch checks the status of a job to pull the logStreamName
of a running batch job in order to return logs for it.

Test plan:
* Unit test
* Ran `torchx log` on a running aws batch job, and verified that logs are now returned.
