### PR TITLE
pin torchmetrics

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,6 +18,7 @@ pytest
 pytorch-lightning==1.5.10
 torch-model-archiver>=0.4.2
 torch>=1.10.0
+torchmetrics<0.11.0
 torchserve>=0.4.2
 torchtext>=0.11.0
 torchvision>=0.11.1


### PR DESCRIPTION
The latest version of torchmetrics (0.11.0) seems to break about 10 tests on TorchX main due to their backwards incompatible changes to their Accuracy() API which is used in TinyImageNetModel. So pinning the version compatible with TorchX. 

Test plan: CI
