### PR TITLE
Make mast scheduler shorten app handle for long app_names

### DIFF
--- a/torchx/schedulers/ids.py
+++ b/torchx/schedulers/ids.py
@@ -6,18 +6,25 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import random
 import struct
 
+START_CANDIDATES: str = "bcdfghjklmnpqrstvwxz"
+END_CANDIDATES: str = START_CANDIDATES + "012345679"
 
-def make_unique(name: str) -> str:
+
+def make_unique(name: str, string_length: int = 0) -> str:
     """
     Appends a unique 64-bit string to the input argument.
 
     Returns:
         string in format $name-$unique_suffix
     """
-    rand_suffix = random_id()
-    return f"{name}-{rand_suffix}"
+    return (
+        f"{name}-{random_id()}"
+        if string_length == 0
+        else f"{name}-{get_len_random_id(string_length)}"
+    )
 
 
 def random_uint64() -> int:
@@ -32,9 +39,6 @@ def random_id() -> str:
     Generates an alphanumeric string ID that matches the requirements from
     https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
     """
-    START_CANDIDATES = "bcdfghjklmnpqrstvwxz"
-    END_CANDIDATES = START_CANDIDATES + "012345679"
-
     out = ""
     v = random_uint64()
     while v > 0:
@@ -46,4 +50,21 @@ def random_id() -> str:
         char = v % len(candidates)
         v = v // len(candidates)
         out += candidates[char]
+    return out
+
+
+def get_len_random_id(string_length: int) -> str:
+    """
+    Generates an alphanumeric string ID that matches the requirements from
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+    """
+    out = ""
+    for i in range(string_length):
+        if out == "":
+            candidates = START_CANDIDATES
+        else:
+            candidates = END_CANDIDATES
+
+        out += random.choice(candidates)
+
     return out

--- a/torchx/schedulers/test/ids_test.py
+++ b/torchx/schedulers/test/ids_test.py
@@ -9,13 +9,20 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from torchx.schedulers.ids import make_unique, random_id, random_uint64
+from torchx.schedulers.ids import (
+    get_len_random_id,
+    make_unique,
+    random_id,
+    random_uint64,
+)
 
 
 class IdsTest(unittest.TestCase):
     def test_make_unique(self) -> None:
         name = "test"
         self.assertNotEqual(make_unique(name), make_unique(name))
+        size = 6
+        self.assertNotEqual(make_unique(name, size), make_unique(name, size))
 
     def test_make_unique_min_len(self) -> None:
         unique_name = make_unique("test")
@@ -32,6 +39,11 @@ class IdsTest(unittest.TestCase):
         v = random_id()
         self.assertIn(v[0], ALPHAS)
         self.assertGreater(len(v), 5)
+
+    def test_get_len_random_id(self) -> None:
+        size = 6
+        self.assertNotEqual(get_len_random_id(size), get_len_random_id(size))
+        self.assertEqual(size, len(get_len_random_id(size)))
 
     @patch("os.urandom", return_value=bytes(range(8)))
     def test_random_id_seed(self, urandom: MagicMock) -> None:


### PR DESCRIPTION
Summary: make short name instead of long name for topic

Differential Revision: D40275429

