### PR TITLE
GCP Batch Integration: launch jobs directly on GCP Batch

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,8 @@ boto3==1.20.24
 captum>=0.4.0
 flake8==3.9.0
 fsspec[s3]==2022.1.0
+google-cloud-batch>=0.3.1
+google-cloud-runtimeconfig>=0.33.2
 hydra-core
 ipython
 kfp==1.8.9

--- a/docs/source/schedulers/kubernetes.rst
+++ b/docs/source/schedulers/kubernetes.rst
@@ -17,7 +17,6 @@ Reference
 
 .. autofunction:: create_scheduler
 .. autofunction:: app_to_resource
-.. autofunction:: cleanup_str
 .. autofunction:: pod_labels
 .. autofunction:: role_to_pod
 .. autofunction:: sanitize_for_serialization

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -18,6 +18,7 @@ DEFAULT_SCHEDULER_MODULES: Mapping[str, str] = {
     "slurm": "torchx.schedulers.slurm_scheduler",
     "kubernetes": "torchx.schedulers.kubernetes_scheduler",
     "aws_batch": "torchx.schedulers.aws_batch_scheduler",
+    "gcp_batch": "torchx.schedulers.gcp_batch_scheduler",
     "ray": "torchx.schedulers.ray_scheduler",
     "lsf": "torchx.schedulers.lsf_scheduler",
 }

--- a/torchx/schedulers/gcp_batch_scheduler.py
+++ b/torchx/schedulers/gcp_batch_scheduler.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+
+This contains the TorchX GCP Batch scheduler which can be used to run TorchX
+components directly on GCP Batch.
+
+This scheduler is in prototype stage and may change without notice.
+
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, TYPE_CHECKING
+
+import torchx
+import yaml
+
+from torchx.schedulers.api import (
+    AppDryRunInfo,
+    DescribeAppResponse,
+    ListAppResponse,
+    Scheduler,
+    Stream,
+)
+from torchx.schedulers.ids import make_unique
+from torchx.specs.api import AppDef, AppState, macros, runopts
+from torchx.util.strings import normalize_str
+from typing_extensions import TypedDict
+
+
+if TYPE_CHECKING:
+    from google.cloud import batch_v1
+
+
+JOB_STATE: Dict[str, AppState] = {
+    "STATE_UNSPECIFIED": AppState.UNKNOWN,
+    "QUEUED": AppState.SUBMITTED,
+    "SCHEDULED": AppState.PENDING,
+    "RUNNING": AppState.RUNNING,
+    "SUCCEEDED": AppState.SUCCEEDED,
+    "FAILED": AppState.FAILED,
+    "DELETION_IN_PROGRESS": AppState.UNKNOWN,
+}
+
+LABEL_VERSION: str = "torchx_version"
+LABEL_APP_NAME: str = "torchx_app_name"
+
+DEFAULT_LOC: str = "us-central1"
+
+DEFAULT_GPU_TYPE = "nvidia-tesla-v100"
+DEFAULT_GPU_MACHINE_TYPE = "n1-standard-8"
+
+
+@dataclass
+class GCPBatchJob:
+    name: str
+    project: str
+    location: str
+    job_def: "batch_v1.Job"
+
+    def __str__(self) -> str:
+        return yaml.dump(self.job_def)
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class GCPBatchOpts(TypedDict, total=False):
+    project: Optional[str]
+    location: Optional[str]
+
+
+class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
+    """
+    GCPBatchScheduler is a TorchX scheduling interface to GCP Batch.
+
+    .. code-block:: bash
+
+        $ pip install torchx
+        $ torchx run --scheduler gcp_batch utils.echo --msg hello
+        gcp_batch://torchx_user/1234
+        $ torchx status gcp_batch://torchx_user/1234
+        ...
+
+    Authentication is loaded from the environment using the gcloud credential handling.
+
+    **Config Options**
+
+    .. runopts::
+        class: torchx.schedulers.gcp_batch_scheduler.create_scheduler
+
+    **Compatibility**
+
+    .. compatibility::
+        type: scheduler
+        features:
+            describe: |
+                Partial support. GCPBatchScheduler will return job status
+                but does not provide the complete original AppSpec.
+
+    """
+
+    def __init__(
+        self,
+        session_name: str,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        client: Optional[Any] = None,
+    ) -> None:
+        Scheduler.__init__(self, "gcp_batch", session_name)
+        # pyre-fixme[4]: Attribute annotation cannot be `Any`.
+        self.__client = client
+
+    @property
+    # pyre-fixme[3]: Return annotation cannot be `Any`.
+    def _client(self) -> Any:
+        from google.cloud import batch_v1
+
+        c = self.__client
+        if c is None:
+            c = self.__client = batch_v1.BatchServiceClient()
+        return c
+
+    def schedule(self, dryrun_info: AppDryRunInfo[GCPBatchJob]) -> str:
+        from google.cloud import batch_v1
+
+        req = dryrun_info.request
+        assert req is not None, f"{dryrun_info} missing request"
+
+        request = batch_v1.CreateJobRequest(
+            parent=f"projects/{req.project}/locations/{req.location}",
+            job=req.job_def,
+            job_id=req.name,
+        )
+
+        response = self._client.create_job(request=request)
+        return f"{req.project}:{req.location}:{req.name}"
+
+    def _app_to_job(self, app: AppDef) -> "batch_v1.Job":
+        from google.cloud import batch_v1
+
+        name = normalize_str(make_unique(app.name))
+
+        taskGroups = []
+        allocationPolicy = None
+
+        # 1. Convert role to task
+        # TODO implement retry_policy, mount conversion
+        # NOTE: Supports only one role for now as GCP Batch supports only one TaskGroup
+        # which is ok to start with as most components have only one role
+        for role_idx, role in enumerate(app.roles):
+            values = macros.Values(
+                img_root="",
+                app_id=name,
+                replica_id=str(0),
+                # TODO set value for rank0_env: TORCHX_RANK0_HOST is a place holder for now
+                rank0_env=("TORCHX_RANK0_HOST"),
+            )
+            role_dict = values.apply(role)
+            role_dict.env["TORCHX_ROLE_IDX"] = str(role_idx)
+            role_dict.env["TORCHX_ROLE_NAME"] = str(role.name)
+
+            resource = role_dict.resource
+            res = batch_v1.ComputeResource()
+            cpu = resource.cpu
+            if cpu <= 0:
+                cpu = 1
+            MILLI = 1000
+            # pyre-ignore [8] : pyre gets confused even when types on both sides of = are int
+            res.cpu_milli = cpu * MILLI
+            memMB = resource.memMB
+            if memMB < 0:
+                raise ValueError(
+                    f"memMB should to be set to a positive value, got {memMB}"
+                )
+            # pyre-ignore [8] : pyre gets confused even when types on both sides of = are int
+            res.memory_mib = memMB
+
+            # TODO support named resources
+            # Using v100 as default GPU type as a100 does not allow changing count for now
+            # TODO See if there is a better default GPU type
+            if resource.gpu > 0:
+                allocationPolicy = batch_v1.AllocationPolicy(
+                    instances=[
+                        batch_v1.AllocationPolicy.InstancePolicyOrTemplate(
+                            policy=batch_v1.AllocationPolicy.InstancePolicy(
+                                machine_type=DEFAULT_GPU_MACHINE_TYPE,
+                                accelerators=[
+                                    batch_v1.AllocationPolicy.Accelerator(
+                                        type_=DEFAULT_GPU_TYPE,
+                                        count=resource.gpu,
+                                    )
+                                ],
+                            )
+                        )
+                    ],
+                )
+                print(f"Using {resource.gpu} GPUs of type {DEFAULT_GPU_TYPE}")
+
+            runnable = batch_v1.Runnable(
+                container=batch_v1.Runnable.Container(
+                    image_uri=role_dict.image,
+                    commands=[role_dict.entrypoint] + role_dict.args,
+                    entrypoint="",
+                )
+            )
+
+            ts = batch_v1.TaskSpec(
+                runnables=[runnable],
+                environments=role_dict.env,
+                max_retry_count=role_dict.max_retries,
+                compute_resource=res,
+            )
+
+            tg = batch_v1.TaskGroup(
+                task_spec=ts,
+                task_count=role_dict.num_replicas,
+                require_hosts_file=True,
+            )
+            taskGroups.append(tg)
+
+        # 2. Convert AppDef to Job
+        job = batch_v1.Job(
+            name=name,
+            task_groups=taskGroups,
+            allocation_policy=allocationPolicy,
+            logs_policy=batch_v1.LogsPolicy(
+                destination=batch_v1.LogsPolicy.Destination.CLOUD_LOGGING,
+            ),
+            # NOTE: GCP Batch does not allow label names with "."
+            labels={
+                LABEL_VERSION: torchx.__version__.replace(".", "-"),
+                LABEL_APP_NAME: name,
+            },
+        )
+        return job
+
+    def _submit_dryrun(
+        self, app: AppDef, cfg: GCPBatchOpts
+    ) -> AppDryRunInfo[GCPBatchJob]:
+        from google.cloud import runtimeconfig
+
+        proj = cfg.get("project")
+        if proj is None:
+            proj = runtimeconfig.Client().project
+        assert proj is not None and isinstance(proj, str), "project must be a str"
+
+        loc = cfg.get("location")
+        assert loc is not None and isinstance(loc, str), "location must be a str"
+
+        job = self._app_to_job(app)
+
+        # Convert JobDef + BatchOpts to GCPBatchJob
+        req = GCPBatchJob(
+            name=str(job.name),
+            project=proj,
+            location=loc,
+            job_def=job,
+        )
+
+        info = AppDryRunInfo(req, repr)
+        info._app = app
+        # pyre-fixme: AppDryRunInfo
+        info._cfg = cfg
+        return info
+
+    def run_opts(self) -> runopts:
+        opts = runopts()
+        opts.add("project", type_=str, help="Name of the GCP project")
+        opts.add(
+            "location",
+            type_=str,
+            default=DEFAULT_LOC,
+            help="Name of the location to schedule the job in",
+        )
+        return opts
+
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        from google.cloud import batch_v1
+
+        # 1. get project, location, job name from app_id
+        proj, loc, name = app_id.split(":")
+
+        # 2. Get the Batch job
+        request = batch_v1.GetJobRequest(
+            name=f"projects/{proj}/locations/{loc}/jobs/{name}",
+        )
+        job = self._client.get_job(request=request)
+
+        # 3. Map job -> DescribeAppResponse
+        # TODO map job taskGroup to Role, map env vars etc
+        return DescribeAppResponse(
+            app_id=app_id,
+            state=JOB_STATE[job.status.state.name],
+        )
+
+    def log_iter(
+        self,
+        app_id: str,
+        role_name: str,
+        k: int = 0,
+        regex: Optional[str] = None,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+        should_tail: bool = False,
+        streams: Optional[Stream] = None,
+    ) -> Iterable[str]:
+        raise NotImplementedError()
+
+    def list(self) -> List[ListAppResponse]:
+        # Create ListJobsRequest with parent str
+        # Use list_job api
+        # map ListJobsPager response to ListAppResponse and return it
+        raise NotImplementedError()
+
+    def _validate(self, app: AppDef, scheduler: str) -> None:
+        # Skip validation step
+        pass
+
+    def _cancel_existing(self, app_id: str) -> None:
+        # 1.create DeleteJobRequest
+        # get job name from app_id
+        # use cancel reason - killed via torchX
+        # 2. Submit request
+        raise NotImplementedError()
+
+
+def create_scheduler(session_name: str, **kwargs: object) -> GCPBatchScheduler:
+    return GCPBatchScheduler(
+        session_name=session_name,
+    )

--- a/torchx/schedulers/test/gcp_batch_scheduler_test.py
+++ b/torchx/schedulers/test/gcp_batch_scheduler_test.py
@@ -1,0 +1,176 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from contextlib import contextmanager
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import torchx
+from torchx import specs
+from torchx.schedulers.gcp_batch_scheduler import (
+    create_scheduler,
+    GCPBatchOpts,
+    GCPBatchScheduler,
+    LABEL_APP_NAME,
+    LABEL_VERSION,
+)
+
+
+def _test_app() -> specs.AppDef:
+    trainer_role = specs.Role(
+        name="trainer",
+        image="pytorch/torchx:latest",
+        entrypoint="main",
+        args=[
+            "--output-path",
+            specs.macros.img_root,
+            "--app-id",
+            specs.macros.app_id,
+            "--rank0_env",
+            specs.macros.rank0_env,
+        ],
+        env={"FOO": "bar"},
+        resource=specs.Resource(
+            cpu=2,
+            memMB=3000,
+            gpu=4,
+        ),
+        num_replicas=1,
+        max_retries=3,
+    )
+    return specs.AppDef("test", roles=[trainer_role])
+
+
+@contextmanager
+def mock_rand() -> Generator[None, None, None]:
+    with patch("torchx.schedulers.gcp_batch_scheduler.make_unique") as make_unique_ctx:
+        make_unique_ctx.return_value = "app-name-42"
+        yield
+
+
+class GCPBatchSchedulerTest(unittest.TestCase):
+    def test_create_scheduler(self) -> None:
+        scheduler = create_scheduler("foo")
+        self.assertIsInstance(scheduler, GCPBatchScheduler)
+
+    @mock_rand()
+    def test_submit_dryrun(self) -> None:
+        from google.cloud import batch_v1
+
+        scheduler = create_scheduler("test")
+        app = _test_app()
+        proj = "test-proj"
+        loc = "us-west-1"
+        cfg = GCPBatchOpts(project=proj, location=loc)
+        info = scheduler._submit_dryrun(app, cfg)
+
+        req = info.request
+        self.assertEqual(req.project, proj)
+        self.assertEqual(req.location, loc)
+
+        name = "app-name-42"
+        env = {}
+        env["TORCHX_ROLE_IDX"] = "0"
+        env["TORCHX_ROLE_NAME"] = "trainer"
+        env["FOO"] = "bar"
+        res = batch_v1.ComputeResource()
+        # pyre-ignore [8] : pyre gets confused even when types on both sides of = are int
+        res.cpu_milli = 2000
+        # pyre-ignore [8] : pyre gets confused even when types on both sides of = are int
+        res.memory_mib = 3000
+        allocationPolicy = batch_v1.AllocationPolicy(
+            instances=[
+                batch_v1.AllocationPolicy.InstancePolicyOrTemplate(
+                    policy=batch_v1.AllocationPolicy.InstancePolicy(
+                        machine_type="n1-standard-8",
+                        accelerators=[
+                            batch_v1.AllocationPolicy.Accelerator(
+                                type_="nvidia-tesla-v100",
+                                count=4,
+                            )
+                        ],
+                    )
+                )
+            ],
+        )
+        runnable = batch_v1.Runnable(
+            container=batch_v1.Runnable.Container(
+                image_uri="pytorch/torchx:latest",
+                commands=[
+                    "main",
+                    "--output-path",
+                    "",
+                    "--app-id",
+                    "app-name-42",
+                    "--rank0_env",
+                    "TORCHX_RANK0_HOST",
+                ],
+            )
+        )
+        ts = batch_v1.TaskSpec(
+            runnables=[runnable],
+            environments=env,
+            max_retry_count=3,
+            compute_resource=res,
+        )
+        taskGroups = []
+        tg = batch_v1.TaskGroup(
+            task_spec=ts,
+            task_count=1,
+            require_hosts_file=True,
+        )
+        taskGroups.append(tg)
+        expected_job_def = batch_v1.Job(
+            name=name,
+            task_groups=taskGroups,
+            allocation_policy=allocationPolicy,
+            logs_policy=batch_v1.LogsPolicy(
+                destination=batch_v1.LogsPolicy.Destination.CLOUD_LOGGING,
+            ),
+            labels={
+                LABEL_VERSION: torchx.__version__.replace(".", "-"),
+                LABEL_APP_NAME: name,
+            },
+        )
+
+        self.assertEqual(req.job_def, expected_job_def)
+
+    def _mock_scheduler(self) -> GCPBatchScheduler:
+        from google.cloud import batch_v1
+
+        scheduler = GCPBatchScheduler("test", client=MagicMock())
+        scheduler._client.get_job.return_value = batch_v1.Job(
+            name="projects/pytorch-ecosystem-gcp/locations/us-central1/jobs/app-name-42",
+            uid="j-82c8495f-8cc9-443c-9e33-4904fcb1test",
+            status=batch_v1.JobStatus(
+                state=batch_v1.JobStatus.State.SUCCEEDED,
+            ),
+        )
+        return scheduler
+
+    @mock_rand()
+    def test_submit(self) -> None:
+        scheduler = self._mock_scheduler()
+        app = _test_app()
+        cfg = GCPBatchOpts(
+            project="test-proj",
+        )
+        # pyre-fixme: GCPBatchOpts type passed to resolve
+        resolved_cfg = scheduler.run_opts().resolve(cfg)
+        # pyre-fixme: _submit_dryrun expects GCPBatchOpts
+        info = scheduler._submit_dryrun(app, resolved_cfg)
+        id = scheduler.schedule(info)
+        self.assertEqual(id, "test-proj:us-central1:app-name-42")
+        self.assertEqual(scheduler._client.create_job.call_count, 1)
+
+    def test_describe_status(self) -> None:
+        scheduler = self._mock_scheduler()
+        app_id = "test-proj:us-central1:app-name-42"
+        status = scheduler.describe(app_id)
+        self.assertIsNotNone(status)
+        self.assertEqual(status.state, specs.AppState.SUCCEEDED)
+        self.assertEqual(status.app_id, app_id)

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -19,7 +19,6 @@ from torchx.schedulers.api import AppDryRunInfo, DescribeAppResponse, ListAppRes
 from torchx.schedulers.docker_scheduler import has_docker
 from torchx.schedulers.kubernetes_scheduler import (
     app_to_resource,
-    cleanup_str,
     create_scheduler,
     KubernetesJob,
     KubernetesOpts,
@@ -205,12 +204,6 @@ class KubernetesSchedulerTest(unittest.TestCase):
             pod,
             want,
         )
-
-    def test_cleanup_str(self) -> None:
-        self.assertEqual("abcd123", cleanup_str("abcd123"))
-        self.assertEqual("abcd123", cleanup_str("-/_a/b/CD!123!"))
-        self.assertEqual("a-bcd123", cleanup_str("-a-bcd123"))
-        self.assertEqual("", cleanup_str("!!!"))
 
     def test_submit_dryrun(self) -> None:
         scheduler = create_scheduler("test")

--- a/torchx/util/strings.py
+++ b/torchx/util/strings.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+
+
+def normalize_str(data: str) -> str:
+    """
+    Invokes ``lower`` on thes string and removes all
+    characters that do not satisfy ``[a-z0-9]`` pattern.
+    This method is mostly used to make sure kubernetes and gcp_batch scheduler gets
+    the job name that does not violate its restrictions.
+    """
+    if data.startswith("-"):
+        data = data[1:]
+    pattern = r"[a-z0-9\-]"
+    return "".join(re.findall(pattern, data.lower()))

--- a/torchx/util/test/strings_test.py
+++ b/torchx/util/test/strings_test.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from torchx.util.strings import normalize_str
+
+
+class StringsTest(unittest.TestCase):
+    def test_normalize_str(self) -> None:
+        self.assertEqual("abcd123", normalize_str("abcd123"))
+        self.assertEqual("abcd123", normalize_str("-/_a/b/CD!123!"))
+        self.assertEqual("a-bcd123", normalize_str("-a-bcd123"))
+        self.assertEqual("", normalize_str("!!!"))


### PR DESCRIPTION
Support directly scheduling jobs on GCP Batch

- Native support for launching Pytorch jobs on GCP: Currently you could use TorchX to launch training jobs on Kubernetes on GCP for which you need to set up Kube clusters etc, or use GCP managed services like Vertex AI. With this integration, the overhead to setup other services goes away and customers can directly launch their training jobs from TorchX on GCP schedulers. 
- Cloud agnostic interface: In addition to current Pytorch customers using GCP, this adds flexibility for customers using one cloud provider to explore others as this adds the ability to easily migrate their Pytorch jobs from one platform to another. 

Addresses https://github.com/pytorch/torchx/issues/410 

Test plan:
Unit tests 
![Screen Shot 2022-10-18 at 12 30 38 PM](https://user-images.githubusercontent.com/87679608/196532219-8da3df5c-3053-4800-9cc3-8b2f4c52acea.png)
