### PR TITLE
When logging schedule call in TorchX, capture the image used.

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -223,9 +223,13 @@ class Runner:
 
         """
         scheduler = none_throws(dryrun_info._scheduler)
+        app_image = none_throws(dryrun_info._app).roles[0].image
         cfg = dryrun_info._cfg
         with log_event(
-            "schedule", scheduler, runcfg=json.dumps(cfg) if cfg else None
+            "schedule",
+            scheduler,
+            app_image=app_image,
+            runcfg=json.dumps(cfg) if cfg else None,
         ) as ctx:
             sched = self._scheduler(scheduler)
             app_id = sched.schedule(dryrun_info)

--- a/torchx/runner/events/__init__.py
+++ b/torchx/runner/events/__init__.py
@@ -80,10 +80,11 @@ class log_event:
         api: str,
         scheduler: Optional[str] = None,
         app_id: Optional[str] = None,
+        app_image: Optional[str] = None,
         runcfg: Optional[str] = None,
     ) -> None:
         self._torchx_event: TorchxEvent = self._generate_torchx_event(
-            api, scheduler or "", app_id, runcfg
+            api, scheduler or "", app_id, app_image=app_image, runcfg=runcfg
         )
 
     def __enter__(self) -> "log_event":
@@ -104,6 +105,7 @@ class log_event:
         api: str,
         scheduler: str,
         app_id: Optional[str] = None,
+        app_image: Optional[str] = None,
         runcfg: Optional[str] = None,
         source: SourceType = SourceType.UNKNOWN,
     ) -> TorchxEvent:
@@ -112,6 +114,7 @@ class log_event:
             scheduler=scheduler,
             api=api,
             app_id=app_id,
+            app_image=app_image,
             runcfg=runcfg,
             source=source,
         )

--- a/torchx/runner/events/api.py
+++ b/torchx/runner/events/api.py
@@ -27,6 +27,7 @@ class TorchxEvent:
         scheduler: Scheduler that is used to execute request
         api: Api name
         app_id: Unique id that is set by the underlying scheduler
+        image: Image/container bundle that is used to execute request.
         runcfg: Run config that was used to schedule app.
         source: Type of source the event is generated.
     """
@@ -35,6 +36,7 @@ class TorchxEvent:
     scheduler: str
     api: str
     app_id: Optional[str] = None
+    app_image: Optional[str] = None
     runcfg: Optional[str] = None
     raw_exception: Optional[str] = None
     source: SourceType = SourceType.UNKNOWN

--- a/torchx/runner/events/test/lib_test.py
+++ b/torchx/runner/events/test/lib_test.py
@@ -26,6 +26,7 @@ class TorchxEventLibTest(unittest.TestCase):
         self.assertEqual(actual_event.scheduler, expected_event.scheduler)
         self.assertEqual(actual_event.api, expected_event.api)
         self.assertEqual(actual_event.app_id, expected_event.app_id)
+        self.assertEqual(actual_event.app_image, expected_event.app_image)
         self.assertEqual(actual_event.runcfg, expected_event.runcfg)
         self.assertEqual(actual_event.source, expected_event.source)
 
@@ -39,11 +40,15 @@ class TorchxEventLibTest(unittest.TestCase):
 
     def test_event_created(self) -> None:
         event = TorchxEvent(
-            session="test_session", scheduler="test_scheduler", api="test_api"
+            session="test_session",
+            scheduler="test_scheduler",
+            api="test_api",
+            app_image="test_app_image",
         )
         self.assertEqual("test_session", event.session)
         self.assertEqual("test_scheduler", event.scheduler)
         self.assertEqual("test_api", event.api)
+        self.assertEqual("test_app_image", event.app_image)
         self.assertEqual(SourceType.UNKNOWN, event.source)
 
     def test_event_deser(self) -> None:
@@ -51,6 +56,7 @@ class TorchxEventLibTest(unittest.TestCase):
             session="test_session",
             scheduler="test_scheduler",
             api="test_api",
+            app_image="test_app_image",
             source=SourceType.EXTERNAL,
         )
         json_event = event.serialize()
@@ -64,22 +70,45 @@ class LogEventTest(unittest.TestCase):
         self.assertEqual(expected.session, actual.session)
         self.assertEqual(expected.app_id, actual.app_id)
         self.assertEqual(expected.api, actual.api)
+        self.assertEqual(expected.app_image, actual.app_image)
         self.assertEqual(expected.source, actual.source)
 
     def test_create_context(self, _) -> None:
         cfg = json.dumps({"test_key": "test_value"})
-        context = log_event("test_call", "local", "test_app_id", cfg)
+        context = log_event(
+            "test_call",
+            "local",
+            "test_app_id",
+            app_image="test_app_image_id",
+            runcfg=cfg,
+        )
         expected_torchx_event = TorchxEvent(
-            "test_app_id", "local", "test_call", "test_app_id", cfg
+            "test_app_id",
+            "local",
+            "test_call",
+            "test_app_id",
+            app_image="test_app_image_id",
+            runcfg=cfg,
         )
         self.assert_torchx_event(expected_torchx_event, context._torchx_event)
 
     def test_record_event(self, record_mock: MagicMock) -> None:
         cfg = json.dumps({"test_key": "test_value"})
         expected_torchx_event = TorchxEvent(
-            "test_app_id", "local", "test_call", "test_app_id", cfg
+            "test_app_id",
+            "local",
+            "test_call",
+            "test_app_id",
+            app_image="test_app_image_id",
+            runcfg=cfg,
         )
-        with log_event("test_call", "local", "test_app_id", cfg) as ctx:
+        with log_event(
+            "test_call",
+            "local",
+            "test_app_id",
+            app_image="test_app_image_id",
+            runcfg=cfg,
+        ) as ctx:
             pass
         self.assert_torchx_event(expected_torchx_event, ctx._torchx_event)
 


### PR DESCRIPTION
Summary:
When logging schedule call in TorchX, capture the image used.
For FB, it will be a FBPkg id.

Differential Revision: D38526631

