### PR TITLE
Torchxconfig

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,7 @@ Documentation
       :caption: Usage (Meta)
 
       fb/quickstart.md
+      fb/setup.md
       fb/cogwheel.rst
       fb/named_resources.rst
 

--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -74,6 +74,21 @@ CLI Usage
    variable TORCHX_CONFIG. It also disables hierarchy loading configs from multiple
    directories as the cases otherwise.
 
+#. User level .torchxconfig
+   In addition to the project-level .torchxconfig at the root of the project directory,
+   you can create one in ``$HOME/.torchxconfig`` to override or specify additional default configs.
+   This config file will get overlaid on top of the one defined at the project root.
+
+#. Config options take the following precedence (high to low):
+    1. Options specified directly from the CLI
+    2. If TORCHXCONFIG env variable is set, the options specified in that file
+    3. If TORCHXCONFIG env variable is not set,
+        a. Options specified in user level .torchxconfig (``$HOME/.torchxconfig``)
+        b. Options specified in .torchxconfig
+    4. Any default values in the code
+
+   Note that malformed or unrecognized options are simply skipped and not applied
+
 **Component Config**
 
 You can specify component defaults by adding a section prefixed with


### PR DESCRIPTION
Summary: As part of internal docs reviva, moving over some Meta specific content from https://internalfb.com/intern/wiki/PyTorch_R2P/TorchX/Project_Setup_(fbcode)/ and https://internalfb.com/intern/wiki/PyTorch_R2P/TorchX/Configuring_(.torchxconfig)/ that are not already captured in https://pytorch.org/torchx/latest/runner.config.html

Differential Revision: D39190047

