### PR TITLE
Distributed

### DIFF
--- a/docs/source/components/distributed.rst
+++ b/docs/source/components/distributed.rst
@@ -8,10 +8,3 @@ Distributed
 
 .. autodata:: torchx.components.dist._TORCH_DEBUG_FLAGS
    :annotation:
-
-.. fbcode::
-
-  .. automodule:: torchx.components.fb.dist
-  .. currentmodule:: torchx.components.fb.dist
-
-  .. autofunction:: torchx.components.fb.dist.hpc

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,7 @@ Documentation
       fb/quickstart.md
       fb/setup.md
       fb/images.md
+      fb/workspace.md
       fb/cogwheel.rst
       fb/named_resources.rst
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,7 @@ Documentation
 
       fb/quickstart.md
       fb/setup.md
+      fb/images.md
       fb/cogwheel.rst
       fb/named_resources.rst
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -130,6 +130,15 @@ Components Library
    components/serve
    components/utils
 
+.. fbcode::
+
+   .. toctree::
+      :maxdepth: 1
+      :caption: Components (Meta)
+      :glob:
+
+      components/fb/*
+
 Runtime Library
 ----------------
 .. toctree::


### PR DESCRIPTION
Summary: Move Meta distributed components to its own page to follow same pattern as schedulers and pipelines

Differential Revision: D39336165

