### PR TITLE
kubernetes_scheduler: fix anchor link to non-js anchor

### DIFF
--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -23,7 +23,7 @@ Install Volcano:
     kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.6.0/installer/volcano-development.yaml
 
 See the
-`Volcano Quickstart <https://github.com/volcano-sh/volcano#quick-start-guide>`_
+`Volcano Quickstart <https://github.com/volcano-sh/volcano#user-content-quick-start-guide>`_
 for more information.
 """
 


### PR DESCRIPTION
<!-- Change Summary -->

GitHub uses JS based anchor links by default which caused sphinx link checking to fail. This uses the hard coded anchor instead.

```
$ curl https://github.com/volcano-sh/volcano#quick-start-guide | rg 'quick-start-guide'
<h2 dir="auto"><a id="user-content-quick-start-guide" class="anchor" aria-hidden="true" href="#quick-start-guide">
```

Fixes https://github.com/pytorch/torchx/runs/7457350927?check_suite_focus=true

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

docbuild
