### PR TITLE
Quickstart guide

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,9 +51,10 @@ Documentation
    .. toctree::
       :maxdepth: 1
       :caption: Usage (Meta)
-      :glob:
 
-      fb/*
+      fb/quickstart.md
+      fb/cogwheel.rst
+      fb/named_resources.rst
 
 
 Works With


### PR DESCRIPTION
Summary:
- Internal torchX docs are scattered across fbcode/torchx/github/docs/source/fb/quickstart.md, https://www.internalfb.com/code/fbsource/fbcode/torchx/examples/apps/README_fb.md and https://www.internalfb.com/intern/wiki/PyTorch_R2P/TorchX/.
- The structure of docs and examples are outdated.

This is an attempt [1/n] to aggregate and revive them.

Adding a Meta quickstart guide (structure consistent with OSS quickstart guide)

Reviewed By: d4l3k, kurman

Differential Revision: D39121264

