### PR TITLE
List API for MAST scheduler

### DIFF
--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -25,6 +25,9 @@ from torchx.specs import (
 from torchx.workspace.api import Workspace
 
 
+LIST_DAYS = 14
+
+
 class Stream(str, Enum):
     STDOUT = "stdout"
     STDERR = "stderr"


### PR DESCRIPTION
Summary: Implement API to list jobs for MAST scheduler. It lists all jobs scheduled by the user in the past 2 weeks.

Reviewed By: d4l3k

Differential Revision: D38139311

