### PR TITLE
Use larger action builder for docpush, same as docbuild which fixes the build

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -62,7 +62,7 @@ jobs:
           fi
 
   docpush:
-    runs-on: ubuntu-20.04
+    runs-on: linux.20_04.4x
     needs: docbuild
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:


### PR DESCRIPTION
Summary: Fix docpush by applying fix used for docbuild.

Differential Revision: D41205217

