### PR TITLE
torchx: lazy load unneeded imports

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -125,9 +125,9 @@ resource can then be used in the following manner:
 
 .. testsetup:: role
 
-   from torchx.specs import named_resources, Resource
+   from torchx.specs import _named_resource_factories, Resource
 
-   named_resources["gpu_x2"] = Resource(cpu=16, gpu=2, memMB=122_000)
+   _named_resource_factories["gpu_x2"] = lambda: Resource(cpu=16, gpu=2, memMB=122_000)
 
 
 .. doctest:: role

--- a/scripts/kfpint.py
+++ b/scripts/kfpint.py
@@ -60,7 +60,7 @@ from integ_test_utils import (
     run,
     run_in_bg,
 )
-from pyre_extensions import none_throws
+from torchx.util.types import none_throws
 from urllib3.exceptions import MaxRetryError
 
 T = TypeVar("T")

--- a/scripts/kube_dist_trainer.py
+++ b/scripts/kube_dist_trainer.py
@@ -13,10 +13,10 @@ import argparse
 import os
 
 from integ_test_utils import build_images, BuildInfo, MissingEnvError, push_images
-from pyre_extensions import none_throws
 from torchx.components.dist import ddp as dist_ddp
 from torchx.runner import get_runner
-from torchx.specs import AppState, named_resources, Resource
+from torchx.specs import _named_resource_factories, AppState, Resource
+from torchx.util.types import none_throws
 
 
 # pyre-ignore-all-errors[21] # Cannot find module utils
@@ -37,7 +37,7 @@ def register_gpu_resource() -> None:
         },
     )
     print(f"Registering resource: {res}")
-    named_resources["GPU_X1"] = res
+    _named_resource_factories["GPU_X1"] = lambda: res
 
 
 def build_and_push_image() -> BuildInfo:

--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -14,7 +14,6 @@ import time
 from queue import Queue
 from typing import List, Optional, TextIO, Tuple
 
-from pyre_extensions import none_throws
 from torchx import specs
 from torchx.cli.cmd_base import SubCommand
 from torchx.cli.colors import ENDC, GREEN
@@ -22,6 +21,8 @@ from torchx.runner import get_runner, Runner
 from torchx.schedulers.api import Stream
 from torchx.specs.api import is_started
 from torchx.specs.builders import make_app_handle
+
+from torchx.util.types import none_throws
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -15,7 +15,6 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple
 
 import torchx.specs as specs
-from pyre_extensions import none_throws
 from torchx.cli.argparse_util import CONFIG_DIRS, torchxconfig_run
 from torchx.cli.cmd_base import SubCommand
 from torchx.cli.cmd_log import get_logs
@@ -29,6 +28,7 @@ from torchx.specs.finder import (
     get_builtin_source,
     get_components,
 )
+from torchx.util.types import none_throws
 
 
 MISSING_COMPONENT_ERROR_MSG = (

--- a/torchx/components/integration_tests/integ_tests.py
+++ b/torchx/components/integration_tests/integ_tests.py
@@ -12,11 +12,12 @@ from json import dumps
 from types import ModuleType
 from typing import Callable, cast, Dict, List, Optional, Type
 
-from pyre_extensions import none_throws
 from torchx.cli.cmd_log import get_logs
 from torchx.components.integration_tests.component_provider import ComponentProvider
 from torchx.runner import get_runner
 from torchx.specs import AppHandle, AppState, AppStatus, CfgVal
+
+from torchx.util.types import none_throws
 
 
 log: logging.Logger = logging.getLogger(__name__)

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from types import TracebackType
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Type
 
-from pyre_extensions import none_throws
 from torchx.runner.events import log_event
 from torchx.schedulers import get_scheduler_factories, SchedulerFactory
 from torchx.schedulers.api import ListAppResponse, Scheduler, Stream
@@ -31,6 +30,8 @@ from torchx.specs import (
     UnknownAppException,
 )
 from torchx.specs.finder import get_component
+
+from torchx.util.types import none_throws
 from torchx.workspace.api import Workspace
 
 

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -14,7 +14,6 @@ from contextlib import contextmanager
 from typing import Generator, List, Mapping, Optional
 from unittest.mock import MagicMock, patch
 
-from pyre_extensions import none_throws
 from torchx.runner import get_runner, Runner
 from torchx.schedulers.api import DescribeAppResponse, ListAppResponse, Scheduler
 from torchx.schedulers.local_scheduler import (
@@ -25,6 +24,8 @@ from torchx.schedulers.test.test_util import write_shell_script
 from torchx.specs import AppDryRunInfo, CfgVal
 from torchx.specs.api import AppDef, AppState, Resource, Role, UnknownAppException
 from torchx.specs.finder import ComponentNotFoundException
+
+from torchx.util.types import none_throws
 from torchx.workspace import Workspace
 
 

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -29,7 +29,6 @@ from datetime import datetime
 from types import FrameType
 from typing import Any, BinaryIO, Callable, Dict, Iterable, List, Optional, TextIO
 
-from pyre_extensions import none_throws
 from torchx.schedulers.api import (
     AppDryRunInfo,
     DescribeAppResponse,
@@ -42,6 +41,8 @@ from torchx.schedulers.api import (
 from torchx.schedulers.ids import make_unique
 from torchx.schedulers.streams import Tee
 from torchx.specs.api import AppDef, AppState, is_terminal, macros, NONE, Role, runopts
+
+from torchx.util.types import none_throws
 from typing_extensions import TypedDict
 
 

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -23,7 +23,6 @@ from typing import Callable, Generator, Optional
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-from pyre_extensions import none_throws
 from torchx.schedulers.api import DescribeAppResponse
 from torchx.schedulers.local_scheduler import (
     _join_PATH,
@@ -36,6 +35,8 @@ from torchx.schedulers.local_scheduler import (
     ReplicaParam,
 )
 from torchx.specs.api import AppDef, AppState, is_terminal, macros, Resource, Role
+
+from torchx.util.types import none_throws
 
 from .test_util import write_shell_script
 

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -11,7 +11,7 @@ used by components to define the apps which can then be launched via a TorchX
 scheduler or pipeline adapter.
 """
 
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 from torchx.specs.named_resources_aws import NAMED_RESOURCES as AWS_NAMED_RESOURCES
 from torchx.util.entrypoints import load_group
@@ -52,19 +52,33 @@ from .builders import make_app_handle, materialize_appdef, parse_mounts  # noqa
 GiB: int = 1024
 
 
-def _load_named_resources() -> Dict[str, Resource]:
+def _load_named_resources() -> Dict[str, Callable[[], Resource]]:
     resource_methods = load_group("torchx.named_resources", default={})
-    materialized_resources = {}
+    materialized_resources: Dict[str, Callable[[], Resource]] = {}
     default = AWS_NAMED_RESOURCES
     for name, resource in default.items():
-        materialized_resources[name] = resource()
+        materialized_resources[name] = resource
     for resource_name, resource_method in resource_methods.items():
-        materialized_resources[resource_name] = resource_method()
-    materialized_resources["NULL"] = NULL_RESOURCE
+        materialized_resources[resource_name] = resource_method
+    materialized_resources["NULL"] = lambda: NULL_RESOURCE
     return materialized_resources
 
 
-named_resources: Dict[str, Resource] = _load_named_resources()
+_named_resource_factories: Dict[str, Callable[[], Resource]] = _load_named_resources()
+
+
+class _NamedResourcesLibrary:
+    def __getitem__(self, key: str) -> Resource:
+        return _named_resource_factories[key]()
+
+    def __contains__(self, key: str) -> bool:
+        return key in _named_resource_factories
+
+    def __iter__(self) -> None:
+        raise NotImplementedError("named resources doesn't support iterating")
+
+
+named_resources: _NamedResourcesLibrary = _NamedResourcesLibrary()
 
 
 def resource(

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -28,7 +28,6 @@ from typing import (
     Union,
 )
 
-import yaml
 from torchx.util.types import to_dict
 
 _APP_STATUS_FORMAT_TEMPLATE = """AppStatus:
@@ -504,6 +503,9 @@ class AppStatus:
             structured_error_msg_parsed = NONE
         app_status_dict["structured_error_msg"] = structured_error_msg_parsed
         app_status_dict["state"] = repr(app_status_dict["state"])
+
+        import yaml
+
         return yaml.dump({"AppStatus": app_status_dict})
 
     def raise_for_status(self) -> None:

--- a/torchx/specs/file_linter.py
+++ b/torchx/specs/file_linter.py
@@ -13,8 +13,8 @@ from dataclasses import dataclass
 from typing import Callable, cast, Dict, List, Optional, Tuple
 
 from docstring_parser import parse
-from pyre_extensions import none_throws
 from torchx.util.io import read_conf_file
+from torchx.util.types import none_throws
 
 
 # pyre-ignore-all-errors[16]

--- a/torchx/specs/finder.py
+++ b/torchx/specs/finder.py
@@ -16,11 +16,12 @@ from inspect import getmembers, isfunction
 from types import ModuleType
 from typing import Callable, Dict, List, Optional, Union
 
-from pyre_extensions import none_throws
 from torchx.specs import AppDef
 from torchx.specs.file_linter import get_fn_docstring, validate
 from torchx.util import entrypoints
 from torchx.util.io import read_conf_file
+
+from torchx.util.types import none_throws
 
 
 logger: logging.Logger = logging.getLogger(__name__)

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -204,6 +204,10 @@ class ResourceTest(unittest.TestCase):
             named_resources_aws.aws_p3_8xlarge(), named_resources["aws_p3.8xlarge"]
         )
 
+    def test_named_resources_contains(self) -> None:
+        self.assertTrue("aws_p3.8xlarge" in named_resources)
+        self.assertFalse("nonexistant" in named_resources)
+
     def test_resource_util_fn(self) -> None:
         self.assertEqual(Resource(cpu=2, gpu=0, memMB=1024), resource())
         self.assertEqual(Resource(cpu=1, gpu=0, memMB=1024), resource(cpu=1))

--- a/torchx/specs/test/builders_test.py
+++ b/torchx/specs/test/builders_test.py
@@ -11,7 +11,6 @@ from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
-from pyre_extensions import none_throws
 from torchx.specs.api import AppDef, Resource, Role
 from torchx.specs.builders import (
     _create_args_parser,
@@ -22,6 +21,8 @@ from torchx.specs.builders import (
     parse_mounts,
     VolumeMount,
 )
+
+from torchx.util.types import none_throws
 
 
 class AppHandleTest(unittest.TestCase):

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import torchx.specs.finder as finder
-from pyre_extensions import none_throws
 from torchx.runner import get_runner
 from torchx.runtime.tracking import FsspecResultTracker
 from torchx.specs.api import AppDef, AppState, Role
@@ -27,6 +26,7 @@ from torchx.specs.finder import (
     get_components,
     ModuleComponentsFinder,
 )
+from torchx.util.types import none_throws
 
 
 def _test_component(name: str, role_name: str = "worker") -> AppDef:

--- a/torchx/util/test/types_test.py
+++ b/torchx/util/test/types_test.py
@@ -15,6 +15,7 @@ from torchx.util.types import (
     get_argparse_param_type,
     is_bool,
     is_primitive,
+    none_throws,
     to_dict,
     to_list,
 )
@@ -195,3 +196,9 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(str, get_argparse_param_type(params["l"]))
         self.assertEqual(str, get_argparse_param_type(params["m"]))
         self.assertEqual(str, get_argparse_param_type(params["o"]))
+
+    def test_none_throws(self) -> None:
+        self.assertEqual(none_throws(10), 10)
+        self.assertEqual(none_throws("str"), "str")
+        with self.assertRaisesRegex(AssertionError, "Unexpected.*None"):
+            none_throws(None)

--- a/torchx/util/types.py
+++ b/torchx/util/types.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import inspect
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import typing_inspect
 
@@ -198,3 +198,15 @@ def get_argparse_param_type(parameter: inspect.Parameter) -> Callable[[str], obj
         return parameter.annotation
     else:
         return str
+
+
+_T = TypeVar("_T")
+
+
+def none_throws(optional: Optional[_T], message: str = "Unexpected `None`") -> _T:
+    """Convert an optional to its value. Raises an `AssertionError` if the value is `None`
+    Copied from https://github.com/facebook/pyre-check/blob/main/pyre_extensions/refinement.py for performance reasons.
+    """
+    if optional is None:
+        raise AssertionError(message)
+    return optional


### PR DESCRIPTION
Summary:
This has a number of small changes to optimize import load time.

Slow imports were identified via `python -m torchx.cli.main -Ximportprof`

* lazy load named resources instead of computing them all upfront in a similar way to schedulers
* use an internal none_throws instead of using pyre-extensions which loads `unittest`.
* lazy load yaml

These lazy loads should be completely safe as pyre enforces their correctness even if we don't load them at import time.

Differential Revision: D39297141

