### PR TITLE
List API for AWS Batch 

### DIFF
--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -483,6 +483,17 @@ class AWSBatchSchedulerTest(unittest.TestCase):
             ],
         }
 
+        scheduler._client.describe_job_queues.return_value = {
+            "ResponseMetadata": {},
+            "jobQueues": [
+                {
+                    "jobQueueName": "torchx",
+                    "jobQueueArn": "arn:aws:batch:test-region:4000005:job-queue/torchx",
+                    "state": "ENABLED",
+                },
+            ],
+        }
+
         return scheduler
 
     @mock_rand()
@@ -523,6 +534,12 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                 },
             ),
         )
+
+    def test_list(self) -> None:
+        scheduler = self._mock_scheduler()
+        expected_app_ids = ["torchx:echo-v1r560pmwn5t3c"]
+        app_ids = scheduler.list()
+        self.assertEqual(app_ids, expected_app_ids)
 
     def test_log_iter(self) -> None:
         scheduler = self._mock_scheduler()


### PR DESCRIPTION
List jobs scheduled in AWS Batch scheduler across all queues. 
Might support listing by queueName in the future. 

Addresses https://github.com/pytorch/torchx/issues/503 

Test plan:
Unit tests
```
(venv38) ubuntu@ip-172-31-24-88:~/rsync/torchx$ torchx list -s aws_batch
torchx 2022-07-13 00:33:16 INFO     Found credentials in environment variables.
aws_batch://torchx/torchx:touch-c79fsrptv..
aws_batch://torchx/torchx:sh-qpdf3z7..
aws_batch://torchx/torchx:torchx-torchserve-vcdqjk..
.
.
```