### PR TITLE
torchx/integration tests: bump memory required by datapreproc example to avoid OOM

### DIFF
--- a/scripts/example_app_defs.py
+++ b/scripts/example_app_defs.py
@@ -22,6 +22,7 @@ class CvTrainerComponentProvider(ComponentProvider):
             image=self._image,
             j="1x1",
             m="torchx.examples.apps.lightning_classy_vision.train",
+            memMB=2048,
         )
 
 


### PR DESCRIPTION
<!-- Change Summary -->

title

fixes https://github.com/pytorch/torchx/actions/runs/3253579490/jobs/5340969255

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI
