### PR TITLE
Torchx mcad coscheduler

### DIFF
--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -512,7 +512,6 @@ def app_to_resource(
                 image_secret,
                 coscheduler_name,
             )
-            # pod.metadata.labels.update(pod_labels(app, role_idx, role, replica_id))
             pod.metadata.labels.update(
                 pod_labels(
                     app, role_idx, role, replica_id, coscheduler_name, unique_app_id

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -515,7 +515,9 @@ def app_to_resource(
             )
             # pod.metadata.labels.update(pod_labels(app, role_idx, role, replica_id))
             pod.metadata.labels.update(
-                pod_labels(app, role_idx, role, replica_id, coscheduler_name, unique_app_id)
+                pod_labels(
+                    app, role_idx, role, replica_id, coscheduler_name, unique_app_id
+                )
             )
 
             genericitem: Dict[str, Any] = {
@@ -680,7 +682,6 @@ def get_appwrapper_status(app: Dict[str, str]) -> AppState:
 
 # Does not handle not ready to dispatch case
 def get_tasks_status_description(status: Dict[str, str]) -> Dict[str, int]:
-
     results = {}
 
     # Keys related to tasks and status
@@ -903,7 +904,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             warnings.warn(msg)
         namespace = cfg.get("namespace")
         assert isinstance(namespace, str), "namespace must be a str"
- 
+
         coscheduler_name = cfg.get("coscheduler_name")
         assert coscheduler_name is None or isinstance(
             coscheduler_name, str
@@ -1096,7 +1097,6 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             return iterator
 
     def list(self) -> List[ListAppResponse]:
-
         active_context = self._get_active_context()
         namespace = active_context["context"]["namespace"]
 

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -510,7 +510,12 @@ def app_to_resource(
             )
             pod.metadata.labels.update(
                 pod_labels(
-                    app, role_idx, role, replica_id, coscheduler_name, unique_app_id
+                    app=app,
+                    role_idx=role_idx,
+                    role=role,
+                    replica_id=replica_id,
+                    coscheduler_name=coscheduler_name,
+                    app_id=unique_app_id,
                 )
             )
 
@@ -738,6 +743,14 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
         $ torchx run --scheduler kubernetes_mcad --scheduler_args namespace=default,image_repo=<your_image_repo> utils.echo --image alpine:latest --msg hello
         ...
 
+    The TorchX-MCAD scheduler can be used with a secondary scheduler on Kubernetes.
+    To enable this, the user must provide the name of the coscheduler.
+    With this feature, a PodGroup is defined for each TorchX role and the coscheduler
+    handles secondary scheduling on the Kubernetes cluster. For additional resources, see:
+    1. PodGroups and Coscheduling: https://github.com/kubernetes-sigs/scheduler-plugins/tree/release-1.24/pkg/coscheduling
+    2. Installing Secondary schedulers: https://github.com/kubernetes-sigs/scheduler-plugins/blob/release-1.24/doc/install.md
+    3. PodGroup CRD: https://github.com/kubernetes-sigs/scheduler-plugins/blob/release-1.24/config/crd/bases/scheduling.sigs.k8s.io_podgroups.yaml
+
     **Config Options**
 
     .. runopts::
@@ -906,7 +919,12 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
         ), "coscheduler_name must be a string"
 
         resource = app_to_resource(
-            app, namespace, service_account, image_secret, coscheduler_name, priority
+            app=app,
+            namespace=namespace,
+            service_account=service_account,
+            image_secret=image_secret,
+            coscheduler_name=coscheduler_name,
+            priority=priority,
         )
 
         req = KubernetesMCADJob(

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -13,10 +13,9 @@ components on a Kubernetes cluster via the Multi-Cluster-Application-Dispatcher 
 Prerequisites
 ==============
 
-TorchX kubernetes scheduler depends on AppWrapper + MCAD.
+TorchX Kubernetes_MCAD scheduler depends on AppWrapper + MCAD.
 
-Install MCAD 
-
+Install MCAD: 
 See deploying Multi-Cluster-Application-Dispatcher guide 
 https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/main/doc/deploy/deployment.md
 
@@ -799,6 +798,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             describe: true
             workspaces: true
             mounts: true
+            elasticity: false
     """
 
     def __init__(

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -351,9 +351,9 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         app = _test_app()
         unique_app_name = "app-name"
         namespace = "default"
-        podgroup = create_pod_group(app, namespace, unique_app_name)
+        podgroup = create_pod_group(app.roles[0], namespace, unique_app_name)
 
-        pod_group_name = unique_app_name + "-pg"
+        pod_group_name = unique_app_name + "-" + cleanup_str(app.roles[0].name) + "-pg"
         expected_pod_group: Dict[str, Any] = {
             "apiVersion": "scheduling.sigs.k8s.io/v1alpha1",
             "kind": "PodGroup",
@@ -515,7 +515,7 @@ spec:
         metadata:
           labels:
             appwrapper.mcad.ibm.com: app-name
-          name: app-name-pg
+          name: app-name-trainerfoo-pg
           namespace: test_namespace
         spec:
           minMember: 1
@@ -527,7 +527,7 @@ spec:
           annotations:
             sidecar.istio.io/inject: 'false'
           labels:
-            pod-group.scheduling.sigs.k8s.io: app-name-pg
+            pod-group.scheduling.sigs.k8s.io: app-name-trainerfoo-pg
             torchx.pytorch.org/app-name: test
             torchx.pytorch.org/replica-id: '0'
             torchx.pytorch.org/role-index: '0'

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -171,7 +171,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         ) as make_unique_ctx:
             make_unique_ctx.return_value = unique_app_name
             resource = app_to_resource(
-                app, "default", service_account=None, image_secret=None, priority=0
+                app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
             )
             actual_cmd = (
                 resource["spec"]["resources"]["GenericItems"][0]["generictemplate"]
@@ -192,7 +192,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
     def test_retry_policy_not_set(self) -> None:
         app = _test_app()
         resource = app_to_resource(
-            app, "default", service_account=None, image_secret=None, priority=0
+            app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
         self.assertListEqual(
@@ -205,7 +205,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         for role in app.roles:
             role.max_retries = 0
         resource = app_to_resource(
-            app, "default", service_account=None, image_secret=None, priority=0
+            app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
         self.assertFalse("policies" in item0)
@@ -231,6 +231,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         app = _test_app()
         unique_app_name = "app-name"
         image_secret = "secret-name"
+        coscheduler_name = "test-co-scheduler-name"
         pod = role_to_pod(
             "app-name-0",
             unique_app_name,
@@ -238,6 +239,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             app.roles[0],
             service_account="srvacc",
             image_secret=image_secret,
+            coscheduler_name=coscheduler_name,
         )
         imagesecret = V1LocalObjectReference(name=image_secret)
 
@@ -312,6 +314,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                         ),
                     ),
                 ],
+                scheduler_name=coscheduler_name,
                 node_selector={},
             ),
             metadata=V1ObjectMeta(
@@ -470,7 +473,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             {
                 "priority": 0,
                 "namespace": "test_namespace",
-                "coscheduler": True,
+                "coscheduler_name": "test_coscheduler",
             }
         )
         with patch(
@@ -560,6 +563,7 @@ spec:
           - {{}}
           nodeSelector: {{}}
           restartPolicy: Never
+          schedulerName: test_coscheduler
           subdomain: app-name
           volumes:
           - emptyDir:
@@ -1209,6 +1213,7 @@ spec:
             role,
             service_account="",
             image_secret="",
+            coscheduler_name="",
         )
         self.assertEqual(
             pod.spec.volumes,
@@ -1265,6 +1270,7 @@ spec:
             role,
             service_account="",
             image_secret="",
+            coscheduler_name="",
         )
         self.assertEqual(
             pod.spec.volumes[1:],
@@ -1322,6 +1328,7 @@ spec:
             role,
             service_account="",
             image_secret="",
+            coscheduler_name="",
         )
         self.assertEqual(
             pod.spec.containers[0].resources.limits,
@@ -1356,6 +1363,7 @@ spec:
             role,
             service_account="",
             image_secret="",
+            coscheduler_name="",
         )
         self.assertEqual(
             pod.spec.node_selector,
@@ -1709,7 +1717,7 @@ spec:
                 "service_account",
                 "priority",
                 "image_secret",
-                "coscheduler",
+                "coscheduler_name",
             },
         )
 

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -171,7 +171,12 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         ) as make_unique_ctx:
             make_unique_ctx.return_value = unique_app_name
             resource = app_to_resource(
-                app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
+                app,
+                "default",
+                service_account=None,
+                image_secret=None,
+                coscheduler_name=None,
+                priority=0,
             )
             actual_cmd = (
                 resource["spec"]["resources"]["GenericItems"][0]["generictemplate"]
@@ -192,7 +197,12 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
     def test_retry_policy_not_set(self) -> None:
         app = _test_app()
         resource = app_to_resource(
-            app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
+            app,
+            "default",
+            service_account=None,
+            image_secret=None,
+            coscheduler_name=None,
+            priority=0,
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
         self.assertListEqual(
@@ -205,7 +215,12 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         for role in app.roles:
             role.max_retries = 0
         resource = app_to_resource(
-            app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
+            app,
+            "default",
+            service_account=None,
+            image_secret=None,
+            coscheduler_name=None,
+            priority=0,
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
         self.assertFalse("policies" in item0)
@@ -606,7 +621,6 @@ spec:
     def test_get_role_information(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         get_namespaced_custom_object.return_value = _test_mcad_generic_item()
 
         spec = get_namespaced_custom_object.return_value["spec"]
@@ -644,7 +658,6 @@ spec:
     def test_get_role_information_no_generic_items(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0] = {}
         get_namespaced_custom_object.return_value = test_generic_item
@@ -663,7 +676,6 @@ spec:
     def test_get_role_information_no_metadata(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"] = {
             "spec": {
@@ -716,7 +728,6 @@ spec:
     def test_get_role_information_no_label(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "metadata"
@@ -736,7 +747,6 @@ spec:
     def test_get_role_information_no_role_name(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "metadata"
@@ -756,7 +766,6 @@ spec:
     def test_get_role_information_no_specs(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0] = {
             "generictemplate": {
@@ -801,7 +810,6 @@ spec:
     def test_get_role_information_no_image_name(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -865,7 +873,6 @@ spec:
     def test_get_role_information_no_resources(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -922,7 +929,6 @@ spec:
     def test_get_role_information_no_cpu(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -990,7 +996,6 @@ spec:
     def test_get_role_information_no_memory(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -1058,7 +1063,6 @@ spec:
     def test_get_role_information_no_ports(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -1126,7 +1130,6 @@ spec:
     def test_get_role_information_no_volume_mounts(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -1522,7 +1525,6 @@ spec:
 
     @patch("kubernetes.client.CustomObjectsApi.get_namespaced_custom_object")
     def test_describe(self, get_namespaced_custom_object: MagicMock) -> None:
-
         get_namespaced_custom_object.return_value = {
             "status": {
                 "state": "Running",
@@ -1586,7 +1588,6 @@ spec:
     def test_describe_pending_dispatch(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         get_namespaced_custom_object.return_value = {
             "status": {
                 "state": "Pending",


### PR DESCRIPTION
This addition enables the option of running TorchX-MCAD with a Kubernetes co-scheduler and PodGroups. In shared Kubernetes clusters where some users do not represent their jobs with AppWrappers, the additional use of a co-scheduler helps ensure correct gang scheduling. 

Test plan:
Updated CI test coverage
Testing includes using the new`--coscheduler_name` flag for the kubernetes_mcad scheduler and ensuring that Kubernetes or OpenShift reports the named scheduler when pods are scheduled. 
