### PR TITLE
Bump torchx pyre-check-nightly version

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -6,10 +6,16 @@
     ".*/IPython/core/tests/nonascii.*",
     ".*/torchx/examples/apps/compute_world_size/.*"
   ],
+  "ignore_all_errors": [
+    "./stubs/"
+  ],
   "site_package_search_strategy": "all",
   "source_directories": [
     "."
   ],
+  "search_path": [
+    "stubs"
+  ],
   "strict": true,
-  "version": "0.0.101650971427"
+  "version": "0.0.101662549039"
 }

--- a/stubs/filelock.pyi
+++ b/stubs/filelock.pyi
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+In the actual implementation of `filelock`, the type `BaseFileLock` is marked
+as abstract. And Pyre does not allow us to instantiate a variable of `Type[X]`
+when `X` is abstract because we cannot be sure that the type is valid to
+instantiate.
+
+In reality, the `FileLock` type is always some concrete instantiatable type so
+it is okay to use; this stub makes Pyre happy by declaring BaseFileLock as not
+abstract.
+"""
+
+import types
+import typing as t
+
+class Timeout(TimeoutError):
+    lock_file: str
+    def __init__(self, lock_file: str) -> None: ...
+    def __str__(self) -> str: ...
+
+class BaseFileLock:
+    def __init__(self, lock_file: str, timeout: float = -1) -> None: ...
+    @property
+    def lock_file(self) -> str: ...
+    @property
+    def timeout(self) -> float: ...
+    @timeout.setter
+    def timeout(self, value: float) -> None: ...
+    @property
+    def is_locked(self) -> bool: ...
+    def acquire(
+        self, timeout: t.Optional[float] = None, poll_intervall: float = 0.05
+    ) -> t.Any: ...
+    def release(self, force: bool = False) -> None: ...
+    def __enter__(self) -> BaseFileLock: ...
+    def __exit__(
+        self,
+        exc_type: t.Optional[type],
+        exc_value: t.Optional[Exception],
+        traceback: t.Optional[types.TracebackType],
+    ) -> None: ...
+    def __del__(self) -> None: ...
+
+class WindowsFileLock(BaseFileLock): ...
+class UnixFileLock(BaseFileLock): ...
+class SoftFileLock(BaseFileLock): ...
+
+FileLock: t.Type[BaseFileLock]

--- a/torchx/schedulers/test/train.py
+++ b/torchx/schedulers/test/train.py
@@ -21,7 +21,7 @@ def compute_world_size() -> int:
     backend = "gloo"
 
     print(f"initializing `{backend}` process group")
-    init_process_group(  # pyre-ignore[16]
+    init_process_group(
         backend=backend,
         init_method=f"tcp://{master_addr}:{master_port}",
         rank=rank,
@@ -29,11 +29,11 @@ def compute_world_size() -> int:
     )
     print("successfully initialized process group")
 
-    rank = get_rank()  # pyre-ignore[16]
-    world_size = get_world_size()  # pyre-ignore[16]
+    rank = get_rank()
+    world_size = get_world_size()
 
     t = F.one_hot(torch.tensor(rank), num_classes=world_size)
-    all_reduce(t)  # pyre-ignore[16]
+    all_reduce(t)
     computed_world_size = int(torch.sum(t).item())
     print(
         f"rank: {rank}, actual world_size: {world_size}, computed world_size: {computed_world_size}"


### PR DESCRIPTION
Summary: Bump pyre-nightly to the latest release, to prevent errors due to error suppressions.

Differential Revision: D39139755

