### PR TITLE
Remove tests for passed methods

### DIFF
--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -65,11 +65,6 @@ class AWSBatchSchedulerTest(unittest.TestCase):
         scheduler = create_scheduler("foo")
         self.assertIsInstance(scheduler, AWSBatchScheduler)
 
-    def test_validate(self) -> None:
-        scheduler = create_scheduler("test")
-        app = _test_app()
-        scheduler._validate(app, "kubernetes")
-
     def test_submit_dryrun_with_share_id(self) -> None:
         scheduler = create_scheduler("test")
         app = _test_app()

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -206,11 +206,6 @@ class KubernetesSchedulerTest(unittest.TestCase):
             want,
         )
 
-    def test_validate(self) -> None:
-        scheduler = create_scheduler("test")
-        app = _test_app()
-        scheduler._validate(app, "kubernetes")
-
     def test_cleanup_str(self) -> None:
         self.assertEqual("abcd123", cleanup_str("abcd123"))
         self.assertEqual("abcd123", cleanup_str("-/_a/b/CD!123!"))


### PR DESCRIPTION
Summary: _validate() is passed/not implemented for kubernetes and aws batch scheduler. Tests are probably a residue of copy/paste. So removing them

Reviewed By: kurman

Differential Revision: D40353739

