### PR TITLE
local_scheduler: better formating when using pdb

### DIFF
--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -42,6 +42,8 @@ def _prefix_line(prefix: str, line: str) -> str:
     """
     if "\r" in line:
         line = line.replace("\r", f"\r{prefix}")
+    if "\n" in line[:-1]:
+        line = line[:-1].replace("\n", f"\n{prefix}") + line[-1:]
     if not line.startswith("\r"):
         line = f"{prefix}{line}"
     return line
@@ -68,7 +70,7 @@ def print_log_lines(
             streams=streams,
         ):
             prefix = f"{GREEN}{role_name}/{replica_id}{ENDC} "
-            print(_prefix_line(prefix, line), file=file, end="")
+            print(_prefix_line(prefix, line), file=file, end="", flush=True)
     except Exception as e:
         exceptions.put(e)
         raise

--- a/torchx/cli/test/cmd_log_test.py
+++ b/torchx/cli/test/cmd_log_test.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Iterator, Optional
 from unittest.mock import MagicMock, patch
 
-from torchx.cli.cmd_log import ENDC, get_logs, GREEN, validate
+from torchx.cli.cmd_log import _prefix_line, ENDC, get_logs, GREEN, validate
 from torchx.runner.api import Runner
 from torchx.schedulers.api import Stream
 from torchx.specs import AppDef, AppHandle, AppState, AppStatus, parse_app_handle, Role
@@ -192,3 +192,13 @@ class CmdLogTest(unittest.TestCase):
 
         with self.assertRaisesRegex(SystemExit, "1"):
             validate("kubernetes://session/queue:name-1234/role/")
+
+    def test_prefix_line(self) -> None:
+        self.assertEqual(_prefix_line("<prefix>", "test\n"), "<prefix>test\n")
+        self.assertEqual(_prefix_line("<prefix>", "\rtest\n"), "\r<prefix>test\n")
+        self.assertEqual(
+            _prefix_line("<prefix>", "foo\rtest\n"), "<prefix>foo\r<prefix>test\n"
+        )
+        self.assertEqual(
+            _prefix_line("<prefix>", "foo\ntest\n"), "<prefix>foo\n<prefix>test\n"
+        )

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -334,3 +334,14 @@ def split_lines(text: str) -> List[str]:
             lines.append(text)
             break
     return lines
+
+
+def split_lines_iterator(chunks: Iterable[str]) -> Iterable[str]:
+    """
+    split_lines_iterator splits each chunk in the iterator by new lines and
+    returns them.
+    """
+    for chunk in chunks:
+        lines = split_lines(chunk)
+        for line in lines:
+            yield line

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -16,7 +16,6 @@ import json
 import logging
 import os
 import pprint
-import re
 import shutil
 import signal
 import subprocess
@@ -28,20 +27,17 @@ import warnings
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from types import FrameType
-from typing import (
-    Any,
-    BinaryIO,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Pattern,
-    TextIO,
-)
+from typing import Any, BinaryIO, Callable, Dict, Iterable, List, Optional, TextIO
 
 from pyre_extensions import none_throws
-from torchx.schedulers.api import AppDryRunInfo, DescribeAppResponse, Scheduler, Stream
+from torchx.schedulers.api import (
+    AppDryRunInfo,
+    DescribeAppResponse,
+    filter_regex,
+    Scheduler,
+    split_lines_iterator,
+    Stream,
+)
 from torchx.schedulers.ids import make_unique
 from torchx.schedulers.streams import Tee
 from torchx.specs.api import AppDef, AppState, is_terminal, macros, NONE, Role, runopts
@@ -969,8 +965,12 @@ class LocalScheduler(Scheduler[LocalOpts]):
                 f"app: {app_id} was not configured to log into a file."
                 f" Did you run it with log_dir set in Dict[str, CfgVal]?"
             )
-
-        return LogIterator(app_id, regex or ".*", log_file, self)
+        iterator = LogIterator(app_id, log_file, self)
+        # sometimes there's multiple lines per logged line
+        iterator = split_lines_iterator(iterator)
+        if regex:
+            iterator = filter_regex(regex, iterator)
+        return iterator
 
     def list(self) -> List[str]:
         raise Exception(
@@ -1007,14 +1007,12 @@ class LogIterator:
     def __init__(
         self,
         app_id: str,
-        regex: str,
         log_file: str,
         # pyre-fixme: Scheduler opts
         scheduler: Scheduler,
         should_tail: bool = True,
     ) -> None:
         self._app_id: str = app_id
-        self._regex: Pattern[str] = re.compile(regex)
         self._log_file: str = log_file
         self._log_fp: Optional[TextIO] = None
         # pyre-fixme: Scheduler opts
@@ -1051,8 +1049,9 @@ class LogIterator:
     def __next__(self) -> str:
         log_fp = self._log_fp
         assert log_fp is not None
+        BUFSIZE = 64000
         while True:
-            line = log_fp.readline()
+            line = log_fp.read(BUFSIZE)
             if not line:
                 # we have reached EOF and app finished
                 if self._app_finished:
@@ -1064,8 +1063,7 @@ class LogIterator:
                 time.sleep(0.1)
                 self._check_finished()
             else:
-                if re.match(self._regex, line):
-                    return line
+                return line
 
 
 def create_scheduler(session_name: str, **kwargs: Any) -> LocalScheduler:

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -11,7 +11,13 @@ from datetime import datetime
 from typing import Iterable, List, Mapping, Optional, TypeVar, Union
 from unittest.mock import MagicMock, patch
 
-from torchx.schedulers.api import DescribeAppResponse, Scheduler, split_lines, Stream
+from torchx.schedulers.api import (
+    DescribeAppResponse,
+    Scheduler,
+    split_lines,
+    split_lines_iterator,
+    Stream,
+)
 from torchx.specs.api import (
     AppDef,
     AppDryRunInfo,
@@ -163,3 +169,22 @@ class SchedulerTest(unittest.TestCase):
         self.assertEqual(split_lines("\n"), ["\n"])
         self.assertEqual(split_lines("foo\nbar"), ["foo\n", "bar"])
         self.assertEqual(split_lines("foo\nbar\n"), ["foo\n", "bar\n"])
+
+    def test_split_lines_iterator(self) -> None:
+        self.assertEqual(
+            list(split_lines_iterator(["1\n2\n3\n4\n"])),
+            [
+                "1\n",
+                "2\n",
+                "3\n",
+                "4\n",
+            ],
+        )
+        self.assertEqual(
+            list(split_lines_iterator(["foo\nbar", "foobar"])),
+            [
+                "foo\n",
+                "bar",
+                "foobar",
+            ],
+        )


### PR DESCRIPTION
<!-- Change Summary -->

This improves the log behavior when running interactive applications such as pdb for debugging purposes. It changes it so that the local scheduler loggers will read whatever is in the buffer instead of requiring a new line character. This means that when using pdb the REPL `(Pdb)` will be printed correctly.

There's a few additional tweaks to generally be more robust to handling new lines in depth.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Added unit tests + existing tests

```
$ torchx run -s local_cwd --log --wait utils.python -c "import pdb; pdb.set_trace()"
```

![2022-07-19-140514_622x202_scrot](https://user-images.githubusercontent.com/909104/179848282-bfa44618-1cc2-4527-a748-cce4a51ecd95.png)

