### PR TITLE
(torchx/resources) Improve error message when named resource is not found

### DIFF
--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -10,7 +10,7 @@ This contains the TorchX AppDef and related component definitions. These are
 used by components to define the apps which can then be launched via a TorchX
 scheduler or pipeline adapter.
 """
-
+import difflib
 from typing import Callable, Dict, Optional
 
 from torchx.specs.named_resources_aws import NAMED_RESOURCES as AWS_NAMED_RESOURCES
@@ -69,7 +69,20 @@ _named_resource_factories: Dict[str, Callable[[], Resource]] = _load_named_resou
 
 class _NamedResourcesLibrary:
     def __getitem__(self, key: str) -> Resource:
-        return _named_resource_factories[key]()
+        if key in _named_resource_factories:
+            return _named_resource_factories[key]()
+        else:
+            matches = difflib.get_close_matches(
+                key,
+                _named_resource_factories.keys(),
+                n=1,
+            )
+            if matches:
+                msg = f"Did you mean `{matches[0]}`?"
+            else:
+                msg = f"Registered named resources: {list(_named_resource_factories.keys())}"
+
+            raise KeyError(f"No named resource found for `{key}`. {msg}")
 
     def __contains__(self, key: str) -> bool:
         return key in _named_resource_factories

--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -33,8 +33,14 @@ from typing import Callable, Mapping
 
 from torchx.specs.api import Resource
 
+# ecs and ec2 have memtax and currently AWS Batch uses hard memory limits
+# so we have to account for mem tax when registering these resources for AWS
+# otherwise the job will be stuck in the jobqueue forever
+# 97% is based on empirical observation that works well for most instance types
+# see: https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html
+MEM_TAX = 0.97
 K8S_ITYPE = "node.kubernetes.io/instance-type"
-GiB: int = 1024
+GiB: int = int(1024 * MEM_TAX)
 
 
 def aws_p3_2xlarge() -> Resource:
@@ -189,6 +195,8 @@ NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = {
     "aws_p3.8xlarge": aws_p3_8xlarge,
     "aws_p3.16xlarge": aws_p3_16xlarge,
     "aws_p3dn.24xlarge": aws_p3dn_24xlarge,
+    "aws_p4d.24xlarge": aws_p4d_24xlarge,
+    "aws_p4de.24xlarge": aws_p4de_24xlarge,
     "aws_g4dn.xlarge": aws_g4dn_xlarge,
     "aws_g4dn.2xlarge": aws_g4dn_2xlarge,
     "aws_g4dn.4xlarge": aws_g4dn_4xlarge,

--- a/torchx/specs/test/named_resources_test.py
+++ b/torchx/specs/test/named_resources_test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from unittest import mock
+
+from torchx.specs import _NamedResourcesLibrary, Resource
+
+
+def mock_resource() -> Resource:
+    return Resource(cpu=0, gpu=0, memMB=0)
+
+
+class NamedResourcesTest(unittest.TestCase):
+    @mock.patch("torchx.specs._named_resource_factories")
+    def test_named_resources_library(
+        self, mock_named_resources: mock.MagicMock
+    ) -> None:
+        mock_named_resources.keys.return_value = [
+            "p3.2xlarge",
+            "p3.16xlarge",
+            "p4d.24xlarge",
+        ]
+
+        with self.assertRaisesRegex(
+            KeyError,
+            "No named resource found for `foo`. Registered named resources:.*",
+        ):
+            _ = _NamedResourcesLibrary()["foo"]
+
+        with self.assertRaisesRegex(
+            KeyError,
+            "No named resource found for `p316xl`. Did you mean `p3.16xlarge`?",
+        ):
+            _ = _NamedResourcesLibrary()["p316xl"]


### PR DESCRIPTION
Improves error message when the no registered named resource is found by:

1. Suggesting one by closest match from the registered named resource
2. If no close match is found then listing all the available registered named resources

Here's an example:

```
(venv39) ubuntu@ip-10-2-87-95(main|✚1)% torchx run -s aws_batch dist.ddp -j 1x8 -h p4dn.24xlarge --script mfive/examples/data/datakit_datapipe.py
torchx 2022-10-31 23:47:04 INFO     loaded configs from /home/ubuntu/workspace/mfive/.torchxconfig
Traceback (most recent call last):
<.... OMITTED FOR BREVIT...>
  File "/home/ubuntu/workspace/torchx/torchx/specs/__init__.py", line 81, in __getitem__
    raise KeyError(f"`{key}` not registered as a named resource. {msg}")
KeyError: 'No named resource found for `p4dn.24xlarge`. Did you mean `aws_p4d.24xlarge`?'
```

Also registers p4d and p4de types (I forgot to register them in my other PR).
And accounts for aws mem_tax 