### PR TITLE
(torchx/tracker) Allow AppRun.run_from_env() to be used without launc…

### DIFF
--- a/docs/source/app_best_practices.rst
+++ b/docs/source/app_best_practices.rst
@@ -105,7 +105,7 @@ model definition from a python file and then you'll load the weights and state
 dict from a ``.ckpt`` or ``.pt`` file.
 
 This is how Pytorch Lightning's
-`ModelCheckpoint <https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.ModelCheckpoint.html>`__ hook works.
+`ModelCheckpoint <https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.callbacks.ModelCheckpoint.html>`__ hook works.
 
 This is the most common but makes it harder to make a reusable app since your
 trainer app needs to include the model definition code.


### PR DESCRIPTION
Currently, due to the fact that `AppRun.run_from_env()` (aliased as `torchx.tracker.app_run_from_env()`) hard-checks
`TORCHX_JOB_ID` env var to set the `job_id` field of the returned `AppRun` object, the application that uses the tracker HAS to be launched with torchx or the user has to manually set the `TORCHX_JOB_ID` to a dummy value. This makes the app tightly coupled with torchx launcher. 

This change does away with this limitation and allows apps to be written to use the tracker without having to be launched by torchx. When not launched by torchx `TORCHX_JOB_ID` won't be set and `run_from_env()` will create an empty AppRun with no trackers and the `job_id` field set to the name of the program.

Test plan:

Added unittest.
