### PR TITLE
torchx: clean up Local scheduler + documentation

### DIFF
--- a/docs/source/ext/runopts.py
+++ b/docs/source/ext/runopts.py
@@ -21,8 +21,9 @@ class RunOptsDirective(SphinxDirective):
         raw_content = "\n".join(self.content)
         args = yaml.safe_load(raw_content)
         cls = locate(args["class"])
+        scheduler = cls("docs")
 
-        body = nodes.literal_block(text=str(cls.run_opts(None)))
+        body = nodes.literal_block(text=str(scheduler.run_opts()))
         return [
             body,
         ]

--- a/docs/source/workspace.rst
+++ b/docs/source/workspace.rst
@@ -42,3 +42,4 @@ torchx.workspace.dir_workspace
 
    .. autoclass:: JetterWorkspace
      :members:
+     :show-inheritance:

--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -263,7 +263,7 @@ class AWSBatchScheduler(Scheduler[AWSBatchOpts], DockerWorkspace):
     **Config Options**
 
     .. runopts::
-        class: torchx.schedulers.aws_batch_scheduler.AWSBatchScheduler
+        class: torchx.schedulers.aws_batch_scheduler.create_scheduler
 
     **Mounts**
 

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -115,7 +115,7 @@ class DockerScheduler(Scheduler[DockerOpts], DockerWorkspace):
     **Config Options**
 
     .. runopts::
-        class: torchx.schedulers.docker_scheduler.DockerScheduler
+        class: torchx.schedulers.docker_scheduler.create_scheduler
 
     **Mounts**
 

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -473,7 +473,7 @@ class KubernetesScheduler(Scheduler[KubernetesOpts], DockerWorkspace):
     **Config Options**
 
     .. runopts::
-        class: torchx.schedulers.kubernetes_scheduler.KubernetesScheduler
+        class: torchx.schedulers.kubernetes_scheduler.create_scheduler
 
     **Mounts**
 

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -527,7 +527,7 @@ class LocalScheduler(Scheduler[LocalOpts]):
     **Config Options**
 
     .. runopts::
-        class: torchx.schedulers.local_scheduler.LocalScheduler
+        class: torchx.schedulers.local_scheduler.create_scheduler
 
     **Compatibility**
 

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -126,7 +126,7 @@ if _has_ray:
         **Config Options**
 
         .. runopts::
-            class: torchx.schedulers.ray_scheduler.RayScheduler
+            class: torchx.schedulers.ray_scheduler.create_scheduler
 
         **Compatibility**
 

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -289,7 +289,7 @@ class SlurmScheduler(Scheduler[SlurmOpts], DirWorkspace):
     **Config Options**
 
     .. runopts::
-        class: torchx.schedulers.slurm_scheduler.SlurmScheduler
+        class: torchx.schedulers.slurm_scheduler.create_scheduler
 
     **Compatibility**
 


### PR DESCRIPTION
Summary:
This contains some documentation updates/cleanups.

For `runopts` it switches all of the schedulers to use the create_scheduler methods for doc generation instead of bypassing the initialization which can cause issues with inheritance.

Differential Revision: D37834482

