### PR TITLE
Add Kubernetes_MCAD scheduler docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,7 @@ Works With
    schedulers/local
    schedulers/docker
    schedulers/kubernetes
+   schedulers/kubernetes_mcad
    schedulers/slurm
    schedulers/ray
    schedulers/aws_batch

--- a/docs/source/schedulers/kubernetes_mcad.rst
+++ b/docs/source/schedulers/kubernetes_mcad.rst
@@ -1,0 +1,28 @@
+Kubernetes-MCAD
+=================
+
+.. automodule:: torchx.schedulers.kubernetes_mcad_scheduler
+
+.. currentmodule:: torchx.schedulers.kubernetes_mcad_scheduler
+
+.. autoclass:: KubernetesMCADScheduler
+   :members:
+   :show-inheritance:
+
+.. autoclass:: KubernetesMCADJob
+   :members:
+
+Reference
+~~~~~~~~~~~~
+
+.. autofunction:: create_scheduler
+.. autofunction:: app_to_resource
+.. autofunction:: mcad_svc
+.. autofunction:: get_appwrapper_status
+.. autofunction:: get_port_for_service
+.. autofunction:: get_role_information
+.. autofunction:: get_tasks_status_description
+.. autofunction:: pod_labels
+.. autofunction:: role_to_pod
+.. autofunction:: sanitize_for_serialization
+

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -755,6 +755,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             describe: true
             workspaces: true
             mounts: true
+            elasticity: false
     """
 
     def __init__(

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -638,7 +638,6 @@ def get_appwrapper_status(app: Dict[str, str]) -> AppState:
 
 # Does not handle not ready to dispatch case
 def get_tasks_status_description(status: Dict[str, str]) -> Dict[str, int]:
-
     results = {}
 
     # Keys related to tasks and status
@@ -1043,7 +1042,6 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             return iterator
 
     def list(self) -> List[ListAppResponse]:
-
         active_context = self._get_active_context()
         namespace = active_context["context"]["namespace"]
 


### PR DESCRIPTION
Added documentation for Kubernetes-MCAD scheduler option

Test plan:
In the docs directory, run `make html` and preview or run `make doctest`
