### PR TITLE
torchx/schedulers: add elastic support for Volcano + add docs

### DIFF
--- a/docs/source/ext/compatibility.py
+++ b/docs/source/ext/compatibility.py
@@ -18,6 +18,7 @@ COMPATIBILITY_SETS = {
         "describe": "Describe Job",
         "workspaces": "Workspaces / Patching",
         "mounts": "Mounts",
+        "elasticity": "Elasticity",
     },
 }
 

--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -296,6 +296,7 @@ class AWSBatchScheduler(Scheduler[AWSBatchOpts], DockerWorkspace):
                 status but does not provide the complete original AppSpec.
             workspaces: true
             mounts: true
+            elasticity: false
     """
 
     def __init__(

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -139,6 +139,7 @@ class DockerScheduler(Scheduler[DockerOpts], DockerWorkspace):
                 status but does not provide the complete original AppSpec.
             workspaces: true
             mounts: true
+            elasticity: false
     """
 
     def __init__(self, session_name: str) -> None:

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -392,6 +392,9 @@ Role {role.name} configured with restarts: {role.max_retries}. As of 1.4.0 Volca
 does NOT support retries correctly. More info: https://github.com/volcano-sh/volcano/issues/1651
                 """
                 warnings.warn(msg)
+            if role.min_replicas is not None:
+                # first min_replicas tasks are required, afterward optional
+                task["minAvailable"] = 1 if replica_id < role.min_replicas else 0
             tasks.append(task)
 
     job_retries = min(role.max_retries for role in app.roles)
@@ -408,6 +411,7 @@ does NOT support retries correctly. More info: https://github.com/volcano-sh/vol
     }
     if priority_class is not None:
         job_spec["priorityClassName"] = priority_class
+
     resource: Dict[str, object] = {
         "apiVersion": "batch.volcano.sh/v1alpha1",
         "kind": "Job",
@@ -522,6 +526,7 @@ class KubernetesScheduler(Scheduler[KubernetesOpts], DockerWorkspace):
                 status but does not provide the complete original AppSpec.
             workspaces: true
             mounts: true
+            elasticity: Requires Volcano >1.6
     """
 
     def __init__(

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -546,6 +546,7 @@ class LocalScheduler(Scheduler[LocalOpts]):
                 Partial support. LocalScheduler runs the app from a local
                 directory but does not support programmatic workspaces.
             mounts: false
+            elasticity: false
     """
 
     def __init__(

--- a/torchx/schedulers/lsf_scheduler.py
+++ b/torchx/schedulers/lsf_scheduler.py
@@ -428,6 +428,7 @@ class LsfScheduler(Scheduler[LsfOpts]):
               LsfScheduler will return job.
           mounts: true
           workspaces: false
+          elasticity: false
 
     **TOFIX**
 

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -145,6 +145,7 @@ if _has_ray:
                     does not provide the complete original AppSpec.
                 workspaces: true
                 mounts: false
+                elasticity: Partial support. Multi role jobs are not supported.
 
         """
 
@@ -286,6 +287,9 @@ if _has_ray:
                     )
 
                     job.actors.append(actor)
+
+            if len(app.roles) > 1 and app.roles[0].min_replicas is not None:
+                raise ValueError("min_replicas is only supported with single role jobs")
 
             return AppDryRunInfo(job, repr)
 

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -314,6 +314,7 @@ class SlurmScheduler(Scheduler[SlurmOpts], DirWorkspace):
                 If ``job_dir`` is specified the DirWorkspace will create a new
                 isolated directory with a snapshot of the workspace.
             mounts: false
+            elasticity: false
 
     If a partition has less than 1GB of RealMemory configured we disable memory
     requests to workaround https://github.com/aws/aws-parallelcluster/issues/2198.

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -850,6 +850,17 @@ spec:
         self.assertEqual(client.images.get().tag.call_count, 1)
         self.assertEqual(client.images.push.call_count, 1)
 
+    def test_min_replicas(self) -> None:
+        app = _test_app(num_replicas=3)
+        app.roles[0].min_replicas = 2
+
+        resource = app_to_resource(app, "test_queue", service_account=None)
+        min_available = [
+            task["minAvailable"]
+            for task in resource["spec"]["tasks"]  # pyre-ignore[16]
+        ]
+        self.assertEqual(min_available, [1, 1, 0])
+
 
 class KubernetesSchedulerNoImportTest(unittest.TestCase):
     """


### PR DESCRIPTION
<!-- Change Summary -->

Volcano 1.6 has per task level elastic support -- this adds support for it in the Kubernetes integration

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Unit test + CI

```
(torchx) tristanr@tristanr-arch2 ~/D/torchx-proj> env TORCHXCONFIG=./.torchxconfig.aws torchx run -s kubernetes  --log --wait --log dist.ddp --env LOGLEVEL=INFO -j 1:2x1 --script foo.py
```

```
(torchx) tristanr@tristanr-arch2 ~/D/torchx-proj> kubectl get jobs.batch.volcano.sh foo-w4k13hh7ht417 -oyaml
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  creationTimestamp: "2022-10-14T00:36:21Z"
  generation: 1
  name: foo-w4k13hh7ht417
  namespace: default
  resourceVersion: "436701698"
  uid: a8576c05-56f5-4b9f-8f04-a3eb305b93cc
spec:
  maxRetry: 3
  minAvailable: 1
  plugins:
    env: []
    svc:
    - --publish-not-ready-addresses
  queue: default
  schedulerName: volcano
  tasks:
  - maxRetry: 3
    minAvailable: 1
    name: foo-0
    replicas: 1
    template:
      metadata:
        annotations:
          sidecar.istio.io/inject: "false"
        labels:
          torchx.pytorch.org/app-name: foo
          torchx.pytorch.org/replica-id: "0"
          torchx.pytorch.org/role-index: "0"
          torchx.pytorch.org/role-name: foo
          torchx.pytorch.org/version: 0.3.0dev0
      spec:
        containers:
        - command:
          - bash
          - -c
          - python -m torch.distributed.run --rdzv_backend c10d --rdzv_endpoint $TORCHX_RANK0_HOST:29500
            --rdzv_id 'foo-w4k13hh7ht417' --nnodes 1:2 --nproc_per_node 1 --tee 3
            --role '' foo.py
          env:
          - name: LOGLEVEL
            value: INFO
          - name: TORCHX_JOB_ID
            value: kubernetes://torchx/foo-w4k13hh7ht417
          - name: TORCHX_RANK0_HOST
            value: localhost
          image: 495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/integration-tests:9354c78665f7fafda8cf67dd1eed36e15d106185ba8ffd32613cc5da4fc7a9cc
          name: foo-0
          ports:
          - containerPort: 29500
            name: c10d
            protocol: TCP
          resources:
            limits:
              cpu: "2"
              memory: 1024M
            requests:
              cpu: 1900m
              memory: "0"
          securityContext: {}
          volumeMounts:
          - mountPath: /dev/shm
            name: dshm
        restartPolicy: Never
        volumes:
        - emptyDir:
            medium: Memory
          name: dshm
  - maxRetry: 3
    minAvailable: 0
    name: foo-1
    replicas: 1
    template:
      metadata:
        annotations:
          sidecar.istio.io/inject: "false"
        labels:
          torchx.pytorch.org/app-name: foo
          torchx.pytorch.org/replica-id: "1"
          torchx.pytorch.org/role-index: "0"
          torchx.pytorch.org/role-name: foo
          torchx.pytorch.org/version: 0.3.0dev0
      spec:
        containers:
        - command:
          - bash
          - -c
          - python -m torch.distributed.run --rdzv_backend c10d --rdzv_endpoint $VC_FOO_0_HOSTS:29500
            --rdzv_id 'foo-w4k13hh7ht417' --nnodes 1:2 --nproc_per_node 1 --tee 3
            --role '' foo.py
          env:
          - name: LOGLEVEL
            value: INFO
          - name: TORCHX_JOB_ID
            value: kubernetes://torchx/foo-w4k13hh7ht417
          image: 495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/integration-tests:9354c78665f7fafda8cf67dd1eed36e15d106185ba8ffd32613cc5da4fc7a9cc
          name: foo-1
          ports:
          - containerPort: 29500
            name: c10d
            protocol: TCP
          resources:
            limits:
              cpu: "2"
              memory: 1024M
            requests:
              cpu: 1900m
              memory: "0"
          securityContext: {}
          volumeMounts:
          - mountPath: /dev/shm
            name: dshm
        restartPolicy: Never
        volumes:
        - emptyDir:
            medium: Memory
          name: dshm
status:
  conditions:
  - lastTransitionTime: "2022-10-14T00:36:21Z"
    status: Pending
  - lastTransitionTime: "2022-10-14T00:36:25Z"
    status: Running
  - lastTransitionTime: "2022-10-14T00:36:34Z"
    status: Completed
  minAvailable: 1
  runningDuration: 13.690138577s
  state:
    lastTransitionTime: "2022-10-14T00:36:34Z"
    phase: Completed
  succeeded: 2
  taskStatusCount:
    foo-0:
      phase:
        Succeeded: 1
    foo-1:
      phase:
        Succeeded: 1
  version: 1

```

Need to get our Volcano 1.6 cluster working to test E2E