### PR TITLE
Upgrade github runner off deprecated version

### DIFF
--- a/.github/workflows/aws-batch-integration-tests.yaml
+++ b/.github/workflows/aws-batch-integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   awsbatch:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   components-launch:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
        include:

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Install Dependencies
         run: |
           set -eux
+          sudo apt-get update
           sudo apt-get install -y pandoc
           pip install -e .[dev]
           pip install -r docs/requirements.txt

--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docbuild:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -61,7 +61,7 @@ jobs:
           fi
 
   docpush:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: docbuild
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:

--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docbuild:
-    runs-on: ubuntu-20.04
+    runs-on: linux.20_04.4x
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/kfp-integration-tests.yaml
+++ b/.github/workflows/kfp-integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   kfp-launch:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/kubernetes-dist-train-integration-tests.yaml
+++ b/.github/workflows/kubernetes-dist-train-integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   kubernetes-launch:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   nightly:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Python 3.8
         uses: actions/setup-python@v2

--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
-        platform: [ubuntu-18.04]
+        platform: [ubuntu-20.04]
         include:
           - python-version: 3.9
             platform: macos-12-xl

--- a/.github/workflows/slurm-integration-tests.yaml
+++ b/.github/workflows/slurm-integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   slurm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Summary:
Upgrade ubuntu action runners (https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

Validating doctest fix as well as I was not able to reproduce it on 22.04.1 LTS

Differential Revision: D41172301

