### PR TITLE
torchx/docker_workspace: fix AWS batch integration tests - print_push_events stderr

### DIFF
--- a/torchx/workspace/docker_workspace.py
+++ b/torchx/workspace/docker_workspace.py
@@ -176,7 +176,7 @@ class DockerWorkspaceMixin(WorkspaceMixin[Dict[str, Tuple[str, str]]]):
 
 def print_push_events(
     events: Iterable[Dict[str, str]],
-    stream: TextIO = sys.stdout,
+    stream: TextIO = sys.stderr,
 ) -> None:
     ID_KEY = "id"
     ERROR_KEY = "error"


### PR DESCRIPTION
<!-- Change Summary -->

Fixes failing test https://github.com/pytorch/torchx/actions/runs/3364112064/jobs/5578086382

print_push_events was defaulting to logging to stdout instead of stderr which screwed up our integration tests that depended on getting the ID from stdout

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI
