### PR TITLE
Fix: dont use importlib_metadata v5.0 due to deprecated behavior and interface.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ classy-vision>=0.6.0
 flake8==3.9.0
 fsspec[s3]==2022.1.0
 hydra-core
-importlib-metadata
+importlib-metadata<5.0
 ipython
 kfp==1.8.9
 moto==3.0.2


### PR DESCRIPTION
Summary:
Temporarily peg importlib_metadata to <5.0 due do breaking changes (https://github.com/python/importlib_metadata/issues/409) for CPython 3.7

The right fix is to use `metadata.entry_points(group=group, name=name)`, however typechecker does not recognize the changes (https://github.com/python/importlib_metadata/commit/7e5bae4c7fbd30366e49249825171b193dff22d4)

Differential Revision: D40053701

