### PR TITLE
component_integration_tests: add aws batch mock support

### DIFF
--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -13,6 +13,9 @@ jobs:
       matrix:
        include:
          - scheduler: "aws_batch"
+         - scheduler: "aws_batch"
+           container_repo: localhost
+           extra_args: "--mock"
          - scheduler: "kubernetes"
          - scheduler: "local_cwd"
          - scheduler: "local_docker"
@@ -69,6 +72,6 @@ jobs:
       - name: Run Components Integration Tests
         env:
           INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
-          CONTAINER_REPO: ${{ secrets.CONTAINER_REPO }}
+          CONTAINER_REPO: ${{ matrix.container_repo || secrets.CONTAINER_REPO }}
         run: |
-          scripts/component_integration_tests.py --scheduler ${{ matrix.scheduler }}
+          scripts/component_integration_tests.py --scheduler ${{ matrix.scheduler }} ${{ matrix.extra_args }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,7 @@ google-cloud-runtimeconfig>=0.33.2
 hydra-core
 ipython
 kfp==1.8.9
-moto==3.0.2
+moto==4.1.3
 pyre-extensions==0.0.21
 pytest
 pytorch-lightning==1.5.10

--- a/scripts/integ_test_utils.py
+++ b/scripts/integ_test_utils.py
@@ -51,8 +51,12 @@ def build_torchx_canary(id: str) -> str:
     return torchx_tag
 
 
+def get_container_repo() -> str:
+    return getenv_asserts("CONTAINER_REPO")
+
+
 def torchx_container_tag(id: str) -> str:
-    CONTAINER_REPO = getenv_asserts("CONTAINER_REPO")
+    CONTAINER_REPO = get_container_repo()
     return f"{CONTAINER_REPO}:canary_{id}_torchx"
 
 
@@ -70,4 +74,6 @@ def push_images(build: BuildInfo) -> None:
     run("docker", "tag", build.torchx_image, torchx_tag)
     build.torchx_image = torchx_tag
 
-    run("docker", "push", torchx_tag)
+    CONTAINER_REPO = get_container_repo()
+    if CONTAINER_REPO != "localhost":
+        run("docker", "push", torchx_tag)


### PR DESCRIPTION
<!-- Change Summary -->

This requires patches to moto to support multinode mocking.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Install https://github.com/d4l3k/moto

```
env CONTAINER_REPO=localhost python scripts/component_integration_tests.py --scheduler aws_batch --mock
```
