### PR TITLE
Return url to job in AWS console for aws_batch scheduler

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -35,6 +35,7 @@ https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html#
 for how to create a image repository.
 """
 
+import re
 import threading
 from dataclasses import dataclass
 from datetime import datetime
@@ -468,10 +469,17 @@ class AWSBatchScheduler(Scheduler[AWSBatchOpts], DockerWorkspace):
                 )
             roles[role].num_replicas += 1
 
+        match = re.match(
+            "arn:aws:batch:([a-z-0-9]+):[0-9]+:job/([a-z-0-9]+)", job["jobArn"]
+        )
+        region = match.group(1)
+        job_id = match.group(2)
+
         return DescribeAppResponse(
             app_id=app_id,
             state=JOB_STATE[job["status"]],
             roles=list(roles.values()),
+            ui_url=f"https://{region}.console.aws.amazon.com/batch/home?region={region}#jobs/mnp-job/{job_id}",
         )
 
     def log_iter(

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -312,7 +312,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
         scheduler._client.describe_jobs.return_value = {
             "jobs": [
                 {
-                    "jobArn": "thejobarn",
+                    "jobArn": "arn:aws:batch:us-west-2:495572122715:job/6afc27d7-3559-43ca-89fd-1007b6bf2546",
                     "jobName": "app-name-42",
                     "jobId": "6afc27d7-3559-43ca-89fd-1007b6bf2546",
                     "jobQueue": "testqueue",
@@ -442,6 +442,10 @@ class AWSBatchSchedulerTest(unittest.TestCase):
         self.assertIsNotNone(status)
         self.assertEqual(status.state, specs.AppState.SUCCEEDED)
         self.assertEqual(status.app_id, "testqueue:app-name-42")
+        self.assertEqual(
+            status.ui_url,
+            "https://us-west-2.console.aws.amazon.com/batch/home?region=us-west-2#jobs/mnp-job/6afc27d7-3559-43ca-89fd-1007b6bf2546",
+        )
         self.assertEqual(
             status.roles[0],
             specs.Role(


### PR DESCRIPTION
For jobs submitted to the `aws_batch` scheduler, return a URL to the job in the AWS console

Test plan:
* Unit test
* Submitted a job to batch, verified that the UI URL works
