### PR TITLE
Fixes pytorch/torchx#548

### DIFF
--- a/torchx/workspace/docker_workspace.py
+++ b/torchx/workspace/docker_workspace.py
@@ -7,6 +7,7 @@
 import io
 import logging
 import posixpath
+import stat
 import tarfile
 import tempfile
 from typing import Dict, IO, Mapping, Optional, Tuple, TYPE_CHECKING
@@ -189,4 +190,12 @@ def _copy_to_tarfile(workspace: str, tf: tarfile.TarFile) -> None:
                 size = info["size"]
                 assert isinstance(size, int), "size must be an int"
                 tinfo.size = size
+
+                # preserve unix mode for supported filesystems; fsspec.filesystem("memory") for example does not support
+                # unix file mode, hence conditional check here
+                if "mode" in info:
+                    mode = info["mode"]
+                    assert isinstance(mode, int), "mode must be an int"
+                    tinfo.mode = stat.S_IMODE(mode)
+
                 tf.addfile(tinfo, f)


### PR DESCRIPTION
Preserve Unix file mode when patching files into docker image.

Test plan:
* Tested with the repro steps in #548
* Verify that existing unit tests in `docker_workspace_test.py` still passes. Seems like the only way to write tests to check the mode is to create a [temporary directory](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory). I'm not sure if the maintainers want tests that interact with the file system?
