### PR TITLE
List API for Ray scheduler 

### DIFF
--- a/torchx/cli/cmd_list.py
+++ b/torchx/cli/cmd_list.py
@@ -24,7 +24,8 @@ class CmdList(SubCommand):
             type=str,
             default=get_default_scheduler_name(),
             choices=list(scheduler_names),
-            help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]",
+            help=f"Name of the scheduler to use. One of: [{','.join(scheduler_names)}]."
+            " For listing app handles for ray scheduler, RAY_ADDRESS env variable should be set.",
         )
 
     def run(self, args: argparse.Namespace) -> None:

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -397,7 +397,17 @@ if _has_ray:
             return iterator
 
         def list(self) -> List[str]:
-            raise NotImplementedError()
+            address = os.getenv("RAY_ADDRESS")
+            if not address:
+                raise Exception(
+                    "RAY_ADDRESS env variable is expected to be set to list jobs on ray scheduler."
+                    " See https://docs.ray.io/en/latest/cluster/jobs-package-ref.html#job-submission-sdk for more info"
+                )
+            client = JobSubmissionClient(address)
+            jobs_dict = client.list_jobs()
+            ip = address.split("http://", 1)[-1]
+            app_handles = [f"{ip}-{job_id}" for job_id in jobs_dict.keys()]
+            return app_handles
 
 
 def create_scheduler(session_name: str, **kwargs: Any) -> "RayScheduler":


### PR DESCRIPTION
Implement list API for Ray shceduler

Test plan:
Unit and integration test
```
(venv38) ubuntu@ip-172-31-24-88:~/rsync/torchx$ torchx list -s ray
ray://torchx/127.0.0.1:8265-123
```