### PR TITLE
strip dict input from torchxconfig

### DIFF
--- a/torchx/util/types.py
+++ b/torchx/util/types.py
@@ -15,7 +15,7 @@ def to_list(arg: str) -> List[str]:
     if len(arg.strip()) == 0:
         return []
     for el in arg.split(","):
-        conf.append(el)
+        conf.append(el.strip())
     return conf
 
 
@@ -66,7 +66,7 @@ def to_dict(arg: str) -> Dict[str, str]:
                 f"`{vk}` cannot be split into `val<delim>key` with delims={delims}"
             )
         else:
-            return vk[0:idx], vk[idx + 1 :]
+            return vk[0:idx].strip(), vk[idx + 1 :].strip()
 
     arg_map: Dict[str, str] = {}
 
@@ -77,7 +77,9 @@ def to_dict(arg: str) -> Dict[str, str]:
     cfg_kv_delim = "="
 
     # ["FOO", "v1;v2,BAR", v3, "BAZ", "v4,v5"]
-    split_arg = [s for s in arg.split(cfg_kv_delim) if s]  # remove empty
+    split_arg = [
+        s.strip() for s in arg.split(cfg_kv_delim) if s.strip()
+    ]  # remove empty
     split_arg_len = len(split_arg)
 
     if split_arg_len < 2:  # no kv -> malformed str


### PR DESCRIPTION
Summary:
app arg of annotation dict doesn't work with following
```
env =  CCML_APP_GUF_USER_MOE=true,
       CCML_APP_GUF_EMBD_OUT_DIM=64,
       CCML_APP_GUF_LOSS=ibs_softmax,
       CCML_APP_GUF_IS_RETRIEVAL=true

```

.ini is only for demonstration, will be removed before landing

Differential Revision:
D41395792

LaMa Project: L1160093

