### PR TITLE
Speed up macOS actions by using larger instance

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -14,7 +14,7 @@ jobs:
         platform: [ubuntu-18.04]
         include:
           - python-version: 3.9
-            platform: macos-latest
+            platform: macos-12-xl
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Summary: Switch to managed macos-12-xl to speed up macos unittests.

Differential Revision: D40562764

