### PR TITLE
List API for local scheduler

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-from time import sleep
-
-print("hello")
-sleep(60)
-print("end")

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from time import sleep
+
+print("hello")
+sleep(60)
+print("end")

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -973,7 +973,7 @@ class LocalScheduler(Scheduler[LocalOpts]):
         return LogIterator(app_id, regex or ".*", log_file, self)
 
     def list(self) -> List[str]:
-        raise NotImplementedError()
+        raise Exception("Apps cannot be listed for local scheduler as they are not persisted")
 
     def _cancel_existing(self, app_id: str) -> None:
         # can assume app_id exists

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -973,7 +973,7 @@ class LocalScheduler(Scheduler[LocalOpts]):
         return LogIterator(app_id, regex or ".*", log_file, self)
 
     def list(self) -> List[str]:
-        raise Exception("Apps cannot be listed for local scheduler as they are not persisted")
+        raise Exception("App handles cannot be listed for local scheduler as they are not persisted by torchx")
 
     def _cancel_existing(self, app_id: str) -> None:
         # can assume app_id exists

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -973,7 +973,9 @@ class LocalScheduler(Scheduler[LocalOpts]):
         return LogIterator(app_id, regex or ".*", log_file, self)
 
     def list(self) -> List[str]:
-        raise Exception("App handles cannot be listed for local scheduler as they are not persisted by torchx")
+        raise Exception(
+            "App handles cannot be listed for local scheduler as they are not persisted by torchx"
+        )
 
     def _cancel_existing(self, app_id: str) -> None:
         # can assume app_id exists

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -735,6 +735,10 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         assert desc is not None
         self.assertEqual(AppState.CANCELLED, desc.state)
 
+    def test_list(self) -> None:
+        with self.assertRaisesRegex(Exception, "cannot be listed for local scheduler"):
+            self.scheduler.list()
+
     def test_exists(self) -> None:
         role = Role(
             "role1",

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -736,7 +736,7 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         self.assertEqual(AppState.CANCELLED, desc.state)
 
     def test_list(self) -> None:
-        with self.assertRaisesRegex(Exception, "cannot be listed for local scheduler"):
+        with self.assertRaisesRegex(Exception, "cannot be listed"):
             self.scheduler.list()
 
     def test_exists(self) -> None:


### PR DESCRIPTION
Add List API for local scheduler. This throws exception as apps launched by local scheduler are only known to the launching python process and are not persisted elsewhere. 
List API: https://github.com/pytorch/torchx/issues/503 

Test plan:
```pytest torchx/schedulers/local_scheduler_test.py```