### PR TITLE
Use raw content for kubectl apply

### DIFF
--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -26,7 +26,7 @@ This requires the installation of etcd service on your kubernetes cluster:
 
 .. code:: bash
 
-    kubectl apply -f https://github.com/pytorch/torchx/blob/main/resources/etcd.yaml
+    kubectl apply -f https://raw.githubusercontent.com/pytorch/torchx/main/resources/etcd.yaml
 
 
 Learn more about running distributed trainers :py:mod:`torchx.components.dist`


### PR DESCRIPTION
Otherwise, the error `error: error parsing https://github.com/pytorch/torchx/blob/main/resources/etcd.yaml: error converting YAML to JSON: yaml: line 28: mapping values are not allowed in this context` is raised.
