### PR TITLE
torchx/Dockerfile: use newer pip for installing

### DIFF
--- a/torchx/runtime/container/Dockerfile
+++ b/torchx/runtime/container/Dockerfile
@@ -2,6 +2,9 @@ FROM pytorch/pytorch:1.13.0-cuda11.6-cudnn8-runtime
 
 WORKDIR /app
 
+# upgrade pip to 22.x+ which has a faster dependency resolver
+RUN pip install --upgrade pip
+
 # copy requirements early so we don't have to redownload dependencies on code
 # changes
 COPY dev-requirements.txt /app


### PR DESCRIPTION
<!-- Change Summary -->

This makes the Dockerfile use the latest version of pip which has a better dependency resolver which fixes our build timeouts

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI