### PR TITLE
Add back aws_batch list integration test

### DIFF
--- a/scripts/awsbatchint.sh
+++ b/scripts/awsbatchint.sh
@@ -47,4 +47,13 @@ else
       echo "expected 2 log lines"
       exit 1
   fi
+
+  torchx list -s aws_batch
+  LIST_LINES="$(torchx list -s aws_batch | grep -c "$APP_ID")"
+
+  if [ "$LIST_LINES" -ne 1 ]
+  then
+      echo "expected $APP_ID to be listed"
+      exit 1
+  fi
 fi


### PR DESCRIPTION
List integration tests for aws_batch was removed as it was failing due to a permissions issue where github-torchx service account wasn't able to describe job queues. Adding the test back as permissions are now updated.