### PR TITLE
Tracking initial API+tests

### DIFF
--- a/torchx/tracker/__init__.py
+++ b/torchx/tracker/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchx/tracker/api.py
+++ b/torchx/tracker/api.py
@@ -1,0 +1,285 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable, Mapping, Optional
+
+from torchx.util.entrypoints import load_group
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+TRACKER_ENV_VAR_NAME = "TORCHX_TRACKERS"
+
+
+@dataclass
+class TrackerSource:
+    """
+    Dataclass to represent sources at backend tracker level
+
+    Args:
+        source_id(str): source ID that can be either other TorchX handle or ID of external entity such as experiment
+        artifact_name(Optional[str]): type of of source. Can be interpreted as type of relationship that can be used for filtering.
+    """
+
+    source_id: str
+    artifact_name: Optional[str]
+
+
+@dataclass
+class TrackerArtifact:
+    """
+    Dataclass to represent artifacts at backend tracker level
+
+    Args:
+        name(str): Name of the artifact
+        path(str): Path to actual artifact
+        metadata(Optional[Mapping[str, object]]): Additional metadata to store about artifact
+    """
+
+    name: str
+    path: str
+    metadata: Optional[Mapping[str, object]]
+
+
+@dataclass
+class AppRunTrackableSource:
+    """
+    Dataclass to represent sources at user API level
+
+    Args:
+        parent(AppRun): source AppRun that current run is derived from.
+        artifact_name(Optional[str]): type of artifact represening parent AppRun.
+    """
+
+    parent: AppRun
+    artifact_name: Optional[str]
+
+
+class Lineage:
+    ...
+
+
+class TrackerBase(ABC):
+    """
+    Abstraction of tracking solution implementations/services.
+
+    This API is stil experimental and may change in the future to a large extend.
+    """
+
+    @abstractmethod
+    def add_artifact(
+        self,
+        run_id: str,
+        name: str,
+        path: str,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        """
+        Adds an artifact to the tracker with the specified name, path and any arbitrary metadata.
+        """
+        ...
+
+    @abstractmethod
+    def artifacts(self, run_id: str) -> Mapping[str, TrackerArtifact]:
+        """
+        Fetches all of the artifacts for the specified run or the current one if not specified.
+        """
+        ...
+
+    @abstractmethod
+    def add_metadata(self, run_id: str, **kwargs: object) -> None:
+        """
+        Adds any arbitrary metadata values to the specified experiment.
+        """
+        ...
+
+    @abstractmethod
+    def metadata(self, run_id: str) -> Mapping[str, object]:
+        """
+        Fetches the metadata for the specified experiment.
+        """
+        ...
+
+    @abstractmethod
+    def add_source(
+        self,
+        run_id: str,
+        source_id: str,
+        artifact_name: Optional[str] = None,
+    ) -> None:
+        """
+        Adds a link to a different job identifying the lineage of the current experiment
+        and the specific artifact that's being used.
+        """
+        ...
+
+    @abstractmethod
+    def sources(
+        self,
+        run_id: str,
+        artifact_name: Optional[str] = None,
+    ) -> Iterable[TrackerSource]:
+        """
+        Returns sources for the specified run. Artifact name can be used to filter the sources.
+        """
+        ...
+
+    @abstractmethod
+    def lineage(self, run_id: str) -> Lineage:
+        """
+        Returns the lineage for the specified experiment. The lineage includes all
+        parent jobs and artifacts this job depends on as well as any jobs that are consuming
+        artifacts from this job.
+        """
+        ...
+
+    @abstractmethod
+    def run_ids(self, **kwargs: str) -> Iterable[str]:
+        """
+        Returns list of experiment run ids. Optionally includes filter parameters.
+        """
+        ...
+
+
+def tracker_config_env_var_name(entrypoint_key: str) -> str:
+    """Utility method to derive tracker config env variable name given tracker name"""
+    return f"TORCHX_TRACKER_{entrypoint_key.upper()}_CONFIG"
+
+
+def trackers_from_environ() -> Iterable[TrackerBase]:
+    """
+    Builds list of Trackers that will be used to persist tracking information and will be used by AppRun
+        to delegate calls to the each instance.
+    Expects `TORCHX_TRACKERS` env variable to contain list of entry-point factory keys, separated by comma.
+    Optionally, for each tracker key user can pass config string value under `TORCHX_TRACKER_<ENTRYPOINT_NAME>_CONFIG` env variable.
+        It is up to each implementation to interpret the value, eg it can an encoded data or path to richer config properties file.
+
+    Entry-points(factory methods) must exist in runtime when job is running since this runs within user-job space.
+    """
+
+    if TRACKER_ENV_VAR_NAME not in os.environ:
+        logger.info("No trackers were configured, skipping setup.")
+        return []
+
+    tracker_backend_entrypoints = os.environ[TRACKER_ENV_VAR_NAME]
+    logger.info(f"Trackers specified {tracker_backend_entrypoints}")
+
+    trackers = []
+
+    entrypoint_factories = load_group("torchx.tracker")
+    for entrypoint_key in tracker_backend_entrypoints.split(","):
+        logger.info(f"Configuring tracker {entrypoint_key}")
+        if entrypoint_key not in entrypoint_factories:
+            logger.warn(
+                f"Coult not find '{entrypoint_key}' tracker entrypoint, skipping."
+            )
+            continue
+        factory = entrypoint_factories[entrypoint_key]
+
+        config_env_name = tracker_config_env_var_name(entrypoint_key)
+        if config_env_name in os.environ:
+            config = os.environ[config_env_name]
+            logger.info(
+                f"Trackers config specified for {tracker_backend_entrypoints} as {config}"
+            )
+            tracker = factory(config)
+        else:
+            logger.info(
+                f"No trackers config specified for {tracker_backend_entrypoints}"
+            )
+            tracker = factory(None)
+        trackers.append(tracker)
+
+    return trackers
+
+
+@dataclass
+class AppRun:
+    """
+    Exposes tracker API to at the job level and should the only API that encapsulates that module implementation.
+
+    This API is stil experimental and may change in the future.
+
+    Args:
+        run_id(str): identity of the job used by tracker API
+        backends(Iterable[TrackerBase]): list of TrackerBase implementations that will be used to persist the data.
+    """
+
+    run_id: str
+    backends: Iterable[TrackerBase]
+
+    @staticmethod
+    @lru_cache(maxsize=1)  # noqa: B019
+    def from_env() -> AppRun:
+        """Factory method do build AppRun that uses environment variabes to build it.
+
+        Single instance of AppRun will be available for the duration of the application, thus expect that calling
+        this method will retorn same AppRun and hence same instances of the backend implementations.
+        """
+
+        torchx_job_id = os.environ["TORCHX_JOB_ID"]
+        return AppRun(run_id=torchx_job_id, backends=trackers_from_environ())
+
+    def add_metadata(self, **kwargs: object) -> None:
+        """Stores metadata for the current run"""
+        for backend in self.backends:
+            backend.add_metadata(self.run_id, **kwargs)
+
+    def add_artifact(
+        self, name: str, path: str, metadata: Optional[Mapping[str, object]] = None
+    ) -> None:
+        """Stores artifacts for the current run
+
+        Args:
+            name(str): name of the artifact
+            path(str): path of the artifact that is stored
+            metadata(Optional[Mapping[str, object]]): optional metadata attached to artifact information
+        """
+        for backend in self.backends:
+            backend.add_artifact(self.run_id, name, path, metadata)
+
+    def job_id(self) -> str:
+        """Current Id of the run"""
+        return self.run_id
+
+    def add_source(self, source_id: str, artifact_name: Optional[str] = None) -> None:
+        """
+        Attaches source to this run. Sources can be either other TorchX runs or external entities such as experiments that may
+        or may not be queriable.
+
+        Args:
+            source_id(str): identity of the source
+            artifact_name(Optional[str]): optional value of type of source
+        """
+        for backend in self.backends:
+            backend.add_source(self.run_id, source_id, artifact_name)
+
+    def sources(self) -> Iterable[AppRunTrackableSource]:
+        """
+        Returns `AppRunTrackableSource` for the run.
+
+        Uses first backend to query this information, although it supports list of trackers in order
+        to persist tracking information.
+        """
+        model_run_sources = []
+        if self.backends:
+            backend = next(iter(self.backends))
+            sources = backend.sources(self.run_id)
+            for source in sources:
+                parent = AppRun(source.source_id, backends=self.backends)
+                model_run_source = AppRunTrackableSource(parent, source.artifact_name)
+                model_run_sources.append(model_run_source)
+
+        return model_run_sources
+
+    def children(self) -> Iterable[AppRun]:
+        ...

--- a/torchx/tracker/test/__init__.py
+++ b/torchx/tracker/test/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchx/tracker/test/api_test.py
+++ b/torchx/tracker/test/api_test.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from collections import defaultdict
+from typing import cast, DefaultDict, Dict, Iterable, Mapping, Optional, Tuple
+from unittest import mock, TestCase
+from unittest.mock import patch
+
+import torchx.tracker.api as api
+from torchx.tracker.api import (
+    AppRun,
+    Lineage,
+    tracker_config_env_var_name,
+    TRACKER_ENV_VAR_NAME,
+    TrackerArtifact,
+    TrackerBase,
+    TrackerSource,
+)
+
+RunId = str
+
+DEFAULT_SOURCE: str = "__parent__"
+
+
+class TestTrackerBackend(api.TrackerBase):
+    def __init__(self, config_path: Optional[str] = None) -> None:
+        self._artifacts: DefaultDict[
+            RunId,
+            DefaultDict[str, Tuple[str, Optional[Mapping[str, object]]]],
+        ] = defaultdict(lambda: defaultdict())
+        self._metdata: DefaultDict[RunId, DefaultDict[str, object]] = defaultdict(
+            lambda: defaultdict()
+        )
+
+        self._sources: DefaultDict[RunId, Dict[str, str]] = defaultdict(dict)
+        self.config_path = config_path
+
+    def add_artifact(
+        self,
+        run_id: str,
+        name: str,
+        path: str,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        self._artifacts[run_id][name] = (path, metadata)
+
+    def artifacts(self, run_id: str) -> Mapping[str, TrackerArtifact]:
+        exp_artifacts = self._artifacts[run_id]
+        return {
+            k: TrackerArtifact(k, path, metadata)
+            for k, [path, metadata] in exp_artifacts.items()
+        }
+
+    def add_metadata(self, run_id: str, **kwargs: object) -> None:
+        self._metdata[run_id].update(kwargs)
+
+    def metadata(self, run_id: str) -> Mapping[str, object]:
+        return self._metdata[run_id]
+
+    def add_source(
+        self,
+        run_id: str,
+        source_id: str,
+        artifact_name: Optional[str],
+    ) -> None:
+        if not artifact_name:
+            artifact_name = DEFAULT_SOURCE
+        self._sources[run_id][artifact_name] = source_id
+
+    def sources(
+        self,
+        run_id: str,
+        artifact_name: Optional[str] = None,
+    ) -> Iterable[TrackerSource]:
+        source_data = self._sources[run_id]
+
+        sources = []
+        for artifact_name, source_id in self._sources[run_id].items():
+            if artifact_name == DEFAULT_SOURCE:
+                sources.append(TrackerSource(source_id, None))
+            else:
+                sources.append(TrackerSource(source_id, artifact_name))
+        return sources
+
+    def lineage(self, run_id: str) -> Lineage:
+        return Lineage()
+
+    def run_ids(self, **kwargs: str) -> Iterable[str]:
+        return []
+
+
+class AppRunApiTest(TestCase):
+    def setUp(self) -> None:
+        os.environ["TORCHX_JOB_ID"] = "scheduler://sesison/app_id"
+        self.tracker = TestTrackerBackend()
+        self.run_id = "run_id"
+        self.model_run = AppRun(self.run_id, [self.tracker])
+
+    @mock.patch.dict(
+        os.environ, {TRACKER_ENV_VAR_NAME: "tracker1", "TORCHX_JOB_ID": "run_id"}
+    )
+    def test_env_factory_test(self) -> None:
+        with patch(
+            "torchx.tracker.api.load_group",
+            return_value={"tracker1": tracker_factory},
+        ):
+            app_run = api.AppRun.from_env()
+            self.assertEqual(app_run.run_id, self.run_id)
+            self.assertEqual(TestTrackerBackend, type(app_run.backends[0]))
+
+    def test_get_exierment_run_id(self) -> None:
+        self.assertEqual(self.run_id, self.model_run.job_id())
+
+    def test_add_artifact(self) -> None:
+        self.model_run.add_artifact("output", "/directory")
+        artifacts = self.tracker.artifacts(self.run_id)
+        self.assertEqual("/directory", artifacts["output"].path)
+        self.assertIsNone(artifacts["output"].metadata)
+
+    def test_add_artifact_with_metadata(self) -> None:
+        self.model_run.add_artifact("output", "/directory", {"date": "2020/01/01"})
+        artifacts = self.tracker.artifacts(self.run_id)
+        metadata = artifacts["output"].metadata
+        self.assertIsNotNone(metadata)
+        if metadata:
+            self.assertEqual("2020/01/01", metadata["date"])
+
+    def test_add_source(self) -> None:
+        self.model_run.add_source("parent_model_run")
+        sources = self.model_run.sources()
+        self.assertEqual(1, len(list(sources)))
+        source = list(sources)[0]
+        self.assertEqual(source.parent.run_id, "parent_model_run")
+        self.assertEqual(source.parent.backends, self.model_run.backends)
+
+    def test_add_metadata(self) -> None:
+        self.model_run.add_metadata(lr=0.01, bs=25)
+
+        metadata = self.tracker.metadata(self.run_id)
+        self.assertEqual(metadata, {"lr": 0.01, "bs": 25})
+
+    def test_add_metadata_should_update_values(self) -> None:
+        self.model_run.add_metadata(lr=0.01, bs=25)
+        self.model_run.add_metadata(bs=10)
+
+        metadata = self.tracker.metadata(self.run_id)
+        self.assertEqual(metadata, {"lr": 0.01, "bs": 10})
+
+    def test_lineage(self) -> None:
+        self.tracker.lineage(self.run_id)
+
+    def test_run_ids(self) -> None:
+        self.tracker.run_ids()
+
+
+def tracker_factory(config: Optional[str] = None) -> TrackerBase:
+    return TestTrackerBackend(config)
+
+
+class TrackerFromEnvironTest(TestCase):
+    def test_config_env_var_name(self) -> None:
+        value = tracker_config_env_var_name("tracker1")
+        self.assertEqual(value, "TORCHX_TRACKER_TRACKER1_CONFIG")
+
+    def test_trackers_from_environ_with_no_trackers_specified(self) -> None:
+        self.assertEqual(len(list(api.trackers_from_environ())), 0)
+
+    @mock.patch.dict(os.environ, {TRACKER_ENV_VAR_NAME: "tracker1"})
+    def test_tracker_from_environ(self) -> None:
+        with patch(
+            "torchx.tracker.api.load_group",
+            return_value={"tracker1": tracker_factory},
+        ):
+            trackers = api.trackers_from_environ()
+            self.assertEqual(1, len(list(trackers)))
+            self.assertEqual(TestTrackerBackend, type(trackers[0]))
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            TRACKER_ENV_VAR_NAME: "tracker1",
+            tracker_config_env_var_name("tracker1"): "myconfig.txt",
+        },
+    )
+    def test_tracker_from_environ_with_config_setting(self) -> None:
+        with patch(
+            "torchx.tracker.api.load_group",
+            return_value={"tracker1": tracker_factory},
+        ):
+            trackers = api.trackers_from_environ()
+            tracker = cast(TestTrackerBackend, list(trackers)[0])
+            self.assertEqual("myconfig.txt", tracker.config_path)
+
+    def test_trackerfrom_environ_that_wasnt_setup(self) -> None:
+        trackers = api.trackers_from_environ()
+        self.assertEqual(len(list(trackers)), 0)
+
+    @mock.patch.dict(os.environ, {TRACKER_ENV_VAR_NAME: "tracker1"})
+    def test_tracker_from_environ_with_missing_entrypoint(self) -> None:
+        with patch(
+            "torchx.tracker.api.load_group",
+            return_value={},
+        ):
+            trackers = api.trackers_from_environ()
+            self.assertEqual(0, len(list(trackers)))


### PR DESCRIPTION
Summary:
Initial experimental API definition for tracker API.

ModelRun API is exposed to user jobs, which eventually delegates to backend tracker implementations.

Unit test has rudimentary backend example and next diff should have a lightweight fsspec backend implementation.

Ref: https://fburl.com/gdoc/699rzj23

Differential Revision: D39548237

