### PR TITLE
Add AppResponse classes to docs

### DIFF
--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -42,3 +42,9 @@ Scheduler Classes
 
 .. autoclass:: SchedulerFactory
    :members:
+
+.. autoclass:: torchx.schedulers.api.DescribeAppResponse
+   :members:
+
+.. autoclass:: torchx.schedulers.api.ListAppResponse
+   :members:


### PR DESCRIPTION
Summary: Add ListAppResponse and DescribeAppResponse classes to docs so that they can be clicked on to see more info about them

Differential Revision: D38761780

