### PR TITLE
(torchx/aws_batch) Enable Region Selection in TorchConfig

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -82,14 +82,11 @@ from torchx.specs.api import (
 from torchx.workspace.docker_workspace import DockerWorkspaceMixin
 from typing_extensions import TypedDict
 
-<<<<<<< HEAD
 TAG_TORCHX_VER = "torchx.pytorch.org/version"
 TAG_TORCHX_APPNAME = "torchx.pytorch.org/app-name"
 TAG_TORCHX_USER = "torchx.pytorch.org/user"
 
-=======
 logger: logging.Logger = logging.getLogger(__name__)
->>>>>>> 7f482731 (Fixing Backwards Compat and List)
 
 if TYPE_CHECKING:
     from docker import DockerClient


### PR DESCRIPTION
QOL improvements for support for AWS regions. 

Current Behavior: Use the default Region specified in .aws config

Proposed Behaviour: Have manual override in .torchxconfig. If no override and no default throw and error

Future Improvements: Add profile support. Add fargate support. 

