### PR TITLE
Azure batch scheduler implementation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -25,3 +25,4 @@ torchvision>=0.11.1
 ts==0.5.1
 usort==1.0.2
 ray[default]
+azure-batch

--- a/torchx/cli/argparse_util.py
+++ b/torchx/cli/argparse_util.py
@@ -97,3 +97,6 @@ class torchxconfig_run(_torchxconfig):
             option_strings=option_strings,
             **kwargs,
         )
+
+def scheduler_params(scheduler:str) -> Dict[str, str]:
+    return config.get_configs("scheduler", scheduler, CONFIG_DIRS)

--- a/torchx/cli/cmd_cancel.py
+++ b/torchx/cli/cmd_cancel.py
@@ -8,8 +8,10 @@
 import argparse
 import logging
 
+from torchx.cli.argparse_util import scheduler_params
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner
+from torchx.specs.api import parse_app_handle
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -24,5 +26,7 @@ class CmdCancel(SubCommand):
 
     def run(self, args: argparse.Namespace) -> None:
         app_handle = args.app_handle
-        runner = get_runner()
+        scheduler, _, app_id = parse_app_handle(app_handle)
+        params = scheduler_params(scheduler)
+        runner = get_runner(name=None, component_defaults=None, **params)
         runner.cancel(app_handle)

--- a/torchx/cli/cmd_describe.py
+++ b/torchx/cli/cmd_describe.py
@@ -11,6 +11,8 @@ import logging
 import pprint
 import sys
 
+
+from torchx.cli.argparse_util import scheduler_params
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner
 from torchx.specs.api import parse_app_handle
@@ -27,11 +29,12 @@ class CmdDescribe(SubCommand):
         )
 
     def run(self, args: argparse.Namespace) -> None:
+        
         app_handle = args.app_handle
         scheduler, _, app_id = parse_app_handle(app_handle)
-        runner = get_runner()
+        params = scheduler_params(scheduler)
+        runner = get_runner(name=None, component_defaults=None, **params)
         app = runner.describe(app_handle)
-
         if app:
             pprint.pprint(dataclasses.asdict(app), indent=2, width=80)
         else:

--- a/torchx/cli/cmd_list.py
+++ b/torchx/cli/cmd_list.py
@@ -10,6 +10,7 @@ import logging
 
 from tabulate import tabulate
 
+from torchx.cli.argparse_util import scheduler_params
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner
 from torchx.schedulers import get_default_scheduler_name, get_scheduler_factories
@@ -35,7 +36,8 @@ class CmdList(SubCommand):
         )
 
     def run(self, args: argparse.Namespace) -> None:
-        with get_runner() as runner:
+        params = scheduler_params(args.scheduler)
+        with get_runner(name=None, component_defaults=None, **params) as runner:
             apps = runner.list(args.scheduler)
             apps_data = [[app.app_handle, str(app.state)] for app in apps]
             print(tabulate(apps_data, headers=[HANDLE_HEADER, STATUS_HEADER]))

--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -15,6 +15,7 @@ from queue import Queue
 from typing import List, Optional, TextIO, Tuple
 
 from torchx import specs
+from torchx.cli.argparse_util import scheduler_params
 from torchx.cli.cmd_base import SubCommand
 from torchx.cli.colors import ENDC, GREEN
 from torchx.runner import get_runner, Runner
@@ -95,7 +96,8 @@ def get_logs(
     role_name = path[2] if len(path) > 2 else None
 
     if not runner:
-        runner = get_runner()
+        params = scheduler_params(scheduler_backend)
+        runner = get_runner(name=None, component_defaults=None, **params)
     app_handle = make_app_handle(scheduler_backend, session_name, app_id)
 
     if len(path) == 4:

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -15,7 +15,7 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple
 
 import torchx.specs as specs
-from torchx.cli.argparse_util import CONFIG_DIRS, torchxconfig_run
+from torchx.cli.argparse_util import CONFIG_DIRS, scheduler_params, torchxconfig_run
 from torchx.cli.cmd_base import SubCommand
 from torchx.cli.cmd_log import get_logs
 from torchx.runner import config, get_runner, Runner
@@ -244,7 +244,8 @@ class CmdRun(SubCommand):
     def run(self, args: argparse.Namespace) -> None:
         os.environ["TORCHX_CONTEXT_NAME"] = os.getenv("TORCHX_CONTEXT_NAME", "cli_run")
         component_defaults = load_sections(prefix="component", dirs=CONFIG_DIRS)
-        with get_runner(component_defaults=component_defaults) as runner:
+        sched_params = scheduler_params(args.scheduler)
+        with get_runner(component_defaults=component_defaults, **sched_params) as runner:
             self._run(runner, args)
 
     def _wait_and_exit(self, runner: Runner, app_handle: str, log: bool) -> None:

--- a/torchx/cli/cmd_runopts.py
+++ b/torchx/cli/cmd_runopts.py
@@ -8,6 +8,7 @@
 import argparse
 import logging
 
+from torchx.cli.argparse_util import scheduler_params
 from torchx.cli.cmd_base import SubCommand
 from torchx.cli.colors import ENDC, GREEN
 from torchx.runner.api import get_runner
@@ -26,7 +27,8 @@ class CmdRunopts(SubCommand):
 
     def run(self, args: argparse.Namespace) -> None:
         filter = args.scheduler
-        with get_runner() as runner:
+        params = scheduler_params(args.scheduler)
+        with get_runner(name=None, component_defaults=None, **params) as runner:
             for scheduler in runner.scheduler_backends():
                 if filter and scheduler != filter:
                     continue

--- a/torchx/cli/cmd_status.py
+++ b/torchx/cli/cmd_status.py
@@ -10,6 +10,7 @@ import logging
 import sys
 from typing import List, Optional
 
+from torchx.cli.argparse_util import scheduler_params
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner
 from torchx.specs.api import parse_app_handle
@@ -48,7 +49,8 @@ class CmdStatus(SubCommand):
     def run(self, args: argparse.Namespace) -> None:
         app_handle = args.app_handle
         scheduler, _, app_id = parse_app_handle(app_handle)
-        runner = get_runner()
+        params = scheduler_params(scheduler)
+        runner = get_runner(name=None, component_defaults=None, **params)
         app_status = runner.status(app_handle)
         filter_roles = parse_list_arg(args.roles)
         if app_status:

--- a/torchx/cli/test/argparse_util_test.py
+++ b/torchx/cli/test/argparse_util_test.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from unittest import mock
 
 from torchx.cli import argparse_util
-from torchx.cli.argparse_util import torchxconfig_run
+from torchx.cli.argparse_util import scheduler_params, torchxconfig_run
 
 
 CONFIG_DIRS = "torchx.cli.argparse_util.CONFIG_DIRS"
@@ -144,3 +144,18 @@ workspace = baz
 
             args = parser.parse_args(["run"])
             self.assertEqual("baz", args.workspace)
+
+
+    def test_scheduler_params(self) -> None:
+        with mock.patch(CONFIG_DIRS, [self.test_dir]):
+            self._write(
+                ".torchxconfig",
+                """
+[scheduler:test_scheduler]
+param1 = val1
+param2 = val2
+                """,
+            )
+            params = scheduler_params("test_scheduler")
+            self.assertEqual("val1", params["param1"])
+            self.assertEqual("val2", params["param2"])

--- a/torchx/cli/test/cmd_log_test.py
+++ b/torchx/cli/test/cmd_log_test.py
@@ -9,7 +9,7 @@ import io
 import sys
 import unittest
 from datetime import datetime
-from typing import Iterator, Optional
+from typing import Any, Dict, Iterator, Optional
 from unittest.mock import MagicMock, patch
 
 from torchx.cli.cmd_log import _prefix_line, ENDC, get_logs, GREEN, validate
@@ -33,7 +33,10 @@ class MockRunner(Runner):
     def __init__(self) -> None:
         pass
 
-    def __call__(self, name: Optional[str] = None) -> "MockRunner":
+    def __call__(self, 
+        name: Optional[str] = None, 
+        component_defaults: Optional[Dict[str, Dict[str, str]]] = None,
+        **scheduler_params: Any) -> "MockRunner":
         return self
 
     def describe(self, app_handle: str) -> AppDef:

--- a/torchx/schedulers/__init__.py
+++ b/torchx/schedulers/__init__.py
@@ -22,6 +22,7 @@ DEFAULT_SCHEDULER_MODULES: Mapping[str, str] = {
     "gcp_batch": "torchx.schedulers.gcp_batch_scheduler",
     "ray": "torchx.schedulers.ray_scheduler",
     "lsf": "torchx.schedulers.lsf_scheduler",
+    "azure_batch": "torchx.schedulers.azure_batch_scheduler",
 }
 
 

--- a/torchx/schedulers/azure_batch_scheduler.py
+++ b/torchx/schedulers/azure_batch_scheduler.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+
+Initial support for Azure Batch scheduler.
+
+This scheduler is in prototype stage and may change without notice.
+
+Overview
+========
+https://learn.microsoft.com/en-us/azure/batch/
+
+
+Prerequisites
+==============
+
+You'll need to setup:
+- Azure Batch Account+credentials.
+- Batch Pool, that:
+    - has enough resources, or
+    - supports autoscaling (https://learn.microsoft.com/en-us/azure/batch/batch-automatic-scaling)
+    - VMs that support container workloads (https://learn.microsoft.com/en-us/azure/batch/batch-docker-container-workloads)
+
+Configuration
+=============
+Use .torchxconfig to configure the Batch Account information
+
+.. code-block:: ini
+[scheduler:azure_batch]
+batch_account_name = <ACCOUNT NAME>
+batch_account_key = "<ACCOUNT_KEY>"
+batch_account_url: <ACCOUNT_URL>
+.. code-block:: ini
+
+Although workspace patching support is WIP, the scheduler can be configured to use existing images by configuring Container Registry.
+
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, TypedDict
+import yaml
+from torchx.schedulers.api import (
+    AppDryRunInfo,
+    DescribeAppResponse,
+    ListAppResponse,
+    Scheduler
+)
+from torchx.schedulers.ids import make_unique
+
+from torchx.specs.api import (
+    AppDef,
+    AppState,
+    macros,
+    runopts,
+    RetryPolicy,
+    Role,
+)
+
+from azure.batch import BatchServiceClient
+
+import azure.batch.models as batchmodels
+from azure.batch import BatchServiceClient
+from azure.batch.batch_auth import SharedKeyCredentials
+import azure.batch.models as batchmodels
+
+
+
+@dataclass
+class AzureBatchJob:
+    job_id: str
+    pool_id: str
+    job: batchmodels.JobAddParameter
+    tasks: List[batchmodels.TaskAddParameter]
+
+    def __str__(self) -> str:
+        return yaml.dump({"job": self.job, "tasks": self.tasks})
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class AzureBatchOpts(TypedDict, total=False):
+    batch_container_registry: Optional[str]
+    batch_container_username: Optional[str]
+    batch_container_password: Optional[str]
+    batch_pool_id: Optional[str]
+
+    
+JOB_STATE: Dict[str, AppState] = {
+    # TODO: instead of state to state mapping, use Job transition states (prev+current) to capture status
+    batchmodels.JobState.active: AppState.RUNNING,
+    batchmodels.JobState.completed: AppState.SUCCEEDED,
+    batchmodels.JobState.deleting: AppState.UNKNOWN,
+    batchmodels.JobState.disabled: AppState.UNKNOWN,
+    batchmodels.JobState.disabling: AppState.UNKNOWN,
+    batchmodels.JobState.enabling: AppState.PENDING,
+    batchmodels.JobState.terminating: AppState.UNKNOWN,
+}
+
+def _as_metadata_model(name:str, value:str) -> batchmodels.MetadataItem:
+    # pyre-ignore[16]
+    return batchmodels.MetadataItem(name=name, value=value)
+
+class AzureBatchScheduler(Scheduler[AzureBatchOpts]):
+    """
+    AzureBatchScheduler is a TorchX scheduling interface to Azure Batch.
+
+    .. code-block:: bash
+
+        $ pip install torchx
+        $ torchx run --scheduler azure_batch --scheduler_args image_repo=ghcr.io/pytorch/torchx --image alpine:latest --msg hello
+        azure_batch://torchx_user/1234
+        $ torchx describe azure_batch://torchx_user/1234
+        ...
+
+    **Config Options**
+
+    .. runopts::
+        class: torchx.schedulers.azure_batch_scheduler.create_scheduler
+
+
+    **Compatibility**
+
+    .. compatibility::
+        type: scheduler
+        features:
+            cancel: true
+            logs: false
+            distributed: true
+            describe: true
+            workspaces: false
+            mounts: false
+            elasticity: false
+    """
+
+    def __init__(
+        self,
+        session_name: str,
+        batch_account_name: Optional[str],
+        batch_account_key: Optional[str],
+        batch_account_url: Optional[str],
+    ) -> None:
+        super().__init__("azure_batch", session_name)
+        self.batch_account_name = batch_account_name
+        self.batch_account_key = batch_account_key
+        self.batch_account_url = batch_account_url
+
+    def _build_client(self) -> BatchServiceClient:
+        credentials = SharedKeyCredentials(
+            self.batch_account_name,
+            self.batch_account_key)
+
+        batch_service_client = BatchServiceClient(
+            credentials,
+            batch_url=self.batch_account_url)
+        
+        return batch_service_client
+    
+
+    def schedule(self, dryrun_info: AppDryRunInfo[AzureBatchJob]) -> str:
+        req = dryrun_info.request
+
+        batch_service_client = self._build_client()
+        pool_id = dryrun_info.request.pool_id
+        if not batch_service_client.pool.exists(pool_id=pool_id):
+            # TODO: add a support for creating autoscaling pool. Currently we expect the pool to exist
+            raise ValueError(f"Batch pool {pool_id} does not exist")
+        job = req.job
+        
+        batch_service_client.job.add(job)
+
+        for task in req.tasks:
+            batch_service_client.task.add(req.job_id, task)
+        return req.job_id
+
+    
+    def _role_as_task(self, name: str, app_role: Role, cfg: AzureBatchOpts) -> batchmodels.TaskAddParameter:
+        values = macros.Values(
+                    img_root="",
+                    app_id=name,
+                    replica_id="",
+                    rank0_env="AZ_BATCH_MASTER_NODE",
+                )
+        role = values.apply(app_role)
+        role_id=f'{name}-{role.name}'
+        if role.num_replicas == 1:
+            task = batchmodels.TaskAddParameter( # pyre-ignore[16]
+                id=role_id,
+                command_line = " ".join([role.entrypoint] + role.args) , 
+            )
+        elif role.num_replicas > 1:
+            task = batchmodels.TaskAddParameter( # pyre-ignore[16]
+                id=role_id,
+                command_line='echo "MPI Primary task started"', # required
+            )
+            # pyre-ignore[16]
+            multi_instance_settings=batchmodels.MultiInstanceSettings( 
+                number_of_instances=role.num_replicas,
+                coordination_command_line=" ".join([role.entrypoint] + role.args)
+            )
+            task.multi_instance_settings = multi_instance_settings
+        else:
+            raise ValueError(f"Expected positive {role.num_replicas} for {role.name} role")
+
+
+        task.environment_settings = [
+            batchmodels.EnvironmentSetting(name="TORCHX_ROLE_NAME", value=str(role.name))] # pyre-ignore[16]
+
+        if role.env:
+            task.environment_settings += [
+                    batchmodels.EnvironmentSetting(name=name, value=value) # pyre-ignore[16]
+                    for name, value in role.env.items()]
+
+        # Scheduler supports only "RetryPolicy.APPLICATION" semantics
+        if role.max_retries:
+            if role.retry_policy == RetryPolicy.REPLICA:
+                raise ValueError("Scheduler supports only RetryPolicy.APPLICATION option")
+            # pyre-ignore[16]
+            task.constraints = batchmodels.TaskConstraints( 
+                max_task_retry_count=role.max_retries)
+
+        if role.image:
+            # pyre-ignore[16]
+            container_settings = batchmodels.TaskContainerSettings(
+                image_name=role.image,
+                # TODO: add support for port and device bindings via container_run_options
+            )
+            if cfg.get("batch_container_registry"):
+                # pyre-ignore[16]
+                container_settings.registry = batchmodels.ContainerRegistry(
+                    user_name=cfg.get("batch_container_username"),
+                    password=cfg.get("batch_container_password"),
+                    registry_server=cfg.get("batch_container_registry"),
+                )
+            task.container_settings = container_settings
+        
+        return task
+
+    def _submit_dryrun(self, app: AppDef, cfg: AzureBatchOpts) -> AppDryRunInfo[AzureBatchJob]:
+        name = make_unique(app.name)
+        # TODO: For those cases when pool is predefined, validate that pool has right resources.
+        pool_id = cfg.get("batch_pool_id") or name
+        tasks = []
+
+        for app_role in app.roles:
+            task = self._role_as_task(name, app_role, cfg)
+            tasks.append(task)
+    
+        # pyre-ignore[16]
+        job = batchmodels.JobAddParameter(
+            id=name,
+            display_name=name,
+            # pyre-ignore[16]
+            pool_info=batchmodels.PoolInformation(pool_id=pool_id),
+            metadata=[_as_metadata_model(k, v) for k, v in app.metadata.items()],
+            on_all_tasks_complete=batchmodels.OnAllTasksComplete.terminate_job,
+        )
+
+        req = AzureBatchJob(
+            job_id = name,
+            pool_id = pool_id,
+            job=job,
+            tasks = tasks,
+        )
+        return AppDryRunInfo(req, repr)
+    
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        batch_service_client = self._build_client()
+        job = batch_service_client.job.get(app_id)
+        tasks = batch_service_client.task.list(app_id)
+        roles = {}
+        for task in tasks:
+            env_settings  = {es.name: es.value for es in task.environment_settings}
+            role_name = env_settings.get("TORCHX_ROLE_NAME", "")
+            if task.multi_instance_settings:
+                replicas =  task.multi_instance_settings.number_of_instances
+            else:
+                replicas = 0
+            
+            if task.container_settings:
+                image = task.container_settings.image_name
+            else:
+                image = None
+            roles[role_name] = Role(
+                name=role_name,
+                num_replicas=replicas,
+                image=image,
+                entrypoint=task.command_line,
+                env=env_settings)
+
+        return DescribeAppResponse(
+            app_id=app_id,
+            state=JOB_STATE[job.state], # TODO: use prev state to check
+            roles=list(roles.values()),
+        )
+
+    def list(self) -> List[ListAppResponse]:
+        batch_service_client = self._build_client()
+        jobs = batch_service_client.job.list()
+        response = []
+        for job in jobs:
+            response.append(ListAppResponse(app_id=job.id, state=JOB_STATE[job.state]))
+
+        return response
+   
+
+    def _cancel_existing(self, app_id: str) -> None:
+        batch_service_client = self._build_client()
+        batch_service_client.job.terminate(
+            job_id=app_id,
+            terminate_reason="killed via torchx CLI",
+        )
+
+    def _run_opts(self) -> runopts:
+        opts = runopts()
+        opts.add("batch_pool_id", type_=str, help="", required=True)
+        opts.add("batch_container_registry", type_=str, default="", help="", required=False)
+        opts.add("batch_container_username", type_=str, default="", help="", required=False)
+        opts.add("batch_container_password", type_=str, default="", help="", required=False)
+    
+        return opts
+
+
+def create_scheduler(session_name: str,
+        batch_account_name: Optional[str] = None,
+        batch_account_key: Optional[str] = None,
+        batch_account_url: Optional[str] = None) -> AzureBatchScheduler:
+    return AzureBatchScheduler(
+        session_name=session_name,
+        batch_account_name=batch_account_name,
+        batch_account_key=batch_account_key,
+        batch_account_url=batch_account_url
+    )

--- a/torchx/schedulers/test/azure_batch_scheduler_test.py
+++ b/torchx/schedulers/test/azure_batch_scheduler_test.py
@@ -1,0 +1,96 @@
+
+
+import unittest
+
+from torchx.schedulers.azure_batch_scheduler import (
+    AzureBatchOpts,
+    AzureBatchScheduler,
+    create_scheduler,
+)
+
+import torchx.schedulers.test.test_data as test_data
+
+class AzureBatchSchedulerTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._scheduler = create_scheduler("test")
+        self._pool_id = "testpool"
+
+    def test_create_scheduler(self) -> None:
+        scheduler = create_scheduler("session")
+        self.assertIsInstance(scheduler, AzureBatchScheduler)
+
+
+    def test_build_client(self) -> None:
+        scheduler = create_scheduler(
+            "session",
+            batch_account_name="account_name",
+            batch_account_key="account_key",
+            batch_account_url="account_url",
+        )
+
+        batch_client = scheduler._build_client()
+        self.assertEqual("account_name", 
+            batch_client.config.credentials.auth._account_name)
+        self.assertEqual("account_key", 
+            batch_client.config.credentials.auth._key)
+        self.assertEqual("account_url", 
+            batch_client.config.batch_url)
+        
+
+    def test_submit_dryrun_with_pool_id_set_request_pool_id(self) -> None:
+        app = test_data.build_app_def()
+        cfg = AzureBatchOpts({"batch_pool_id": self._pool_id})
+        info = self._scheduler.submit_dryrun(app, cfg)
+
+        req = info.request
+        
+        self.assertEqual(self._pool_id, req.pool_id)
+
+    def test_submit_dryrun_with_pool_id_set_job_pool_id(self) -> None:
+        app = test_data.build_app_def()
+        cfg = AzureBatchOpts({"batch_pool_id": self._pool_id})
+        info = self._scheduler.submit_dryrun(app, cfg)
+
+        req = info.request
+        
+        self.assertEqual(self._pool_id, req.job.pool_info.pool_id)
+
+
+    def test_submit_dryrun_job(self) -> None:
+        app = test_data.build_app_def()
+        app.metadata = {"prop1":"val1"}
+        cfg = AzureBatchOpts({"batch_pool_id": self._pool_id})
+
+        info = self._scheduler.submit_dryrun(app, cfg)
+        req = info.request        
+        job = req.job
+
+        self.assertTrue(job.id.startswith(app.name))
+        self.assertEqual(job.id, job.display_name)
+
+        self.assertEqual(job.id, job.display_name)
+
+        self.assertEqual(job.pool_info.pool_id, self._pool_id)
+        self.assertEqual(len(job.metadata), 1)
+
+    def test_submit_dryrun_tasks(self) -> None:
+        app = test_data.build_app_def()
+        cfg = AzureBatchOpts({"batch_pool_id": self._pool_id})
+
+        info = self._scheduler.submit_dryrun(app, cfg)
+        req = info.request        
+        tasks = req.tasks
+        trainer_task = tasks[0]
+
+        self.assertEqual(len(tasks), 1)
+
+        env = {prop.name:prop.value for prop in trainer_task.environment_settings}
+        self.assertEqual(env["FOO"], app.roles[0].env["FOO"])
+        self.assertEqual(env["TORCHX_ROLE_NAME"], app.roles[0].name)
+
+        self.assertEqual(trainer_task.multi_instance_settings.number_of_instances,
+            app.roles[0].num_replicas)
+
+        self.assertEqual(trainer_task.multi_instance_settings.coordination_command_line,
+            f"main --output-path  --app-id {req.job.id} --rank0_env AZ_BATCH_MASTER_NODE")

--- a/torchx/schedulers/test/test_data.py
+++ b/torchx/schedulers/test/test_data.py
@@ -1,0 +1,30 @@
+from torchx import specs
+
+def build_app_def() -> specs.AppDef:
+    trainer_role = specs.Role(
+        name="trainer",
+        image="pytorch/torchx:latest",
+        entrypoint="main",
+        args=[
+            "--output-path",
+            specs.macros.img_root,
+            "--app-id",
+            specs.macros.app_id,
+            "--rank0_env",
+            specs.macros.rank0_env,
+        ],
+        env={"FOO": "bar"},
+        resource=specs.Resource(
+            cpu=2,
+            memMB=3000,
+            gpu=4,
+        ),
+        port_map={"foo": 1234},
+        num_replicas=2,
+        max_retries=3,
+        mounts=[
+            specs.BindMount(src_path="/src", dst_path="/dst", read_only=True),
+        ],
+    )
+
+    return specs.AppDef("test", roles=[trainer_role])


### PR DESCRIPTION
1. Modify commands to initialize scheduler with options that can be defined in config. Generally most of the schedulers can operate using scheduler options, however in some cases for multi-tenant setup operations needs to be pre-configured. For example, Azure Batch allows multiple Batch accounts
2. Initial implementation of the Azure batch scheduler. Provides support for scheduling, stopping, listing and describing jobs. Azure Batch has a good support HPC support and training jobs should work out of the box.


Major things that needs to be addressed:
- Support for patching using Docker (currently it can run existing image)
- Creating autoscaling pools that maps to resource requirements


Testing
=======
- Unit test
- `python -m torchx.cli.main run --scheduler azure_batch --scheduler_args image_repo=ghcr.io/pytorch/torchx utils.echo --image alpine:latest  --msg hello`

<img width="1147" alt="Screenshot 2023-02-08 at 7 15 27 PM" src="https://user-images.githubusercontent.com/74940256/217708959-ed34a19f-b761-4b02-9747-54e1f6e7ef88.png">
<img width="1775" alt="Screenshot 2023-02-08 at 7 15 43 PM" src="https://user-images.githubusercontent.com/74940256/217708989-7ef1a9a7-750f-49b6-9e25-3674ecfd1e3c.png">
<img width="829" alt="Screenshot 2023-02-08 at 7 15 51 PM" src="https://user-images.githubusercontent.com/74940256/217709007-d8b41d98-7754-4094-bf7f-0ab8d70d5891.png">
