### PR TITLE
List API for docker scheduler 

### DIFF
--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -448,7 +448,13 @@ class DockerScheduler(Scheduler[DockerOpts], DockerWorkspace):
             return logs
 
     def list(self) -> List[str]:
-        raise NotImplementedError()
+        unique_app_ids = {
+            cntr.labels[LABEL_APP_ID]
+            for cntr in self._docker_client.containers.list(
+                all=True, filters={"label": f"{LABEL_APP_ID}"}
+            )
+        }
+        return list(unique_app_ids)
 
 
 def _to_str(a: Union[str, bytes]) -> str:

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -354,6 +354,11 @@ if has_docker():
                 ],
             )
 
+        def test_docker_list(self) -> None:
+            app = self._docker_app("echo", "bar")
+            app_id = self.scheduler.submit(app, cfg={})
+            self.assertTrue(app_id in self.scheduler.list())
+
         def test_docker_cancel(self) -> None:
             app = self._docker_app("sleep", "10000")
             app_id = self.scheduler.submit(app, cfg={})


### PR DESCRIPTION
API to list apps scheduled by torchx in docker scheduler 
Addresses https://github.com/pytorch/torchx/issues/503 

Test plan:
Add unit and integration tests 

```
√ xx@xx-mbp torchx % torchx list -s local_docker
local_docker://torchx/test-app-k701kzdsb6c1q
local_docker://torchx/torchx_utils_python-zvjfxxz3l5kgvc
local_docker://torchx/test-app-klsl3btcg5sf7
.
.
local_docker://torchx/app_name_0
local_docker://torchx/test-app-w3c41792k15z9
local_docker://torchx/test-app-x6mrqcjdvq4pv
local_docker://torchx/echo-zv9b2sks2npbfd
local_docker://torchx/echo-tm2rlf3tfhr3f
```
