### PR TITLE
(torchx/resources) Add g4d, g5, p4d, p3 (rest of them), and trn1 types

### DIFF
--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -33,61 +33,152 @@ from typing import Callable, Mapping
 
 from torchx.specs.api import Resource
 
+K8S_ITYPE = "node.kubernetes.io/instance-type"
 GiB: int = 1024
 
 
 def aws_p3_2xlarge() -> Resource:
     return Resource(
-        cpu=8,
-        gpu=1,
-        memMB=61 * GiB,
-        capabilities={
-            "node.kubernetes.io/instance-type": "p3.2xlarge",
-        },
+        cpu=8, gpu=1, memMB=61 * GiB, capabilities={K8S_ITYPE: "p3.2xlarge"}
     )
 
 
 def aws_p3_8xlarge() -> Resource:
     return Resource(
-        cpu=32,
-        gpu=4,
-        memMB=244 * GiB,
-        capabilities={
-            "node.kubernetes.io/instance-type": "p3.8xlarge",
-        },
+        cpu=32, gpu=4, memMB=244 * GiB, capabilities={K8S_ITYPE: "p3.8xlarge"}
+    )
+
+
+def aws_p3_16xlarge() -> Resource:
+    return Resource(
+        cpu=64, gpu=8, memMB=488 * GiB, capabilities={K8S_ITYPE: "p3.16xlarge"}
+    )
+
+
+def aws_p3dn_24xlarge() -> Resource:
+    return Resource(
+        cpu=96, gpu=8, memMB=768 * GiB, capabilities={K8S_ITYPE: "p3dn.24xlarge"}
+    )
+
+
+def aws_p4d_24xlarge() -> Resource:
+    return Resource(
+        cpu=96, gpu=8, memMB=1152 * GiB, capabilities={K8S_ITYPE: "p4d.24xlarge"}
+    )
+
+
+def aws_p4de_24xlarge() -> Resource:
+    # p4de has same cpu, gpu, memMB as p4d but gpu memory is 2x (32GB vs 64GB per GPU)
+    return Resource(
+        cpu=96, gpu=8, memMB=1152 * GiB, capabilities={K8S_ITYPE: "p4de.24xlarge"}
     )
 
 
 def aws_t3_medium() -> Resource:
-    return Resource(
-        cpu=2,
-        gpu=0,
-        memMB=4 * GiB,
-        capabilities={
-            "node.kubernetes.io/instance-type": "t3.medium",
-        },
-    )
+    return Resource(cpu=2, gpu=0, memMB=4 * GiB, capabilities={K8S_ITYPE: "t3.medium"})
 
 
 def aws_m5_2xlarge() -> Resource:
     return Resource(
-        cpu=8,
-        gpu=0,
-        memMB=32 * GiB,
-        capabilities={
-            "node.kubernetes.io/instance-type": "m5.2xlarge",
-        },
+        cpu=8, gpu=0, memMB=32 * GiB, capabilities={K8S_ITYPE: "m5.2xlarge"}
     )
 
 
 def aws_g4dn_xlarge() -> Resource:
     return Resource(
-        cpu=4,
-        gpu=1,
-        memMB=16 * GiB,
-        capabilities={
-            "node.kubernetes.io/instance-type": "g4dn.xlarge",
-        },
+        cpu=4, gpu=1, memMB=16 * GiB, capabilities={K8S_ITYPE: "g4dn.xlarge"}
+    )
+
+
+def aws_g4dn_2xlarge() -> Resource:
+    return Resource(
+        cpu=8, gpu=1, memMB=32 * GiB, capabilities={K8S_ITYPE: "g4dn.2xlarge"}
+    )
+
+
+def aws_g4dn_4xlarge() -> Resource:
+    return Resource(
+        cpu=16, gpu=1, memMB=64 * GiB, capabilities={K8S_ITYPE: "g4dn.4xlarge"}
+    )
+
+
+def aws_g4dn_8xlarge() -> Resource:
+    return Resource(
+        cpu=32, gpu=1, memMB=128 * GiB, capabilities={K8S_ITYPE: "g4dn.8xlarge"}
+    )
+
+
+def aws_g4dn_16xlarge() -> Resource:
+    return Resource(
+        cpu=64, gpu=1, memMB=256 * GiB, capabilities={K8S_ITYPE: "g4dn.16xlarge"}
+    )
+
+
+def aws_g4dn_12xlarge() -> Resource:
+    return Resource(
+        cpu=48, gpu=4, memMB=192 * GiB, capabilities={K8S_ITYPE: "g4dn.12xlarge"}
+    )
+
+
+def aws_g4dn_metal() -> Resource:
+    return Resource(
+        cpu=96, gpu=8, memMB=384 * GiB, capabilities={K8S_ITYPE: "g4dn.metal"}
+    )
+
+
+def aws_g5_xlarge() -> Resource:
+    return Resource(cpu=4, gpu=1, memMB=16 * GiB, capabilities={K8S_ITYPE: "g5.xlarge"})
+
+
+def aws_g5_2xlarge() -> Resource:
+    return Resource(
+        cpu=8, gpu=1, memMB=32 * GiB, capabilities={K8S_ITYPE: "g5.2xlarge"}
+    )
+
+
+def aws_g5_4xlarge() -> Resource:
+    return Resource(
+        cpu=16, gpu=1, memMB=64 * GiB, capabilities={K8S_ITYPE: "g5.4xlarge"}
+    )
+
+
+def aws_g5_8xlarge() -> Resource:
+    return Resource(
+        cpu=32, gpu=1, memMB=128 * GiB, capabilities={K8S_ITYPE: "g5.8xlarge"}
+    )
+
+
+def aws_g5_16xlarge() -> Resource:
+    return Resource(
+        cpu=64, gpu=1, memMB=256 * GiB, capabilities={K8S_ITYPE: "g5.16xlarge"}
+    )
+
+
+def aws_g5_12xlarge() -> Resource:
+    return Resource(
+        cpu=48, gpu=4, memMB=192 * GiB, capabilities={K8S_ITYPE: "g5.12xlarge"}
+    )
+
+
+def aws_g5_24xlarge() -> Resource:
+    return Resource(
+        cpu=96, gpu=4, memMB=384 * GiB, capabilities={K8S_ITYPE: "g5.24xlarge"}
+    )
+
+
+def aws_g5_48xlarge() -> Resource:
+    return Resource(
+        cpu=192, gpu=8, memMB=768 * GiB, capabilities={K8S_ITYPE: "g5.48xlarge"}
+    )
+
+
+def aws_trn1_2xl() -> Resource:
+    return Resource(cpu=8, gpu=0, memMB=32 * GiB, capabilities={K8S_ITYPE: "trn1.2xl"})
+
+
+def aws_trn1_32xl() -> Resource:
+    return Resource(
+        cpu=128, gpu=0, memMB=512 * GiB, capabilities={K8S_ITYPE: "trn1.32xl"}
     )
 
 
@@ -96,5 +187,23 @@ NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = {
     "aws_m5.2xlarge": aws_m5_2xlarge,
     "aws_p3.2xlarge": aws_p3_2xlarge,
     "aws_p3.8xlarge": aws_p3_8xlarge,
+    "aws_p3.16xlarge": aws_p3_16xlarge,
+    "aws_p3dn.24xlarge": aws_p3dn_24xlarge,
     "aws_g4dn.xlarge": aws_g4dn_xlarge,
+    "aws_g4dn.2xlarge": aws_g4dn_2xlarge,
+    "aws_g4dn.4xlarge": aws_g4dn_4xlarge,
+    "aws_g4dn.8xlarge": aws_g4dn_8xlarge,
+    "aws_g4dn.16xlarge": aws_g4dn_16xlarge,
+    "aws_g4dn.12xlarge": aws_g4dn_12xlarge,
+    "aws_g4dn.metal": aws_g4dn_metal,
+    "aws_g5.xlarge": aws_g5_xlarge,
+    "aws_g5.2xlarge": aws_g5_2xlarge,
+    "aws_g5.4xlarge": aws_g5_4xlarge,
+    "aws_g5.8xlarge": aws_g5_8xlarge,
+    "aws_g5.16xlarge": aws_g5_16xlarge,
+    "aws_g5.12xlarge": aws_g5_12xlarge,
+    "aws_g5.24xlarge": aws_g5_24xlarge,
+    "aws_g5.48xlarge": aws_g5_48xlarge,
+    "aws_trn1.2xl": aws_trn1_2xl,
+    "aws_trn1.32xl": aws_trn1_32xl,
 }

--- a/torchx/specs/test/named_resources_test_aws.py
+++ b/torchx/specs/test/named_resources_test_aws.py
@@ -8,27 +8,160 @@
 import unittest
 
 from torchx.specs.named_resources_aws import (
+    aws_g4dn_12xlarge,
+    aws_g4dn_16xlarge,
+    aws_g4dn_2xlarge,
+    aws_g4dn_4xlarge,
+    aws_g4dn_8xlarge,
+    aws_g4dn_metal,
+    aws_g4dn_xlarge,
+    aws_g5_12xlarge,
+    aws_g5_16xlarge,
+    aws_g5_24xlarge,
+    aws_g5_2xlarge,
+    aws_g5_48xlarge,
+    aws_g5_4xlarge,
+    aws_g5_8xlarge,
+    aws_g5_xlarge,
     aws_m5_2xlarge,
+    aws_p3_16xlarge,
     aws_p3_2xlarge,
     aws_p3_8xlarge,
+    aws_p3dn_24xlarge,
+    aws_p4d_24xlarge,
+    aws_p4de_24xlarge,
     aws_t3_medium,
+    aws_trn1_2xl,
+    aws_trn1_32xl,
     GiB,
+    K8S_ITYPE,
     NAMED_RESOURCES,
 )
 
 
 class NamedResourcesTest(unittest.TestCase):
-    def test_aws_p3_2xlarge(self) -> None:
-        resource = aws_p3_2xlarge()
-        self.assertEqual(8, resource.cpu)
-        self.assertEqual(1, resource.gpu)
-        self.assertEqual(61 * GiB, resource.memMB)
+    def test_aws_p3(self) -> None:
+        p3_2 = aws_p3_2xlarge()
+        self.assertEqual(8, p3_2.cpu)
+        self.assertEqual(1, p3_2.gpu)
+        self.assertEqual(61 * GiB, p3_2.memMB)
 
-    def test_aws_p3_8xlarge(self) -> None:
-        resource = aws_p3_8xlarge()
-        self.assertEqual(32, resource.cpu)
-        self.assertEqual(4, resource.gpu)
-        self.assertEqual(244 * GiB, resource.memMB)
+        p3_8 = aws_p3_8xlarge()
+        self.assertEqual(p3_8.cpu, p3_2.cpu * 4)
+        self.assertEqual(p3_8.gpu, p3_2.gpu * 4)
+        self.assertEqual(p3_8.memMB, p3_2.memMB * 4)
+
+        p3_16 = aws_p3_16xlarge()
+        self.assertEqual(p3_16.cpu, p3_2.cpu * 8)
+        self.assertEqual(p3_16.gpu, p3_2.gpu * 8)
+        self.assertEqual(p3_16.memMB, p3_2.memMB * 8)
+
+        p3dn_24 = aws_p3dn_24xlarge()
+        self.assertEqual(96, p3dn_24.cpu)
+        self.assertEqual(p3_16.gpu, p3dn_24.gpu)
+        self.assertEqual(768 * GiB, p3dn_24.memMB)
+
+    def test_aws_p4(self) -> None:
+        p4d = aws_p4d_24xlarge()
+        p4de = aws_p4de_24xlarge()
+
+        self.assertEqual(96, p4d.cpu)
+        self.assertEqual(8, p4d.gpu)
+        self.assertEqual(1152 * GiB, p4d.memMB)
+
+        self.assertEqual(p4de.cpu, p4d.cpu)
+        self.assertEqual(p4de.gpu, p4d.gpu)
+        self.assertEqual(p4de.memMB, p4d.memMB)
+
+    def test_aws_g4dn(self) -> None:
+        g4d = aws_g4dn_xlarge()
+        self.assertEqual(4, g4d.cpu)
+        self.assertEqual(1, g4d.gpu)
+        self.assertEqual(16 * GiB, g4d.memMB)
+
+        g4d_2 = aws_g4dn_2xlarge()
+        self.assertEqual(g4d_2.cpu, g4d.cpu * 2)
+        self.assertEqual(g4d_2.gpu, g4d.gpu)
+        self.assertEqual(g4d_2.memMB, g4d.memMB * 2)
+
+        g4d_4 = aws_g4dn_4xlarge()
+        self.assertEqual(g4d_4.cpu, g4d.cpu * 4)
+        self.assertEqual(g4d_4.gpu, g4d.gpu)
+        self.assertEqual(g4d_4.memMB, g4d.memMB * 4)
+
+        g4d_8 = aws_g4dn_8xlarge()
+        self.assertEqual(g4d_8.cpu, g4d.cpu * 8)
+        self.assertEqual(g4d_8.gpu, g4d.gpu)
+        self.assertEqual(g4d_8.memMB, g4d.memMB * 8)
+
+        g4d_16 = aws_g4dn_16xlarge()
+        self.assertEqual(g4d_16.cpu, g4d.cpu * 16)
+        self.assertEqual(g4d_16.gpu, g4d.gpu)
+        self.assertEqual(g4d_16.memMB, g4d.memMB * 16)
+
+        g4d_12 = aws_g4dn_12xlarge()
+        self.assertEqual(g4d_12.cpu, g4d.cpu * 12)
+        self.assertEqual(g4d_12.gpu, 4)
+        self.assertEqual(g4d_12.memMB, g4d.memMB * 12)
+
+        g4d_metal = aws_g4dn_metal()
+        self.assertEqual(g4d_metal.cpu, g4d_12.cpu * 2)
+        self.assertEqual(g4d_metal.gpu, g4d_12.gpu * 2)
+        self.assertEqual(g4d_metal.memMB, g4d_12.memMB * 2)
+
+    def test_aws_g5(self) -> None:
+        g5 = aws_g5_xlarge()
+
+        self.assertEqual(4, g5.cpu)
+        self.assertEqual(1, g5.gpu)
+        self.assertEqual(16 * GiB, g5.memMB)
+
+        g5_2 = aws_g5_2xlarge()
+        self.assertEqual(g5_2.cpu, g5.cpu * 2)
+        self.assertEqual(g5_2.gpu, g5.gpu)
+        self.assertEqual(g5_2.memMB, g5.memMB * 2)
+
+        g5_4 = aws_g5_4xlarge()
+        self.assertEqual(g5_4.cpu, g5.cpu * 4)
+        self.assertEqual(g5_4.gpu, g5.gpu)
+        self.assertEqual(g5_4.memMB, g5.memMB * 4)
+
+        g5_8 = aws_g5_8xlarge()
+        self.assertEqual(g5_8.cpu, g5.cpu * 8)
+        self.assertEqual(g5_8.gpu, g5.gpu)
+        self.assertEqual(g5_8.memMB, g5.memMB * 8)
+
+        g5_16 = aws_g5_16xlarge()
+        self.assertEqual(g5_16.cpu, g5.cpu * 16)
+        self.assertEqual(g5_16.gpu, g5.gpu)
+        self.assertEqual(g5_16.memMB, g5.memMB * 16)
+
+        g5_12 = aws_g5_12xlarge()
+        self.assertEqual(48, g5_12.cpu)
+        self.assertEqual(4, g5_12.gpu)
+        self.assertEqual(384 * GiB, g5_12.memMB * 2)
+
+        g5_24 = aws_g5_24xlarge()
+        self.assertEqual(g5_24.cpu, g5_12.cpu * 2)
+        self.assertEqual(g5_24.gpu, g5_12.gpu)
+        self.assertEqual(g5_24.memMB, g5_12.memMB * 2)
+
+        g5_48 = aws_g5_48xlarge()
+        self.assertEqual(g5_48.cpu, g5_12.cpu * 4)
+        self.assertEqual(g5_48.gpu, 8)
+        self.assertEqual(g5_48.memMB, g5_12.memMB * 4)
+
+    def test_aws_trn1(self) -> None:
+        trn1_2 = aws_trn1_2xl()
+
+        self.assertEqual(8, trn1_2.cpu)
+        self.assertEqual(0, trn1_2.gpu)
+        self.assertEqual(32 * GiB, trn1_2.memMB)
+
+        trn1_32 = aws_trn1_32xl()
+        self.assertEqual(trn1_32.cpu, trn1_2.cpu * 16)
+        self.assertEqual(trn1_32.gpu, trn1_2.gpu)
+        self.assertEqual(trn1_32.memMB, trn1_2.memMB * 16)
 
     def test_aws_m5_2xlarge(self) -> None:
         resource = aws_m5_2xlarge()
@@ -45,4 +178,4 @@ class NamedResourcesTest(unittest.TestCase):
     def test_capabilities(self) -> None:
         for name, func in NAMED_RESOURCES.items():
             resource = func()
-            self.assertIn("node.kubernetes.io/instance-type", resource.capabilities)
+            self.assertIn(K8S_ITYPE, resource.capabilities)


### PR DESCRIPTION
Adding complete instance types for g4d, g5, p4d, p3 and trn1 (trainium)

Test plan:
Added unittests
