### PR TITLE
Add ability to pass parent run ID, entrypoint tracker names and tracker config string as env variable

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -161,6 +161,12 @@ class CmdRun(SubCommand):
             help="local workspace to build/patch (buck-target of main binary if using buck)",
         )
         subparser.add_argument(
+            "--parent_run_id",
+            type=str,
+            help="optional parent run ID that this run belongs to."
+            " It can be used to group runs for experiment tracking purposes",
+        )
+        subparser.add_argument(
             "component_name_and_args",
             nargs=argparse.REMAINDER,
         )
@@ -191,6 +197,7 @@ class CmdRun(SubCommand):
                     args.scheduler,
                     workspace=args.workspace,
                     cfg=cfg,
+                    parent_run_id=args.parent_run_id,
                 )
                 logger.info(
                     "\n=== APPLICATION ===\n"
@@ -205,6 +212,7 @@ class CmdRun(SubCommand):
                     args.scheduler,
                     workspace=args.workspace,
                     cfg=cfg,
+                    parent_run_id=args.parent_run_id,
                 )
                 # DO NOT delete this line. It is used by slurm tests to retrieve the app id
                 print(app_handle)

--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -398,7 +398,7 @@ def load_sections(
 def get_configs(
     prefix: str,
     name: str,
-    dirs: Optional[List[str]],
+    dirs: Optional[List[str]] = None,
 ) -> Dict[str, str]:
     """
     Gets all the config values in the section ``["{prefix}:{name}"]``.

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -168,6 +168,130 @@ class RunnerTest(unittest.TestCase):
                     "local_dir://" + SESSION_NAME + "/${app_id}",
                 )
 
+    def test_dryrun_trackers_parent_run_id_as_paramenter(self, _) -> None:
+        scheduler_mock = MagicMock()
+        expected_parent_run_id = "123"
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={"local_dir": lambda name: scheduler_mock},
+        ) as runner:
+            role1 = Role(
+                name="echo1",
+                image=self.test_dir,
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            role2 = Role(
+                name="echo2",
+                image=self.test_dir,
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            app = AppDef("name", roles=[role1, role2])
+            runner.dryrun(
+                app, "local_dir", cfg=self.cfg, parent_run_id=expected_parent_run_id
+            )
+            for role in app.roles:
+                self.assertEqual(
+                    role.env["TORCHX_PARENT_RUN_ID"],
+                    expected_parent_run_id,
+                )
+
+    @patch("torchx.runner.api._get_configured_trackers")
+    def test_dryrun_setup_trackers(self, config_trackers_mock: MagicMock, _) -> None:
+        config_trackers_mock.return_value = {
+            "my_tracker1": "manifold://config1.txt",
+            "my_tracker2": "manifold://config2.txt",
+        }
+        scheduler_mock = MagicMock()
+        expected_trackers = "my_tracker1,my_tracker2"
+        expected_tracker1_config = "manifold://config1.txt"
+        expected_tracker2_config = "manifold://config2.txt"
+
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={"local_dir": lambda name: scheduler_mock},
+        ) as runner:
+            role1 = Role(
+                name="echo1",
+                image=self.test_dir,
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            role2 = Role(
+                name="echo2",
+                image=self.test_dir,
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            app = AppDef("name", roles=[role1, role2])
+            runner.dryrun(app, "local_dir", cfg=self.cfg, parent_run_id="999")
+            for role in app.roles:
+                self.assertEqual(
+                    role.env["TORCHX_TRACKERS"],
+                    expected_trackers,
+                )
+                self.assertEqual(
+                    role.env["TORCHX_TRACKER_MY_TRACKER1_CONFIG"],
+                    expected_tracker1_config,
+                )
+                self.assertEqual(
+                    role.env["TORCHX_TRACKER_MY_TRACKER2_CONFIG"],
+                    expected_tracker2_config,
+                )
+
+    @patch.dict(
+        os.environ,
+        {
+            "TORCHX_TRACKERS": "my_tracker1,my_tracker2",
+            "TORCHX_TRACKER_MY_TRACKER1_CONFIG": "manifold://config1.txt",
+            "TORCHX_TRACKER_MY_TRACKER2_CONFIG": "manifold://config2.txt",
+        },
+    )
+    def test_dryrun_setup_trackers_as_env_variable(self, _) -> None:
+        scheduler_mock = MagicMock()
+        expected_trackers = "my_tracker1,my_tracker2"
+        expected_tracker1_config = "manifold://config1.txt"
+        expected_tracker2_config = "manifold://config2.txt"
+
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={"local_dir": lambda name: scheduler_mock},
+        ) as runner:
+            role1 = Role(
+                name="echo1",
+                image=self.test_dir,
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            role2 = Role(
+                name="echo2",
+                image=self.test_dir,
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            app = AppDef("name", roles=[role1, role2])
+            runner.dryrun(app, "local_dir", cfg=self.cfg, parent_run_id="999")
+            for role in app.roles:
+                self.assertEqual(
+                    role.env["TORCHX_TRACKERS"],
+                    expected_trackers,
+                )
+                self.assertEqual(
+                    role.env["TORCHX_TRACKER_MY_TRACKER1_CONFIG"],
+                    expected_tracker1_config,
+                )
+                self.assertEqual(
+                    role.env["TORCHX_TRACKER_MY_TRACKER2_CONFIG"],
+                    expected_tracker2_config,
+                )
+
     def test_dryrun_with_workspace(self, _) -> None:
         class TestScheduler(Scheduler, Workspace):
             def __init__(self, build_new_img: bool):


### PR DESCRIPTION
Summary:
When tracking runs as part of an experiment, we would like to setup multiple backends with in a remote job.

- Allow specifying parent run ID, eg this could be previous run, MLHub experiment ID or w&b project ID
- List of tracker backends to setup (entrypoint keys that will be available remotely)
- Optinal config k/v, e.g. config file

More context:
https://fburl.com/gdoc/c6kgghma

Reviewed By: d4l3k

Differential Revision: D39547793

