### PR TITLE
(torchx/resources) Account for ECS and EC2 memtax for aws named resou…

### DIFF
--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -33,8 +33,14 @@ from typing import Callable, Mapping
 
 from torchx.specs.api import Resource
 
+# ecs and ec2 have memtax and currently AWS Batch uses hard memory limits
+# so we have to account for mem tax when registering these resources for AWS
+# otherwise the job will be stuck in the jobqueue forever
+# 97% is based on empirical observation that works well for most instance types
+# see: https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html
+MEM_TAX = 0.97
 K8S_ITYPE = "node.kubernetes.io/instance-type"
-GiB: int = 1024
+GiB: int = int(1024 * MEM_TAX)
 
 
 def aws_p3_2xlarge() -> Resource:


### PR DESCRIPTION
Without accounting for ECS + EC2 mem tax, the default aws named resources will cause the job to hang forever since Batch is not able to allocate the job due to the available memory the ECS agent sees being less than the one advertised in https://aws.amazon.com/ec2/instance-types/.

Chose 3% mem tax (0.97 multiplier) based on empirical evidence from our Batch clusters that most instances seem to have 97% of their advertised memory made available to the ECS agent.

Test plan:

Submitted a job to AWS batch with the host type `aws_p4dn.24xlarge` and observed it complete to SUCCESS.

```
torchx run -s aws_batch dist.ddp -j 1x8 -h aws_p4d.24xlarge --script mfive/examples/data/datakit_datapipe.py
```
