### PR TITLE
(torchx/aws_batch) Added username tag + make list API only return torchx submitted jobs by filtering on tag

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -794,7 +794,7 @@ class runopts:
 
     def cfg_from_str(self, cfg_str: str) -> Dict[str, CfgVal]:
         """
-        Parses scheduler ``runcfg`` from a string literal and returns
+        Parses scheduler ``cfg`` from a string literal and returns
         a cfg map where the cfg values have been cast into the appropriate
         types as specified by this runopts object. Unknown keys are ignored
         and not returned in the resulting map.


### PR DESCRIPTION
Two QoL improvements to aws_batch scheduler:

1. Added a username tag (torchx.pytorch.org/user) which is configurable via cfg.user (gets unix user by default)
2. Make `list` API only return torchx submitted jobs by filtering on the existence of `torchx.pytorch.org/version`. This make s it possible to user torchx on batch clusters that are shared with other jobs being launched from different launchers.

Future improvements:
1. Add filter to only list jobs for a particular user? --> requires the `cfg` to be plumbed through the list API for scheduler and runner.
