### PR TITLE
List API - refactor out common logic

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -554,7 +554,11 @@ class Runner:
         """
         with log_event("list", scheduler):
             sched = self._scheduler(scheduler)
-            return sched.list()
+            app_handles = [
+                make_app_handle(scheduler, self._name, app_id)
+                for app_id in sched.list()
+            ]
+            return app_handles
 
     # pyre-fixme: Scheduler opts
     def _scheduler(self, scheduler: str) -> Scheduler:

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -363,13 +363,17 @@ class RunnerTest(unittest.TestCase):
 
     def test_list(self, _) -> None:
         scheduler_mock = MagicMock()
-        app_handles_return = ["app_handle1", "app_handle2"]
-        scheduler_mock.list.return_value = app_handles_return
+        app_ids_return = ["app_handle1", "app_handle2"]
+        scheduler_mock.list.return_value = app_ids_return
+        app_handles_expected = [
+            "kubernetes://test_session/app_handle1",
+            "kubernetes://test_session/app_handle2",
+        ]
         with Runner(
             name=SESSION_NAME, schedulers={"kubernetes": scheduler_mock}
         ) as runner:
             app_handles = runner.list("kubernetes")
-            self.assertEqual(app_handles, app_handles_return)
+            self.assertEqual(app_handles, app_handles_expected)
             scheduler_mock.list.assert_called_once()
 
     @patch("json.dumps")

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -174,7 +174,7 @@ class Scheduler(abc.ABC, Generic[T]):
     @abc.abstractmethod
     def list(self) -> List[str]:
         """
-        Lists the app handles launched on the scheduler.
+        Lists the app ids launched on the scheduler.
         Note: This API is in prototype phase and is subject to change.
         """
         raise NotImplementedError()

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -66,7 +66,6 @@ from torchx.specs.api import (
     runopts,
     VolumeMount,
 )
-from torchx.specs.builders import make_app_handle
 from torchx.workspace.docker_workspace import DockerWorkspace
 from typing_extensions import TypedDict
 
@@ -759,7 +758,7 @@ class KubernetesScheduler(Scheduler[KubernetesOpts], DockerWorkspace):
             return iterator
 
     def list(self) -> List[str]:
-        job_names = []
+        app_ids = []
         namespace = "default"
         resp = self._custom_objects_api().list_namespaced_custom_object(
             group="batch.volcano.sh",
@@ -772,9 +771,8 @@ class KubernetesScheduler(Scheduler[KubernetesOpts], DockerWorkspace):
         for item in items:
             name = item["metadata"]["name"]
             app_id = f"{namespace}:{name}"
-            app_handle = make_app_handle("kubernetes", "default", app_id)
-            job_names.append(app_handle)
-        return job_names
+            app_ids.append(app_id)
+        return app_ids
 
 
 def create_scheduler(session_name: str, **kwargs: Any) -> KubernetesScheduler:

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -764,7 +764,7 @@ spec:
             ],
         }
         scheduler = create_scheduler("test")
-        app_handles = scheduler.list()
+        app_ids = scheduler.list()
         call = list_namespaced_custom_object.call_args
         args, kwargs = call
         self.assertEqual(
@@ -778,10 +778,10 @@ spec:
             },
         )
         self.assertEqual(
-            app_handles,
+            app_ids,
             [
-                "kubernetes://default/default:cifar-trainer-something",
-                "kubernetes://default/default:test-trainer",
+                "default:cifar-trainer-something",
+                "default:test-trainer",
             ],
         )
 


### PR DESCRIPTION
Move common logic shared across schedulers(kubernetes, docker etc) like creating app_handle from app_id to runner list API from scheduler's list implementation 

Test plan:
Updated unit tests and ran pytest
