### PR TITLE
Add Kubernetes_MCAD scheduler docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,7 @@ Works With
    schedulers/local
    schedulers/docker
    schedulers/kubernetes
+   schedulers/kubernetes_mcad
    schedulers/slurm
    schedulers/ray
    schedulers/aws_batch

--- a/docs/source/schedulers/kubernetes_mcad.rst
+++ b/docs/source/schedulers/kubernetes_mcad.rst
@@ -1,0 +1,28 @@
+Kubernetes-MCAD
+=================
+
+.. automodule:: torchx.schedulers.kubernetes_mcad_scheduler
+
+.. currentmodule:: torchx.schedulers.kubernetes_mcad_scheduler
+
+.. autoclass:: KubernetesMCADScheduler
+   :members:
+   :show-inheritance:
+
+.. autoclass:: KubernetesMCADJob
+   :members:
+
+Reference
+~~~~~~~~~~~~
+
+.. autofunction:: create_scheduler
+.. autofunction:: app_to_resource
+.. autofunction:: mcad_svc
+.. autofunction:: get_appwrapper_status
+.. autofunction:: get_port_for_service
+.. autofunction:: get_role_information
+.. autofunction:: get_tasks_status_description
+.. autofunction:: pod_labels
+.. autofunction:: role_to_pod
+.. autofunction:: sanitize_for_serialization
+

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -755,6 +755,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             describe: true
             workspaces: true
             mounts: true
+            elasticity: false
     """
 
     def __init__(


### PR DESCRIPTION
Added documentation for Kubernetes-MCAD scheduler

Test plan:
In documents directory, run `make html` and preview or run `make doctest`.
