### PR TITLE
Specify region in flow operator

### DIFF
--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -92,6 +92,7 @@ def ddp(
     rdzv_port: int = 29500,
     mounts: Optional[List[str]] = None,
     debug: bool = False,
+    region: Optional[str] = None,
 ) -> specs.AppDef:
     """
     Distributed data parallel style application (one role, multi-replica).
@@ -114,6 +115,7 @@ def ddp(
         cpu: number of cpus per replica
         gpu: number of gpus per replica
         memMB: cpu memory in MB per replica
+        region: region scheduler will use for placing the job
         h: a registered named resource (if specified takes precedence over cpu, gpu, memMB)
         j: {nnodes}x{nproc_per_node}, for gpu hosts, nproc_per_node must not exceed num gpus
         env: environment varibles to be passed to the run (e.g. ENV1=v1,ENV2=v2,ENV3=v3)
@@ -192,7 +194,9 @@ def ddp(
                 min_replicas=min_nnodes,
                 entrypoint="bash",
                 num_replicas=int(max_nnodes),
-                resource=specs.resource(cpu=cpu, gpu=gpu, memMB=memMB, h=h),
+                resource=specs.resource(
+                    cpu=cpu, gpu=gpu, memMB=memMB, h=h, region=region
+                ),
                 args=["-c", _args_join(cmd)],
                 env=env,
                 port_map={

--- a/torchx/components/utils.py
+++ b/torchx/components/utils.py
@@ -20,7 +20,10 @@ import torchx.specs as specs
 
 
 def echo(
-    msg: str = "hello world", image: str = torchx.IMAGE, num_replicas: int = 1
+    msg: str = "hello world",
+    image: str = torchx.IMAGE,
+    num_replicas: int = 1,
+    region: Optional[str] = None,
 ) -> specs.AppDef:
     """
     Echos a message to stdout (calls echo)
@@ -29,6 +32,7 @@ def echo(
         msg: message to echo
         image: image to use
         num_replicas: number of replicas to run
+        region: region scheduler will use for placing the job
 
     """
     return specs.AppDef(
@@ -40,7 +44,7 @@ def echo(
                 entrypoint="echo",
                 args=[msg],
                 num_replicas=num_replicas,
-                resource=specs.Resource(cpu=1, gpu=0, memMB=1024),
+                resource=specs.Resource(cpu=1, gpu=0, memMB=1024, region=region),
             )
         ],
     )
@@ -77,6 +81,7 @@ def sh(
     cpu: int = 1,
     gpu: int = 0,
     memMB: int = 1024,
+    region: Optional[str] = None,
     h: Optional[str] = None,
     env: Optional[Dict[str, str]] = None,
     max_retries: int = 0,
@@ -93,6 +98,7 @@ def sh(
         cpu: number of cpus per replica
         gpu: number of gpus per replica
         memMB: cpu memory in MB per replica
+        region: region scheduler will use for placing the job
         h: a registered named resource (if specified takes precedence over cpu, gpu, memMB)
         env: environment varibles to be passed to the run (e.g. ENV1=v1,ENV2=v2,ENV3=v3)
         max_retries: the number of scheduler retries allowed
@@ -114,7 +120,9 @@ def sh(
                 entrypoint="sh",
                 args=["-c", escaped_args],
                 num_replicas=num_replicas,
-                resource=specs.resource(cpu=cpu, gpu=gpu, memMB=memMB, h=h),
+                resource=specs.resource(
+                    cpu=cpu, gpu=gpu, memMB=memMB, h=h, region=region
+                ),
                 env=env,
                 max_retries=max_retries,
                 mounts=specs.parse_mounts(mounts) if mounts else [],
@@ -135,6 +143,7 @@ def python(
     memMB: int = 1024,
     h: Optional[str] = None,
     num_replicas: int = 1,
+    region: Optional[str] = None,
 ) -> specs.AppDef:
     """
     Runs ``python`` with the specified module, command or script on the specified
@@ -155,6 +164,7 @@ def python(
         cpu: number of cpus per replica
         gpu: number of gpus per replica
         memMB: cpu memory in MB per replica
+        region: region scheduler will use for placing the job
         h: a registered named resource (if specified takes precedence over cpu, gpu, memMB)
         num_replicas: number of copies to run (each on its own container)
     :return:
@@ -181,7 +191,9 @@ def python(
                 image=image,
                 entrypoint="python",
                 num_replicas=num_replicas,
-                resource=specs.resource(cpu=cpu, gpu=gpu, memMB=memMB, h=h),
+                resource=specs.resource(
+                    cpu=cpu, gpu=gpu, memMB=memMB, h=h, region=region
+                ),
                 args=[*cmd, *args],
                 env={"HYDRA_MAIN_MODULE": m} if m else {},
             )
@@ -197,6 +209,7 @@ def binary(
     cpu: int = 1,
     gpu: int = 0,
     memMB: int = 1024,
+    region: Optional[str] = None,
     h: Optional[str] = None,
 ) -> specs.AppDef:
     """
@@ -209,6 +222,7 @@ def binary(
         cpu: number of cpus per replica
         gpu: number of gpus per replica
         memMB: cpu memory in MB per replica
+        region: region scheduler will use for placing the job
         h: a registered named resource (if specified takes precedence over cpu, gpu, memMB)
     :return:
     """
@@ -221,7 +235,9 @@ def binary(
                 entrypoint=entrypoint,
                 num_replicas=num_replicas,
                 args=[*args],
-                resource=specs.resource(cpu=cpu, gpu=gpu, memMB=memMB, h=h),
+                resource=specs.resource(
+                    cpu=cpu, gpu=gpu, memMB=memMB, h=h, region=region
+                ),
             )
         ],
     )

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -71,6 +71,7 @@ def resource(
     cpu: Optional[int] = None,
     gpu: Optional[int] = None,
     memMB: Optional[int] = None,
+    region: Optional[str] = None,
     h: Optional[str] = None,
 ) -> Resource:
     """
@@ -110,6 +111,7 @@ def resource(
             cpu=cpu or DEFAULT_CPU,
             gpu=gpu or DEFAULT_GPU,
             memMB=memMB or DEFAULT_MEM_MB,
+            region=region,
         )
 
 

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -73,6 +73,7 @@ class Resource:
         memMB: MB of ram
         capabilities: additional hardware specs (interpreted by scheduler)
         devices: a list of named devices with their quantities
+        region: optional locality constraint that is scheduler specific
 
     Note: you should prefer to use named_resources instead of specifying the raw
     resource requirement directly.
@@ -83,6 +84,7 @@ class Resource:
     memMB: int
     capabilities: Dict[str, Any] = field(default_factory=dict)
     devices: Dict[str, int] = field(default_factory=dict)
+    region: Optional[str] = None
 
     @staticmethod
     def copy(original: "Resource", **capabilities: Any) -> "Resource":
@@ -99,6 +101,7 @@ class Resource:
             memMB=original.memMB,
             capabilities=res_capabilities,
             devices=original.devices,
+            region=original.region,
         )
 
 

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -176,13 +176,15 @@ Traceback (most recent call last):
 class ResourceTest(unittest.TestCase):
     def test_copy_resource(self) -> None:
         old_capabilities = {"test_key": "test_value", "old_key": "old_value"}
-        resource = Resource(1, 2, 3, old_capabilities)
+        resource = Resource(1, 2, 3, old_capabilities, {"device": 1}, region="zone1")
         new_resource = Resource.copy(
             resource, test_key="test_value_new", new_key="new_value"
         )
         self.assertEqual(new_resource.cpu, 1)
         self.assertEqual(new_resource.gpu, 2)
         self.assertEqual(new_resource.memMB, 3)
+        self.assertEqual(new_resource.devices, {"device": 1})
+        self.assertEqual(new_resource.region, "zone1")
 
         self.assertEqual(len(new_resource.capabilities), 3)
         self.assertEqual(new_resource.capabilities["old_key"], "old_value")
@@ -208,6 +210,10 @@ class ResourceTest(unittest.TestCase):
         self.assertEqual(Resource(cpu=2, gpu=0, memMB=1024), resource())
         self.assertEqual(Resource(cpu=1, gpu=0, memMB=1024), resource(cpu=1))
         self.assertEqual(Resource(cpu=2, gpu=1, memMB=1024), resource(cpu=2, gpu=1))
+        self.assertEqual(
+            Resource(cpu=2, gpu=1, memMB=1024, region="zone1"),
+            resource(cpu=2, gpu=1, region="zone1"),
+        )
         self.assertEqual(
             Resource(cpu=2, gpu=1, memMB=2048), resource(cpu=2, gpu=1, memMB=2048)
         )


### PR DESCRIPTION
Summary:
Exposing `region` as an optional resource.

Context: https://fb.workplace.com/groups/140700188041197/posts/385437310234149

Differential Revision: D39068448

