### PR TITLE
torchx: use importlib_metadata for Python 3.10+ syntax

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,6 @@ classy-vision>=0.6.0
 flake8==3.9.0
 fsspec[s3]==2022.1.0
 hydra-core
-importlib-metadata<5.0
 ipython
 kfp==1.8.9
 moto==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pyre-extensions
 docstring-parser==0.8.1
+importlib-metadata
 pyyaml
 docker
 filelock

--- a/setup.py
+++ b/setup.py
@@ -79,9 +79,6 @@ if __name__ == "__main__":
             "kubernetes": ["kubernetes>=11"],
             "ray": ["ray>=1.12.1"],
             "dev": dev_reqs,
-            ':python_version < "3.8"': [
-                "importlib-metadata",
-            ],
         },
         # PyPI package information.
         classifiers=[

--- a/torchx/util/test/entrypoints_test.py
+++ b/torchx/util/test/entrypoints_test.py
@@ -5,14 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-
-try:
-    from importlib.metadata import EntryPoint
-except ImportError:
-    from importlib_metadata import EntryPoint
 from configparser import ConfigParser
-from typing import Dict, List
+from typing import List
 from unittest.mock import MagicMock, patch
+
+from importlib_metadata import EntryPoint, EntryPoints
 
 from torchx.util.entrypoints import load, load_group
 
@@ -61,12 +58,12 @@ _EP_GRP_IGN_MOD_TXT: str = """
 [ep.grp.missing.mod.test]
 baz = torchx.util.test.entrypoints_test.missing_module
 """
-_ENTRY_POINTS: Dict[str, List[EntryPoint]] = {
-    "entrypoints.test": EntryPoint_from_text(_EP_TXT),
-    "ep.grp.test": EntryPoint_from_text(_EP_GRP_TXT),
-    "ep.grp.missing.attr.test": EntryPoint_from_text(_EP_GRP_IGN_ATTR_TXT),
-    "ep.grp.missing.mod.test": EntryPoint_from_text(_EP_GRP_IGN_MOD_TXT),
-}
+_ENTRY_POINTS: EntryPoints = EntryPoints(
+    EntryPoint_from_text(_EP_TXT)
+    + EntryPoint_from_text(_EP_GRP_TXT)
+    + EntryPoint_from_text(_EP_GRP_IGN_ATTR_TXT)
+    + EntryPoint_from_text(_EP_GRP_IGN_MOD_TXT)
+)
 
 _METADATA_EPS: str = "torchx.util.entrypoints.metadata.entry_points"
 
@@ -77,6 +74,9 @@ class EntryPointsTest(unittest.TestCase):
         print(type(load("entrypoints.test", "foo")))
         self.assertEqual("foobar", load("entrypoints.test", "foo")())
 
+        with self.assertRaisesRegex(KeyError, "baz"):
+            load("entrypoints.test", "baz")()
+
     @patch(_METADATA_EPS, return_value=_ENTRY_POINTS)
     def test_load_with_default(self, mock_md_eps: MagicMock) -> None:
         self.assertEqual("barbaz", load("entrypoints.test", "missing", barbaz)())
@@ -86,7 +86,7 @@ class EntryPointsTest(unittest.TestCase):
     @patch(_METADATA_EPS, return_value=_ENTRY_POINTS)
     def test_load_group(self, mock_md_eps: MagicMock) -> None:
         eps = load_group("ep.grp.test")
-        self.assertEqual(2, len(eps))
+        self.assertEqual(2, len(eps), eps)
         self.assertEqual("foobar", eps["foo"]())
         self.assertEqual("barbaz", eps["bar"]())
 


### PR DESCRIPTION
<!-- Change Summary -->

importlib.metadata in 3.12 breaks compatibility with the dict style interface. This switches TorchX to use importlib_metadata for all versions and switches the code to use the 3.10+ select style interface instead of dict.

This avoids having to pin importlib_metadata<5 such as in https://github.com/pytorch/tutorials/pull/2091

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Unit tests on both importlib_metadata 5.0 and 4.1.3