### PR TITLE
use minikube for integration tests

### DIFF
--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -8,19 +8,26 @@ on:
 
 jobs:
   components-launch:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
-       include:
-         - scheduler: "aws_batch"
-         - scheduler: "aws_batch"
-           container_repo: localhost
-           extra_args: "--mock"
-         - scheduler: "kubernetes"
-         - scheduler: "local_cwd"
-         - scheduler: "local_docker"
-         - scheduler: "ray"
+        include:
+          - scheduler: "aws_batch"
+            platform: ubuntu-20.04
+          - scheduler: "aws_batch"
+            container_repo: localhost
+            extra_args: "--mock"
+            platform: ubuntu-20.04
+          - scheduler: "kubernetes"
+            container_repo: localhost:5000/torchx
+            platform: "linux.20_04.16x"
+          - scheduler: "local_cwd"
+            platform: ubuntu-20.04
+          - scheduler: "local_docker"
+            platform: ubuntu-20.04
+          - scheduler: "ray"
+            platform: ubuntu-20.04
       fail-fast: false
+    runs-on: ${{ matrix.platform }}
     permissions:
       id-token: write
       contents: read
@@ -69,9 +76,13 @@ jobs:
           sleep 5 # wait till the node joins so that `status` command displays the head node info
           ray status
 
+      - name: Start Kubernetes
+        if: ${{ matrix.scheduler == 'kubernetes' }}
+        run: |
+          scripts/setup_minikube.sh
+
       - name: Run Components Integration Tests
         env:
           INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
-          CONTAINER_REPO: ${{ matrix.container_repo || secrets.CONTAINER_REPO }}
         run: |
-          scripts/component_integration_tests.py --scheduler ${{ matrix.scheduler }} ${{ matrix.extra_args }}
+          scripts/component_integration_tests.py --scheduler ${{ matrix.scheduler }} --container_repo "${{ matrix.container_repo || secrets.CONTAINER_REPO }}"  ${{ matrix.extra_args }}

--- a/scripts/component_integration_tests.py
+++ b/scripts/component_integration_tests.py
@@ -31,17 +31,18 @@ logging.basicConfig(
 # pyre-ignore-all-errors[11]
 
 
-def build_and_push_image() -> BuildInfo:
+def build_and_push_image(container_repo: str) -> BuildInfo:
     build = build_images()
-    push_images(build)
+    push_images(build, container_repo=container_repo)
     return build
 
 
 def argparser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Process some integers.")
+    parser = argparse.ArgumentParser(description="Run TorchX integration tests.")
     choices = list(get_scheduler_factories().keys())
     parser.add_argument("--scheduler", required=True, choices=choices)
     parser.add_argument("--mock", action="store_true")
+    parser.add_argument("--container_repo", type=str)
     return parser
 
 
@@ -68,7 +69,7 @@ def main() -> None:
         "gcp_batch",
     ):
         try:
-            build = build_and_push_image()
+            build = build_and_push_image(args.container_repo)
             torchx_image = build.torchx_image
         except MissingEnvError:
             dryrun = True

--- a/scripts/example_app_defs.py
+++ b/scripts/example_app_defs.py
@@ -29,7 +29,7 @@ class CvTrainerComponentProvider(ComponentProvider):
 class DatapreprocComponentProvider(ComponentProvider):
     def get_app_def(self) -> AppDef:
         return utils_python(
-            *("--output_path", "/tmp/test"),
+            *("--output_path", "/tmp/test", "--limit", "100"),
             image=self._image,
             m="torchx.examples.apps.datapreproc.datapreproc",
         )

--- a/scripts/integ_test_utils.py
+++ b/scripts/integ_test_utils.py
@@ -51,13 +51,8 @@ def build_torchx_canary(id: str) -> str:
     return torchx_tag
 
 
-def get_container_repo() -> str:
-    return getenv_asserts("CONTAINER_REPO")
-
-
-def torchx_container_tag(id: str) -> str:
-    CONTAINER_REPO = get_container_repo()
-    return f"{CONTAINER_REPO}:canary_{id}_torchx"
+def torchx_container_tag(container_repo: str, id: str) -> str:
+    return f"{container_repo}:canary_{id}_torchx"
 
 
 def build_images() -> BuildInfo:
@@ -69,11 +64,10 @@ def build_images() -> BuildInfo:
     )
 
 
-def push_images(build: BuildInfo) -> None:
-    torchx_tag = torchx_container_tag(build.id)
+def push_images(build: BuildInfo, container_repo: str) -> None:
+    torchx_tag = torchx_container_tag(container_repo=container_repo, id=build.id)
     run("docker", "tag", build.torchx_image, torchx_tag)
     build.torchx_image = torchx_tag
 
-    CONTAINER_REPO = get_container_repo()
-    if CONTAINER_REPO != "localhost":
+    if container_repo and container_repo != "localhost":
         run("docker", "push", torchx_tag)

--- a/scripts/setup_minikube.sh
+++ b/scripts/setup_minikube.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eux
+minikube delete
+minikube start --driver=docker --cpus=max --memory=max --nodes=2
+minikube addons enable registry
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.7.0/installer/volcano-development.yaml
+kubectl create namespace torchx-dev
+kubectl port-forward --namespace kube-system service/registry 5000:80 &

--- a/torchx/examples/apps/datapreproc/datapreproc.py
+++ b/torchx/examples/apps/datapreproc/datapreproc.py
@@ -75,6 +75,11 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         help="remote path to save the .tar.gz data to",
         required=True,
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="limit number of processed examples",
+    )
     return parser.parse_args(argv)
 
 
@@ -112,6 +117,9 @@ def main(argv: List[str]) -> None:
                 if not is_image_file(path):
                     continue
                 image_files.append(path)
+
+                if args.limit and len(image_files) > args.limit:
+                    break
         for path in tqdm(image_files, miniters=int(len(image_files) / 2000)):
             f = Image.open(path)
             f = transform(f)


### PR DESCRIPTION
<!-- Change Summary -->

This uses minikube for integration tests instead of running in a remote dedicated cluster. This makes the environment reproducible, reduces maintenance, and makes it easier for more users to contribute.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI
