### PR TITLE
torchx/workspace: workspace_opts + standardize dryrun_push_images and push_images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Milestone: https://github.com/pytorch/torchx/milestones/3
     * Slurm jobs will by default launch in the current working directory to match `local_cwd` and workspace behavior. #372
     * Replicas now have their own log files and can be accessed programmatically. #373
     * Support for `comment`, `mail-user` and `constraint` fields. #391
-    * Workspace support (prototype) - Slurm jobs can now be launched in isolated experiment directories. #416
+    * WorkspaceMixin support (prototype) - Slurm jobs can now be launched in isolated experiment directories. #416
   * Kubernetes
     * Support for running jobs under service accounts. #408
     * Support for specifying instance types. #433

--- a/docs/source/workspace.rst
+++ b/docs/source/workspace.rst
@@ -6,7 +6,7 @@ torchx.workspace
 
 .. currentmodule:: torchx.workspace
 
-.. autoclass:: Workspace
+.. autoclass:: WorkspaceMixin
   :members:
 
 .. autofunction:: walk_workspace
@@ -18,7 +18,7 @@ torchx.workspace.docker_workspace
 .. automodule:: torchx.workspace.docker_workspace
 .. currentmodule:: torchx.workspace.docker_workspace
 
-.. autoclass:: DockerWorkspace
+.. autoclass:: DockerWorkspaceMixin
   :members:
   :private-members: _update_app_images, _push_images
 
@@ -29,7 +29,7 @@ torchx.workspace.dir_workspace
 .. automodule:: torchx.workspace.dir_workspace
 .. currentmodule:: torchx.workspace.dir_workspace
 
-.. autoclass:: DirWorkspace
+.. autoclass:: DirWorkspaceMixin
   :members:
 
 .. fbcode::
@@ -40,6 +40,6 @@ torchx.workspace.dir_workspace
    .. automodule:: torchx.workspace.fb.jetter_workspace
    .. currentmodule:: torchx.workspace.fb.jetter_workspace
 
-   .. autoclass:: JetterWorkspace
+   .. autoclass:: JetterWorkspaceMixin
      :members:
      :show-inheritance:

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -34,7 +34,7 @@ from torchx.specs.finder import get_component
 from torchx.tracker.api import tracker_config_env_var_name, TRACKER_ENV_VAR_NAME
 
 from torchx.util.types import none_throws
-from torchx.workspace.api import Workspace
+from torchx.workspace.api import WorkspaceMixin
 
 from .config import get_config, get_configs
 
@@ -363,7 +363,7 @@ class Runner:
         with log_event("dryrun", scheduler, runcfg=json.dumps(cfg) if cfg else None):
             sched = self._scheduler(scheduler)
 
-            if workspace and isinstance(sched, Workspace):
+            if workspace and isinstance(sched, WorkspaceMixin):
                 role = app.roles[0]
                 old_img = role.image
 

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -26,7 +26,7 @@ from torchx.specs.api import AppDef, AppState, Resource, Role, UnknownAppExcepti
 from torchx.specs.finder import ComponentNotFoundException
 
 from torchx.util.types import none_throws
-from torchx.workspace import Workspace
+from torchx.workspace import WorkspaceMixin
 
 
 GET_SCHEDULER_FACTORIES = "torchx.runner.api.get_scheduler_factories"
@@ -293,9 +293,9 @@ class RunnerTest(unittest.TestCase):
                 )
 
     def test_dryrun_with_workspace(self, _) -> None:
-        class TestScheduler(Scheduler, Workspace):
+        class TestScheduler(WorkspaceMixin[None], Scheduler):
             def __init__(self, build_new_img: bool):
-                Scheduler.__init__(self, backend="ignored", session_name="ignored")
+                super().__init__(backend="ignored", session_name="ignored")
                 self.build_new_img = build_new_img
 
             def schedule(self, dryrun_info: AppDryRunInfo) -> str:

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -62,7 +62,7 @@ class TestScheduler(Scheduler):
     def list(self) -> List[ListAppResponse]:
         raise NotImplementedError()
 
-    def run_opts(self) -> runopts:
+    def _run_opts(self) -> runopts:
         opts = runopts()
         opts.add(
             "i",

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -22,7 +22,7 @@ from torchx.specs import (
     RoleStatus,
     runopts,
 )
-from torchx.workspace.api import Workspace
+from torchx.workspace.api import WorkspaceMixin
 
 
 DAYS_IN_2_WEEKS = 14
@@ -138,7 +138,7 @@ class Scheduler(abc.ABC, Generic[T]):
         """
         if workspace:
             sched = self
-            assert isinstance(sched, Workspace)
+            assert isinstance(sched, WorkspaceMixin)
             role = app.roles[0]
             sched.build_workspace_and_update_role(role, workspace, cfg)
         dryrun_info = self.submit_dryrun(app, cfg)
@@ -189,6 +189,12 @@ class Scheduler(abc.ABC, Generic[T]):
         Returns the run configuration options expected by the scheduler.
         Basically a ``--help`` for the ``run`` API.
         """
+        opts = self._run_opts()
+        if isinstance(self, WorkspaceMixin):
+            opts.update(self.workspace_opts())
+        return opts
+
+    def _run_opts(self) -> runopts:
         return runopts()
 
     @abc.abstractmethod

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -38,7 +38,7 @@ from torchx.specs.api import (
     runopts,
     VolumeMount,
 )
-from torchx.workspace.docker_workspace import DockerWorkspace
+from torchx.workspace.docker_workspace import DockerWorkspaceMixin
 from typing_extensions import TypedDict
 
 
@@ -76,7 +76,7 @@ class DockerJob:
         return str(self)
 
 
-LABEL_VERSION: str = DockerWorkspace.LABEL_VERSION
+LABEL_VERSION: str = DockerWorkspaceMixin.LABEL_VERSION
 LABEL_APP_ID: str = "torchx.pytorch.org/app-id"
 LABEL_ROLE_NAME: str = "torchx.pytorch.org/role-name"
 LABEL_REPLICA_ID: str = "torchx.pytorch.org/replica-id"
@@ -98,7 +98,7 @@ class DockerOpts(TypedDict, total=False):
     copy_env: Optional[List[str]]
 
 
-class DockerScheduler(Scheduler[DockerOpts], DockerWorkspace):
+class DockerScheduler(DockerWorkspaceMixin, Scheduler[DockerOpts]):
     """
     DockerScheduler is a TorchX scheduling interface to Docker.
 
@@ -143,8 +143,7 @@ class DockerScheduler(Scheduler[DockerOpts], DockerWorkspace):
     """
 
     def __init__(self, session_name: str) -> None:
-        Scheduler.__init__(self, "docker", session_name)
-        DockerWorkspace.__init__(self)
+        super().__init__("docker", session_name)
 
     def _ensure_network(self) -> None:
         import filelock
@@ -346,7 +345,7 @@ class DockerScheduler(Scheduler[DockerOpts], DockerWorkspace):
         for container in containers:
             container.stop()
 
-    def run_opts(self) -> runopts:
+    def _run_opts(self) -> runopts:
         opts = runopts()
         opts.add(
             "copy_env",

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -573,7 +573,7 @@ class LocalScheduler(Scheduler[LocalOpts]):
         self._base_log_dir: Optional[str] = None
         self._created_tmp_log_dir: bool = False
 
-    def run_opts(self) -> runopts:
+    def _run_opts(self) -> runopts:
         opts = runopts()
         opts.add(
             "log_dir",

--- a/torchx/schedulers/lsf_scheduler.py
+++ b/torchx/schedulers/lsf_scheduler.py
@@ -440,7 +440,7 @@ class LsfScheduler(Scheduler[LsfOpts]):
     def __init__(self, session_name: str) -> None:
         super().__init__("lsf", session_name)
 
-    def run_opts(self) -> runopts:
+    def _run_opts(self) -> runopts:
         opts = runopts()
         opts.add(
             "lsf_queue",

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -29,7 +29,7 @@ from torchx.schedulers.api import (
 from torchx.schedulers.ids import make_unique
 from torchx.schedulers.ray.ray_common import RayActor, TORCHX_RANK0_HOST
 from torchx.specs import AppDef, macros, NONE, ReplicaStatus, Role, RoleStatus, runopts
-from torchx.workspace.dir_workspace import TmpDirWorkspace
+from torchx.workspace.dir_workspace import TmpDirWorkspaceMixin
 from typing_extensions import TypedDict
 
 
@@ -113,7 +113,7 @@ if _has_ray:
         requirements: Optional[str] = None
         actors: List[RayActor] = field(default_factory=list)
 
-    class RayScheduler(Scheduler[RayOpts], TmpDirWorkspace):
+    class RayScheduler(TmpDirWorkspaceMixin, Scheduler[RayOpts]):
         """
         RayScheduler is a TorchX scheduling interface to Ray. The job def
         workers will be launched as Ray actors
@@ -153,7 +153,7 @@ if _has_ray:
             super().__init__("ray", session_name)
 
         # TODO: Add address as a potential CLI argument after writing ray.status() or passing in config file
-        def run_opts(self) -> runopts:
+        def _run_opts(self) -> runopts:
             opts = runopts()
             opts.add(
                 "cluster_config_file",

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -41,7 +41,7 @@ from torchx.specs import (
     RoleStatus,
     runopts,
 )
-from torchx.workspace.dir_workspace import DirWorkspace
+from torchx.workspace.dir_workspace import DirWorkspaceMixin
 from typing_extensions import TypedDict
 
 SLURM_JOB_DIRS = ".torchxslurmjobdirs"
@@ -257,7 +257,7 @@ fi
 {self.materialize()}"""
 
 
-class SlurmScheduler(Scheduler[SlurmOpts], DirWorkspace):
+class SlurmScheduler(DirWorkspaceMixin, Scheduler[SlurmOpts]):
     """
     SlurmScheduler is a TorchX scheduling interface to slurm. TorchX expects
     that slurm CLI tools are locally installed and job accounting is enabled.
@@ -311,7 +311,7 @@ class SlurmScheduler(Scheduler[SlurmOpts], DirWorkspace):
                 Partial support. SlurmScheduler will return job and replica
                 status but does not provide the complete original AppSpec.
             workspaces: |
-                If ``job_dir`` is specified the DirWorkspace will create a new
+                If ``job_dir`` is specified the DirWorkspaceMixin will create a new
                 isolated directory with a snapshot of the workspace.
             mounts: false
             elasticity: false
@@ -323,7 +323,7 @@ class SlurmScheduler(Scheduler[SlurmOpts], DirWorkspace):
     def __init__(self, session_name: str) -> None:
         super().__init__("slurm", session_name)
 
-    def run_opts(self) -> runopts:
+    def _run_opts(self) -> runopts:
         opts = runopts()
         opts.add(
             "partition",

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -29,13 +29,13 @@ from torchx.specs.api import (
     Role,
     runopts,
 )
-from torchx.workspace.api import Workspace
+from torchx.workspace.api import WorkspaceMixin
 
 T = TypeVar("T")
 
 
 class SchedulerTest(unittest.TestCase):
-    class MockScheduler(Scheduler[T], Workspace):
+    class MockScheduler(Scheduler[T], WorkspaceMixin[None]):
         def __init__(self, session_name: str) -> None:
             super().__init__("mock", session_name)
 
@@ -73,7 +73,7 @@ class SchedulerTest(unittest.TestCase):
         def list(self) -> List[ListAppResponse]:
             return []
 
-        def run_opts(self) -> runopts:
+        def _run_opts(self) -> runopts:
             opts = runopts()
             opts.add("foo", type_=str, required=True, help="required option")
             return opts

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -892,6 +892,9 @@ class runopts:
 
         self._opts[cfg_key] = runopt(default, type_, required, help)
 
+    def update(self, other: "runopts") -> None:
+        self._opts.update(other._opts)
+
     def __repr__(self) -> str:
         required = [(key, opt) for key, opt in self._opts.items() if opt.is_required]
         optional = [

--- a/torchx/workspace/__init__.py
+++ b/torchx/workspace/__init__.py
@@ -20,4 +20,4 @@ Example workspace paths:
     * ``memory://foo-bar/`` an in-memory workspace for notebook/programmatic usage
 """
 
-from torchx.workspace.api import walk_workspace, Workspace  # noqa: F401
+from torchx.workspace.api import walk_workspace, WorkspaceMixin  # noqa: F401

--- a/torchx/workspace/dir_workspace.py
+++ b/torchx/workspace/dir_workspace.py
@@ -13,10 +13,10 @@ from typing import Mapping
 
 import fsspec
 from torchx.specs import CfgVal, Role
-from torchx.workspace.api import walk_workspace, Workspace
+from torchx.workspace.api import walk_workspace, WorkspaceMixin
 
 
-class TmpDirWorkspace(Workspace):
+class TmpDirWorkspaceMixin(WorkspaceMixin[None]):
     def build_workspace_and_update_role(
         self, role: Role, workspace: str, cfg: Mapping[str, CfgVal]
     ) -> None:
@@ -31,7 +31,7 @@ class TmpDirWorkspace(Workspace):
         role.image = job_dir
 
 
-class DirWorkspace(Workspace):
+class DirWorkspaceMixin(WorkspaceMixin[None]):
     def build_workspace_and_update_role(
         self, role: Role, workspace: str, cfg: Mapping[str, CfgVal]
     ) -> None:

--- a/torchx/workspace/test/dir_workspace_test.py
+++ b/torchx/workspace/test/dir_workspace_test.py
@@ -12,12 +12,16 @@ import unittest
 
 import fsspec
 from torchx.specs import Role
-from torchx.workspace.dir_workspace import _copy_to_dir, DirWorkspace, TmpDirWorkspace
+from torchx.workspace.dir_workspace import (
+    _copy_to_dir,
+    DirWorkspaceMixin,
+    TmpDirWorkspaceMixin,
+)
 
 
 class DirWorkspaceTest(unittest.TestCase):
     def test_build_workspace_no_job_dir(self) -> None:
-        w = DirWorkspace()
+        w = DirWorkspaceMixin()
         role = Role(
             name="role",
             image="blah",
@@ -27,7 +31,7 @@ class DirWorkspaceTest(unittest.TestCase):
         self.assertEqual(role.image, "blah")
 
     def test_build_workspace(self) -> None:
-        w = DirWorkspace()
+        w = DirWorkspaceMixin()
         role = Role(
             name="role",
             image="blah",
@@ -108,7 +112,7 @@ class DirWorkspaceTest(unittest.TestCase):
 
 class TmpDirWorkspaceTest(unittest.TestCase):
     def test_build_workspace(self) -> None:
-        w = TmpDirWorkspace()
+        w = TmpDirWorkspaceMixin()
         role = Role(
             name="role",
             image="blah",


### PR DESCRIPTION
<!-- Change Summary -->

This makes a few changes intended to make it easier to swap out the workspace implementation for schedulers that support multiple image runtimes. I.e. LSF and Slurm support Docker, Singularity, native, etc

* This adds a new `workspace_opts` so we can keep runopts attached to the workspace
* This standardizes the `dryrun_push_images` and `push_images` that were used in DockerWorkspace so we can swap the workspace without running into any type issues.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Refactor -- no functional changes. Existing tests/CI should suffice
