### PR TITLE
AX backed HPO component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ wordlist.dic
 pipeline.yaml
 
 /codecov
+
+#emacs backup files
+*~
+.#*

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 aiobotocore==2.1.0
-ax-platform[mysql]==0.2.3
+ax-platform[mysql]==0.2.5.1
 black==22.3.0
 boto3==1.20.24
 captum>=0.4.0

--- a/torchx/components/hpo.py
+++ b/torchx/components/hpo.py
@@ -1,0 +1,193 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import os
+from typing import Dict, List, Optional
+
+import torchx
+import torchx.specs as specs
+
+
+def _build_hpo_app(
+    eval_fn: str,
+    objective: str,
+    hpo_params_file: str,
+    hpo_strategy: str,
+    hpo_trials: int,
+    hpo_maximize: bool,
+    name: Optional[str],
+    cpu: int,
+    gpu: int,
+    memMB: int,
+    h: Optional[str],
+    image: str,
+    env: Optional[Dict[str, str]],
+    max_retries: int,
+    mounts: Optional[List[str]],
+) -> specs.AppDef:
+    role_name = eval_fn
+    if env is None:
+        env = {}
+    env.setdefault("LOGLEVEL", os.getenv("LOGLEVEL", "WARNING"))
+
+    opt_args = []
+    if hpo_trials:
+        opt_args.extend(["--hpo_trials", str(hpo_trials)])
+    if hpo_maximize:
+        opt_args.extend(["--hpo_maximize"])
+    return specs.AppDef(
+        name=name or role_name,
+        roles=[
+            specs.Role(
+                name=role_name,
+                image=image,
+                entrypoint="python",
+                args=[
+                    *[
+                        "-m",
+                        "torchx.components.hpo_runner",
+                        "--eval_fn",
+                        f"{eval_fn}",
+                        "--objective",
+                        f"{objective}",
+                        "--hpo_params_file",
+                        f"{hpo_params_file}",
+                        "--hpo_strategy",
+                        f"{hpo_strategy}",
+                    ],
+                    *opt_args,
+                ],
+                resource=specs.resource(cpu=cpu, gpu=gpu, memMB=memMB, h=h),
+                env=env,
+                max_retries=max_retries,
+                mounts=specs.parse_mounts(mounts) if mounts else [],
+            )
+        ],
+    )
+
+
+def bayesian(
+    eval_fn: str,
+    objective: str = None,
+    hpo_params_file: str = None,
+    hpo_trials: int = None,
+    hpo_maximize: bool = False,
+    name: Optional[str] = None,
+    cpu: int = 1,
+    gpu: int = 0,
+    memMB: int = 1024,
+    h: Optional[str] = None,
+    image: str = torchx.IMAGE,
+    env: Optional[Dict[str, str]] = None,
+    max_retries: int = 0,
+    mounts: Optional[List[str]] = None,
+) -> specs.AppDef:
+    """
+        Hyper-parameter optimization application that uses bayesian candidate selection approach.
+
+        Notes: Utilizes `torchx.components.hpo_runner` module to control the experiment definition and
+        execution, which currently:
+        - Uses Ax library for candidate selection
+        - Limited to sequential single-arm processing
+        - Bayesian candidate selection will run initial grid-search like exploration for initial BO input
+        For now results are printed out, with a plan to migrate to proper tracking solution.
+
+        Args:
+            eval_fn: Object reference entry-point, eg. `mymodule:my_training_function`. Input is a map with
+                     properties defined in `hpo_params_file` and output is a map with results.
+            objective: property that is in output map and will be used as a performance metric
+            hpo_prams_file: Parameter json file in following format {"params": {"PARAM_NAME_1": {"type": "[float|int|str|bool]", "[range|choice]":["v1", "v2"] }}}
+            hpo_trials: number of trials to execute
+            hpo_maximize: expected objective value direction
+            name: job name override (uses the eval_fn as name if not specified)
+            cpu: number of cpus per replica
+            gpu: number of gpus per replica
+            memMB: cpu memory in MB per replica
+            h: a registered named resource (if specified takes precedence over cpu, gpu, memMB)
+            image: image (e.g. docker)
+            env: environment properties (K/Vs)
+            max_retries: the number of scheduler retries allowed
+            mounts: mounts to mount into the worker environment/container (ex. type=<bind/volume>,src=/host,dst=/job[,readonly]).
+                    See scheduler documentation for more info.
+
+    """
+    return _build_hpo_app(
+        eval_fn=eval_fn,
+        objective=objective,
+        hpo_params_file=hpo_params_file,
+        hpo_strategy="bayesian",
+        hpo_trials=hpo_trials,
+        hpo_maximize=hpo_maximize,
+        name=name,
+        cpu=cpu,
+        gpu=gpu,
+        memMB=memMB,
+        h=h,
+        image=image,
+        env=env,
+        max_retries=max_retries,
+        mounts=mounts,
+    )
+
+
+def grid_search(
+    eval_fn: str,
+    objective: str = None,
+    hpo_params_file: str = None,
+    hpo_trials: int = None,
+    hpo_maximize: bool = False,
+    name: Optional[str] = None,
+    cpu: int = 1,
+    gpu: int = 0,
+    memMB: int = 1024,
+    h: Optional[str] = None,
+    image: str = torchx.IMAGE,
+    env: Optional[Dict[str, str]] = None,
+    max_retries: int = 0,
+    mounts: Optional[List[str]] = None,
+) -> specs.AppDef:
+    """
+    Hyper-parameter optimization application that uses grid search candidate selection approach.
+
+    Notes: Utilizes `torchx.components.hpo_runner` module to control the experiment definition and execution, which currently:
+    - Uses Ax library for candidate selection
+    - Limited to sequential single-arm processing
+    - Instead of uniform grid search, uses SOBOL strategy
+    For now results are printed out, with a plan to migrate to proper tracking solution.
+
+    Args:
+    Args:
+        eval_fn: Object reference entry-point, eg. `mymodule:my_training_function`. Input is a map with
+                 properties defined in `hpo_params_file` and output is a map with results.
+        objective: property that is in output map and will be used as a performance metric
+        hpo_prams_file: Parameter json file in following format {"params": {"PARAM_NAME_1": {"type": "[float|int|str|bool]", "[range|choice]":["v1", "v2"] }}}
+        hpo_trials: number of trials to execute
+        hpo_maximize: expected objective value direction
+        name: job name override (uses the eval_fn as name if not specified)
+        cpu: number of cpus per replica
+        gpu: number of gpus per replica
+        memMB: cpu memory in MB per replica
+        h: a registered named resource (if specified takes precedence over cpu, gpu, memMB)
+        image: image (e.g. docker)
+        env: environment properties (K/Vs)
+        max_retries: the number of scheduler retries allowed
+        mounts: mounts to mount into the worker environment/container (ex. type=<bind/volume>,src=/host,dst=/job[,readonly]).
+                See scheduler documentation for more info.
+    """
+
+    return _build_hpo_app(
+        eval_fn=eval_fn,
+        objective=objective,
+        hpo_params_file=hpo_params_file,
+        hpo_strategy="grid_search",
+        hpo_trials=hpo_trials,
+        hpo_maximize=hpo_maximize,
+        name=name,
+        cpu=cpu,
+        gpu=gpu,
+        memMB=memMB,
+        h=h,
+        image=image,
+        env=env,
+        max_retries=max_retries,
+        mounts=mounts,
+    )

--- a/torchx/components/hpo_runner.py
+++ b/torchx/components/hpo_runner.py
@@ -1,0 +1,292 @@
+from dataclasses import dataclass
+import sys
+import importlib
+import json
+from enum import Enum
+from ax.service.ax_client import AxClient
+from ax.modelbridge.registry import Models
+from ax.modelbridge.generation_strategy import GenerationStrategy, GenerationStep
+
+from typing import (
+    Dict,
+    List,
+    TypedDict,
+    Union,
+)
+
+import argparse
+
+
+def _arg_parser():
+    arg_parser = argparse.ArgumentParser(description="HPO Runner args")
+    arg_parser.add_argument(
+        "--eval_fn",
+        type=str,
+        help="Fully qualified run function name. eg. my_modue:train_func",
+    )
+    arg_parser.add_argument("--objective",
+                            type=str,
+                            help="objective key in eval_fn")
+    arg_parser.add_argument("--hpo_params_file",
+                            type=str,
+                            help="HPO parameters")
+    arg_parser.add_argument(
+        "--hpo_strategy",
+        type=str,
+        choices=["grid_search", "bayesian", "auto"],
+        default="auto",
+        help="HPO selection strategy. Auto - may generate hybrid strategy",
+    )
+    arg_parser.add_argument(
+        "--hpo_trials",
+        type=int,
+        default=20,
+        help="Maximun number of trials to run.",
+    )
+    arg_parser.add_argument(
+        "--hpo_maximize",
+        default=False,
+        action="store_true",
+        help="Optimization direction. Default action is to minimize",
+    )
+
+    return arg_parser
+
+
+class SearchSpaceParamType(str, Enum):
+    INT = "int"
+    FLOAT = "float"
+    STRING = "str"
+    BOOL = "bool"
+
+
+class RangeConstraint(TypedDict):
+    upper: Union[int, float]
+    lower: Union[int, float]
+
+
+@dataclass
+class SearchSpaceParamRangeConstraint:
+    range: RangeConstraint
+
+
+@dataclass
+class SearchSpaceParamChoiceConstraint:
+    choices: List[Union[int, float, str, bool]]
+
+
+SearchSpaceParamConstraint = Union[SearchSpaceParamRangeConstraint,
+                                   SearchSpaceParamChoiceConstraint]
+
+
+@dataclass
+class SearchSpaceParam:
+    name: str
+    param_type: SearchSpaceParamType
+    constraints: List[SearchSpaceParamConstraint]
+
+
+def _parse_param(name, json_data) -> SearchSpaceParam:
+    constraint = None
+    cast_op = str
+    if json_data["type"] == SearchSpaceParamType.INT:
+        cast_op = int
+    elif json_data["type"] == SearchSpaceParamType.FLOAT:
+        cast_op = float
+
+    if "range" in json_data:
+        assert len(
+            json_data["range"]) == 2, "Range requires start and end values"
+        lower = cast_op(json_data["range"][0])
+        upper = cast_op(json_data["range"][1])
+        if upper < lower:
+            lower, upper = upper, lower
+        constraint = RangeConstraint(upper=upper, lower=lower)
+    elif "choice" in json_data:
+        choices = [cast_op(v) for v in json_data["choice"]]
+        constraint = SearchSpaceParamChoiceConstraint(choices)
+    else:
+        raise ValueError(
+            "Parameters must have either 'range' or 'choice' constraints defined"
+        )
+    return SearchSpaceParam(name=name,
+                            param_type=json_data["type"],
+                            constraints=[constraint])
+
+
+def _parse_params(json_data) -> List[SearchSpaceParam]:
+    if "params" in json_data:
+        return [
+            _parse_param(name, props)
+            for name, props in json_data["params"].items()
+        ]
+    else:
+        return []
+
+
+class AxClientBackedHPO:
+
+    def sobol_gs_factory(self, hpo_trials):
+        return GenerationStrategy(steps=[
+            GenerationStep(
+                model=Models.SOBOL,
+                num_trials=hpo_trials,
+                max_parallelism=5,
+            ),
+        ])
+
+    def sobol_gpei_gs_factory(self, initial_trials, gpei_trials):
+        return GenerationStrategy(steps=[
+            GenerationStep(
+                model=Models.SOBOL,
+                num_trials=initial_trials,
+                min_trials_observed=min(initial_trials, 3),
+                max_parallelism=5,
+            ),
+            GenerationStep(
+                model=Models.GPEI,
+                num_trials=gpei_trials,
+                max_parallelism=3,
+            ),
+        ])
+
+    def __init__(self, ax_client=None):
+        # allow injection for testing purposes
+        self.ax_client = ax_client
+
+    def _params_to_ax_client(self, params) -> List[Dict]:
+        ax_client_params = []
+        for param in params:
+            ax_client_param = {}
+            ax_client_param["name"] = param.name
+
+            if type(param.constraints[0]) == SearchSpaceParamChoiceConstraint:
+                ax_client_param["type"] = "choice"
+                ax_client_param["values"] = param.constraints[0].choices
+            else:
+                ax_client_param["type"] = "range"
+                ax_client_param["bounds"] = [
+                    param.constraints[0]["lower"],
+                    param.constraints[0]["upper"],
+                ]
+            ax_client_params.append(ax_client_param)
+
+        return ax_client_params
+
+    def _optimize(
+        self,
+        params: List[SearchSpaceParam],
+        eval_callable,
+        objective,
+        minimize,
+        hpo_trials,
+        generation_strategy: GenerationStrategy = None,
+    ) -> None:
+        if not self.ax_client:
+            self.ax_client = AxClient(generation_strategy=generation_strategy)
+        ax_params = self._params_to_ax_client(params)
+
+        self.ax_client.create_experiment(
+            name="torchx_hpo_experiment",
+            parameters=ax_params,
+            objective_name=objective,
+            minimize=minimize,
+        )
+
+        for i in range(hpo_trials):
+            parameters, trial_index = self.ax_client.get_next_trial()
+            self.ax_client.complete_trial(trial_index=trial_index,
+                                          raw_data=eval_callable(parameters))
+
+        best_parameters, values = self.ax_client.get_best_parameters()
+        return best_parameters
+
+    def grid_search(
+        self,
+        params: List[SearchSpaceParam],
+        eval_callable,
+        objective,
+        minimize,
+        hpo_trials,
+    ) -> None:
+
+        return self._optimize(
+            params,
+            eval_callable,
+            objective,
+            minimize,
+            hpo_trials,
+            generation_strategy=self.sobol_gs_factory(hpo_trials),
+        )
+
+    def bayesian(
+        self,
+        params: List[SearchSpaceParam],
+        eval_callable,
+        objective,
+        minimize,
+        hpo_trials,
+    ) -> None:
+        if hpo_trials < 2:
+            raise ValueError(
+                "Bayesian optimization requires more than one trial")
+        initial_trials = 5
+        if initial_trials + 1 > hpo_trials:
+            initial_trials = 1
+
+        return self._optimize(
+            params,
+            eval_callable,
+            objective,
+            minimize,
+            hpo_trials,
+            generation_strategy=self.sobol_gpei_gs_factory(
+                initial_trials, hpo_trials - initial_trials),
+        )
+
+    def auto(
+        self,
+        params: List[SearchSpaceParam],
+        eval_callable,
+        objective,
+        minimize,
+        hpo_trials,
+    ) -> None:
+
+        return self._optimize(params, eval_callable, objective, minimize,
+                              hpo_trials)
+
+
+def _run(args):
+    modname, qualname_separator, qualname = args.eval_fn.partition(":")
+    mod = importlib.import_module(modname)
+    eval_fn_ref = getattr(mod, qualname)
+
+    params = None
+    with open(args.hpo_params_file) as f:
+        params_json = json.load(f)
+        params = _parse_params(params_json)
+
+    minimize = False if args.hpo_maximize else True
+    ax_client_api_based_hpo = AxClientBackedHPO()
+    if args.hpo_strategy == "grid_search":
+        candidate_optimal_properties = ax_client_api_based_hpo.grid_search(
+            params, eval_fn_ref, args.objective, minimize, args.hpo_trials)
+    elif args.hpo_strategy == "bayesian":
+        candidate_optimal_properties = ax_client_api_based_hpo.bayesian(
+            params, eval_fn_ref, args.objective, minimize, args.hpo_trials)
+    else:
+        candidate_optimal_properties = ax_client_api_based_hpo.auto(
+            params, eval_fn_ref, args.objective, minimize, args.hpo_trials)
+
+    return candidate_optimal_properties
+
+
+def main():
+    arg_parser = _arg_parser()
+    args = arg_parser.parse_args(sys.argv[1:])
+    _run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/torchx/components/test/hpo_runner_test.py
+++ b/torchx/components/test/hpo_runner_test.py
@@ -1,0 +1,210 @@
+import torchx.components.hpo_runner as hpo_runner
+from torchx.components.hpo_runner import (
+    SearchSpaceParamType,
+    SearchSpaceParam,
+    SearchSpaceParamChoiceConstraint,
+)
+
+import unittest
+from unittest.mock import Mock, MagicMock, patch, mock_open
+import json
+
+
+def booth_fn(params):
+    x1 = params['x1']
+    x2 = params['x2']
+    val = (x1 + 2 * x2 - 7)**2 + (2 * x1 + x2 - 5)**2
+    return {"val": val}
+
+
+class HpoRunnerTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.args = [
+            "--eval_fn",
+            "torchx.components.test.hpo_runner_test:booth_fn",
+            "--objective",
+            "val",
+            "--hpo_params_file",
+            "hpo_params_file.json",
+            "--hpo_strategy",
+            "auto",
+        ]
+        self.params_json = '{"params": \
+{ \
+ "x1": { \
+  "type": "float", \
+  "range": ["0.01", "0.1"] }, \
+"x2": { \
+  "type": "int", \
+  "choice" : [1, 2, 3] \
+ } \
+} \
+}'
+
+    def test_parse_params(self):
+
+        params = hpo_runner._parse_params(json.loads(self.params_json))
+        self.assertEqual(2, len(params))
+        self.assertEqual("x1", params[0].name)
+
+        self.assertEqual(SearchSpaceParamType.FLOAT, params[0].param_type)
+        self.assertEqual(0.01, params[0].constraints[0]["lower"])
+        self.assertEqual(0.1, params[0].constraints[0]["upper"])
+
+        self.assertEqual("x2", params[1].name)
+
+        self.assertEqual(SearchSpaceParamType.INT, params[1].param_type)
+
+        self.assertEqual([1, 2, 3], params[1].constraints[0].choices)
+
+    def test_arg_parser(self):
+        arg_parser = hpo_runner._arg_parser()
+        parsed_args = arg_parser.parse_args(self.args)
+        self.assertEqual(parsed_args.eval_fn,
+                         "torchx.components.test.hpo_runner_test:booth_fn")
+        self.assertEqual(parsed_args.objective, "val")
+        self.assertEqual(parsed_args.hpo_params_file, "hpo_params_file.json")
+        self.assertEqual(parsed_args.hpo_strategy, "auto")
+
+    def test_run_auto(self):
+        parsed_args = hpo_runner._arg_parser().parse_args(self.args)
+        with patch("builtins.open",
+                   mock_open(read_data=self.params_json)) as mock_file:
+            with patch("torchx.components.hpo_runner.AxClientBackedHPO.auto"
+                       ) as auto_strategy_mock:
+                result = {"k": "v"}
+                auto_strategy_mock.return_value = result
+                hpo_runner._run(parsed_args)
+                auto_strategy_mock.assert_called_once()
+
+    def test_run_grid_search(self):
+        parsed_args = hpo_runner._arg_parser().parse_args(
+            self.args + ["--hpo_strategy", "grid_search"])
+        with patch("builtins.open",
+                   mock_open(read_data=self.params_json)) as mock_file:
+            with patch(
+                    "torchx.components.hpo_runner.AxClientBackedHPO.grid_search"
+            ) as grid_search_mock:
+                result = {"k": "v"}
+                grid_search_mock.return_value = result
+                hpo_runner._run(parsed_args)
+                grid_search_mock.assert_called_once()
+
+    def test_run_bayesian(self):
+        parsed_args = hpo_runner._arg_parser().parse_args(
+            self.args + ["--hpo_strategy", "bayesian"])
+        with patch("builtins.open",
+                   mock_open(read_data=self.params_json)) as mock_file:
+            with patch(
+                    "torchx.components.hpo_runner.AxClientBackedHPO.bayesian"
+            ) as bayesian_mock:
+                result = {"k": "v"}
+                bayesian_mock.return_value = result
+                actual_result = hpo_runner._run(parsed_args)
+                bayesian_mock.assert_called_once()
+
+
+class AxClientBackedHPOTest(unittest.TestCase):
+
+    def setUp(self):
+        self.ax_client_mock = Mock()
+        self.optimizer = hpo_runner.AxClientBackedHPO(self.ax_client_mock)
+        self.param_space = [
+            SearchSpaceParam(
+                name="x1",
+                param_type="float",
+                constraints=[{
+                    "upper": 0.1,
+                    "lower": 0.01
+                }],
+            ),
+            SearchSpaceParam(
+                name="x2",
+                param_type="int",
+                constraints=[
+                    SearchSpaceParamChoiceConstraint(choices=[1, 2, 3])
+                ],
+            ),
+        ]
+
+    def test_to_ax_params(self):
+        output = self.optimizer._params_to_ax_client(self.param_space)
+
+        self.assertEqual("x1", output[0]["name"])
+        self.assertEqual("range", output[0]["type"])
+        self.assertEqual([0.01, 0.1], output[0]["bounds"])
+        self.assertEqual("x2", output[1]["name"])
+        self.assertEqual("choice", output[1]["type"])
+        self.assertEqual([1, 2, 3], output[1]["values"])
+
+    def test_optimize_with_auto_strategy(self):
+        expected_best_params = {"x1": 1, "x2": 2}
+        hpo_trials = 10
+
+        self.ax_client_mock.get_next_trial = MagicMock(return_value=[{
+            "x1": 1,
+            "x2": 2
+        }, 0])
+
+        self.ax_client_mock.get_best_parameters = MagicMock(
+            return_value=[expected_best_params, 10])
+
+        actual_best_params = self.optimizer.auto(
+            self.param_space,
+            lambda px: {"result": px["x1"] + px["x2"]},
+            "result",
+            True,
+            hpo_trials,
+        )
+
+        self.ax_client_mock.create_experiment.assert_called_with(
+            name="torchx_hpo_experiment",
+            parameters=self.optimizer._params_to_ax_client(self.param_space),
+            objective_name="result",
+            minimize=True,
+        )
+
+        self.assertEqual(actual_best_params, expected_best_params)
+
+    def test_optimize_with_grid_search_strategy(self):
+        hpo_trials = 10
+        expected_best_params = {"x1": 1, "x2": 2}
+        self.ax_client_mock.get_next_trial = MagicMock(return_value=[{
+            "x1": 1,
+            "x2": 2
+        }, 0])
+
+        self.ax_client_mock.get_best_parameters = MagicMock(
+            return_value=[expected_best_params, 10])
+
+        actual_best_params = self.optimizer.grid_search(
+            self.param_space,
+            lambda px: {"result": px["x1"] + px["x2"]},
+            "result",
+            True,
+            hpo_trials,
+        )
+
+        self.assertEqual(actual_best_params, expected_best_params)
+
+    def test_optimize_with_bayesian_strategy(self):
+        hpo_trials = 10
+        expected_best_params = {"x1": 1, "x2": 2}
+        self.ax_client_mock.get_next_trial = MagicMock(return_value=[{
+            "x1": 1,
+            "x2": 2
+        }, 0])
+
+        self.ax_client_mock.get_best_parameters = MagicMock(
+            return_value=[expected_best_params, 10])
+
+        actual_best_params = self.optimizer.bayesian(
+            self.param_space,
+            lambda px: {"result": px["x1"] + px["x2"]},
+            "result",
+            True,
+            hpo_trials,
+        )
+
+        self.assertEqual(actual_best_params, expected_best_params)

--- a/torchx/components/test/hpo_test.py
+++ b/torchx/components/test/hpo_test.py
@@ -1,0 +1,98 @@
+import torchx.components.hpo as hpo
+from torchx.components.component_test_base import ComponentTestCase
+
+
+def _to_dict(iterable):
+    # Assumes odd elements are the key and even elements are values
+    mapping = {}
+    for i, el in enumerate(iterable):
+        if i % 2 == 0:
+            key = el
+        else:
+            mapping[key] = el
+    return mapping
+
+
+class HpoTestCase(ComponentTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.args = {
+            "eval_fn": "torchx.apps.utils.booth:main",
+            "objective": "accuracy",
+            "hpo_params_file": "parameters.json",
+            "hpo_trials": 100,
+            "hpo_maximize": True,
+            "name": "appname",
+            "cpu": 16,
+            "gpu": 2,
+            "memMB": 1024,
+            "image": "image",
+            "env": {
+                "VAR": "VAL"
+            },
+            "max_retries": 2,
+            "mounts": ["type=bind", "src=/dst", "dst=/dst", "readonly"],
+        }
+
+    def test_grid_search(self) -> None:
+        self.validate(hpo, "grid_search")
+
+    def test_bayesian(self) -> None:
+        self.validate(hpo, "bayesian")
+
+    def test_grid_search_arguments(self) -> None:
+        app = hpo.grid_search(**self.args)
+
+        self.assertEqual(app.name, self.args["name"])
+        self.assertEqual(1, len(app.roles))
+        role = app.roles[0]
+        self.assertEqual(role.name, self.args["eval_fn"])
+        self.assertEqual(role.image, self.args["image"])
+        for k, v in self.args["env"].items():
+            self.assertEqual(role.env[k], v)
+        self.assertEqual(role.max_retries, self.args["max_retries"])
+        self.assertEqual(len(role.mounts), 1)
+        self.assertEqual(role.resource.cpu, self.args["cpu"])
+        self.assertEqual(role.resource.gpu, self.args["gpu"])
+        self.assertEqual(role.resource.memMB, self.args["memMB"])
+
+        entrypoint = role.entrypoint
+
+        actual_args = _to_dict(role.args)
+        self.assertEqual(actual_args["-m"], "torchx.components.hpo_runner")
+        self.assertEqual(actual_args["--eval_fn"],
+                         "torchx.apps.utils.booth:main")
+        self.assertEqual(actual_args["--objective"], self.args["objective"])
+        self.assertEqual(actual_args["--hpo_params_file"],
+                         self.args["hpo_params_file"])
+        self.assertEqual(actual_args["--hpo_strategy"], "grid_search")
+        self.assertEqual(actual_args["--hpo_trials"],
+                         str(self.args["hpo_trials"]))
+
+    def test_bayesian_arguments(self) -> None:
+        app = hpo.bayesian(**self.args)
+
+        self.assertEqual(app.name, self.args["name"])
+        self.assertEqual(1, len(app.roles))
+        role = app.roles[0]
+        self.assertEqual(role.name, self.args["eval_fn"])
+        self.assertEqual(role.image, self.args["image"])
+        for k, v in self.args["env"].items():
+            self.assertEqual(role.env[k], v)
+        self.assertEqual(role.max_retries, self.args["max_retries"])
+        self.assertEqual(len(role.mounts), 1)
+        self.assertEqual(role.resource.cpu, self.args["cpu"])
+        self.assertEqual(role.resource.gpu, self.args["gpu"])
+        self.assertEqual(role.resource.memMB, self.args["memMB"])
+
+        entrypoint = role.entrypoint
+
+        actual_args = _to_dict(role.args)
+        self.assertEqual(actual_args["-m"], "torchx.components.hpo_runner")
+        self.assertEqual(actual_args["--eval_fn"],
+                         "torchx.apps.utils.booth:main")
+        self.assertEqual(actual_args["--objective"], self.args["objective"])
+        self.assertEqual(actual_args["--hpo_params_file"], self.args["hpo_params_file"])
+        self.assertEqual(actual_args["--hpo_strategy"], "bayesian")
+        self.assertEqual(actual_args["--hpo_trials"], str(self.args["hpo_trials"]))


### PR DESCRIPTION
Initial TorchX Component for Hyper-parameter tuning (https://github.com/pytorch/torchx/issues/510)

UX:
===
Exposes `grid_search` and `bayesian` candidate selection strategies and requires input to define search space, eg:
```
{
  "params": {
    "p1": {
      "type": "float",
      "range": [
          "0.1",
          "1.0"
        ]

    },
    "p2": {
      "type": "str",
      "choice": [
          "sparse",
          "dense"
        ]
    }
  }
}
```

Further ideas: next things that can be added are constraints on output and constraints on the input pairs/combinations (depending whether underlining library supports that)

Candidate selection is just printed for now, until we get better tracking.

Implementation: 
======

Uses AX Client library (hence limitation on sequential trails). We can migrate to AX's TorchXRunner+AX Scheduler, however this will require get UX correct to define evaluation and metric output processing.



Test plan:
- Unit tests

Running locally: 
```
python -m torchx.cli.main run -s local_cwd hpo.bayesian --eval_fn test_script:booth --objective booth_eval --hpo_params_file ./hpo_booth_params.json --hpo_trials 10 --hpo_maximize False`
torchx 2022-07-31 20:19:18 INFO     loaded configs from /home/ubuntu/torchx/.torchxconfig
torchx 2022-07-31 20:19:20 INFO     Log directory not set in scheduler cfg. Creating a temporary log dir that will be deleted on exit. To preserve log directory set the `log_dir` cfg option
torchx 2022-07-31 20:19:20 INFO     Log directory is: /tmp/torchx_t11ek_1z
local_cwd://torchx/foo:booth-v1mnf6hxttv6w
torchx 2022-07-31 20:19:20 INFO     Waiting for the app to finish...
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Starting optimization with verbose logging. To disable logging, set the `verbose_logging` argument to `False`. Note that float values in the logs are rounded to 6 decimal points.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.utils.instantiation: Inferred value type of ParameterType.FLOAT for parameter x1. If that is not the expected value type, you can explicity specify 'value_type' ('int', 'float', 'bool' or 'str') in parameter dict.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.utils.instantiation: Inferred value type of ParameterType.FLOAT for parameter x2. If that is not the expected value type, you can explicity specify 'value_type' ('int', 'float', 'bool' or 'str') in parameter dict.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.utils.instantiation: Created search space: SearchSpace(parameters=[RangeParameter(name='x1', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x2', parameter_type=FLOAT, range=[0.0, 1.0])], parameter_constraints=[]).
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Generated new trial 0 with parameters {'x1': 0.21218, 'x2': 0.54938}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Completed trial 0 with data: {'booth_eval': (48.576151, None)}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Generated new trial 1 with parameters {'x1': 0.7242, 'x2': 0.036728}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Completed trial 1 with data: {'booth_eval': (50.823399, None)}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Generated new trial 2 with parameters {'x1': 0.490495, 'x2': 0.727069}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Completed trial 2 with data: {'booth_eval': (36.393588, None)}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Generated new trial 3 with parameters {'x1': 0.187858, 'x2': 0.654356}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Completed trial 3 with data: {'booth_eval': (46.048082, None)}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Generated new trial 4 with parameters {'x1': 0.792806, 'x2': 0.731653}.
foo:booth/0 [INFO 07-31 20:19:21] ax.service.ax_client: Completed trial 4 with data: {'booth_eval': (29.70154, None)}.
foo:booth/0 [INFO 07-31 20:19:22] ax.service.ax_client: Generated new trial 5 with parameters {'x1': 0.872643, 'x2': 0.944132}.
foo:booth/0 [INFO 07-31 20:19:22] ax.service.ax_client: Completed trial 5 with data: {'booth_eval': (23.308695, None)}.
foo:booth/0 [INFO 07-31 20:19:22] ax.service.ax_client: Generated new trial 6 with parameters {'x1': 1.0, 'x2': 1.0}.
foo:booth/0 [INFO 07-31 20:19:22] ax.service.ax_client: Completed trial 6 with data: {'booth_eval': (20.0, None)}.
foo:booth/0 [INFO 07-31 20:19:23] ax.service.ax_client: Generated new trial 7 with parameters {'x1': 1.0, 'x2': 0.916478}.
foo:booth/0 [INFO 07-31 20:19:23] ax.service.ax_client: Completed trial 7 with data: {'booth_eval': (21.705324, None)}.
foo:booth/0 [INFO 07-31 20:19:23] ax.service.ax_client: Generated new trial 8 with parameters {'x1': 0.142224, 'x2': 0.94607}.
foo:booth/0 [INFO 07-31 20:19:23] ax.service.ax_client: Completed trial 8 with data: {'booth_eval': (38.86652, None)}.
foo:booth/0 [INFO 07-31 20:19:23] ax.service.ax_client: Generated new trial 9 with parameters {'x1': 0.51109, 'x2': 0.36712}.
foo:booth/0 [INFO 07-31 20:19:23] ax.service.ax_client: Completed trial 9 with data: {'booth_eval': (46.153399, None)}.
torchx 2022-07-31 20:19:25 INFO     Job finished: SUCCEEDED

```
