### PR TITLE
Kubernetes Recommended Labels

### DIFF
--- a/torchx/pipelines/kfp/adapter.py
+++ b/torchx/pipelines/kfp/adapter.py
@@ -175,7 +175,7 @@ def component_from_app(
                 ),
             )
 
-        c.pod_labels.update(pod_labels(app, 0, role_spec, 0))
+        c.pod_labels.update(pod_labels(app, 0, role_spec, 0, app.name))
 
         return c
 

--- a/torchx/pipelines/kfp/test/adapter_test.py
+++ b/torchx/pipelines/kfp/test/adapter_test.py
@@ -129,11 +129,13 @@ outputs: []
             self.assertEqual(
                 a.pod_labels,
                 {
-                    "torchx.pytorch.org/version": torchx.__version__,
-                    "torchx.pytorch.org/app-name": "test",
+                    "app.kubernetes.io/instance": "test",
+                    "app.kubernetes.io/name": "test",
+                    "app.kubernetes.io/part-of": "torchx.pytorch.org",
+                    "app.kubernetes.io/version": torchx.__version__,
+                    "torchx.pytorch.org/replica-id": "0",
                     "torchx.pytorch.org/role-index": "0",
                     "torchx.pytorch.org/role-name": "trainer",
-                    "torchx.pytorch.org/replica-id": "0",
                 },
             )
 

--- a/torchx/pipelines/kfp/test/adapter_test.py
+++ b/torchx/pipelines/kfp/test/adapter_test.py
@@ -130,12 +130,13 @@ outputs: []
                 a.pod_labels,
                 {
                     "app.kubernetes.io/instance": "test",
+                    "app.kubernetes.io/managed-by": "torchx.pytorch.org",
                     "app.kubernetes.io/name": "test",
-                    "app.kubernetes.io/part-of": "torchx.pytorch.org",
-                    "app.kubernetes.io/version": torchx.__version__,
-                    "torchx.pytorch.org/replica-id": "0",
+                    "torchx.pytorch.org/version": torchx.__version__,
+                    "torchx.pytorch.org/app-name": "test",
                     "torchx.pytorch.org/role-index": "0",
                     "torchx.pytorch.org/role-name": "trainer",
+                    "torchx.pytorch.org/replica-id": "0",
                 },
             )
 

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -512,7 +512,6 @@ def app_to_resource(
                 image_secret,
                 coscheduler_name,
             )
-            # pod.metadata.labels.update(pod_labels(app, role_idx, role, replica_id))
             pod.metadata.labels.update(
                 pod_labels(
                     app, role_idx, role, replica_id, coscheduler_name, unique_app_id

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -1150,7 +1150,7 @@ def pod_labels(
         LABEL_ORGANIZATION: "torchx.pytorch.org",
         LABEL_VERSION: torchx.__version__,
         LABEL_UNIQUE_NAME: app_id,
-        LABEL_ROLE_NAME: role.name, 
+        LABEL_ROLE_NAME: role.name,
         LABEL_ROLE_INDEX: str(role_idx),
         LABEL_REPLICA_ID: str(replica_id),
     }

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -515,7 +515,9 @@ def app_to_resource(
             )
             # pod.metadata.labels.update(pod_labels(app, role_idx, role, replica_id))
             pod.metadata.labels.update(
-                pod_labels(app, role_idx, role, replica_id, coscheduler_name, unique_app_id)
+                pod_labels(
+                    app, role_idx, role, replica_id, coscheduler_name, unique_app_id
+                )
             )
 
             genericitem: Dict[str, Any] = {
@@ -680,7 +682,6 @@ def get_appwrapper_status(app: Dict[str, str]) -> AppState:
 
 # Does not handle not ready to dispatch case
 def get_tasks_status_description(status: Dict[str, str]) -> Dict[str, int]:
-
     results = {}
 
     # Keys related to tasks and status
@@ -903,7 +904,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             warnings.warn(msg)
         namespace = cfg.get("namespace")
         assert isinstance(namespace, str), "namespace must be a str"
- 
+
         coscheduler_name = cfg.get("coscheduler_name")
         assert coscheduler_name is None or isinstance(
             coscheduler_name, str
@@ -1096,7 +1097,6 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             return iterator
 
     def list(self) -> List[ListAppResponse]:
-
         active_context = self._get_active_context()
         namespace = active_context["context"]["namespace"]
 

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -1150,6 +1150,7 @@ def create_scheduler(session_name: str, **kwargs: Any) -> KubernetesMCADSchedule
         session_name=session_name,
     )
 
+
 def object_labels(
     app: AppDef,
     app_id: str,
@@ -1159,6 +1160,7 @@ def object_labels(
         LABEL_ORGANIZATION: "torchx.pytorch.org",
         LABEL_UNIQUE_NAME: app_id,
     }
+
 
 def pod_labels(
     app: AppDef,

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -354,8 +354,13 @@ def role_to_pod(
     )
 
 
-def create_pod_group(role: Role, namespace: str, app_id: str) -> "Dict[str, Any]":
+def create_pod_group(
+    app: AppDef, role: Role, namespace: str, app_id: str
+) -> "Dict[str, Any]":
     pod_group_name = app_id + "-" + cleanup_str(role.name) + "-pg"
+
+    labels = object_labels(app, app_id)
+    labels.update({"appwrapper.mcad.ibm.com": app_id})
 
     pod_group: Dict[str, Any] = {
         "apiVersion": "scheduling.sigs.k8s.io/v1alpha1",
@@ -363,9 +368,7 @@ def create_pod_group(role: Role, namespace: str, app_id: str) -> "Dict[str, Any]
         "metadata": {
             "name": pod_group_name,
             "namespace": namespace,
-            "labels": {
-                "appwrapper.mcad.ibm.com": app_id,
-            },
+            "labels": labels,
         },
         "spec": {
             "minMember": role.num_replicas,
@@ -379,7 +382,9 @@ def create_pod_group(role: Role, namespace: str, app_id: str) -> "Dict[str, Any]
     return genericitem_pod_group
 
 
-def mcad_svc(svc_name: str, namespace: str, service_port: str) -> "V1Service":
+def mcad_svc(
+    app: AppDef, svc_name: str, namespace: str, service_port: str
+) -> "V1Service":
     from kubernetes.client.models import (  # noqa: F401, F811
         V1Container,
         V1ContainerPort,
@@ -400,12 +405,15 @@ def mcad_svc(svc_name: str, namespace: str, service_port: str) -> "V1Service":
         V1VolumeMount,
     )
 
+    labels = object_labels(app, svc_name)
+
     return V1Service(
         api_version="v1",
         kind="Service",
         metadata=V1ObjectMeta(
             name=svc_name,
             namespace=namespace,
+            labels=labels,
         ),
         spec=V1ServiceSpec(
             cluster_ip="None",
@@ -479,7 +487,9 @@ def app_to_resource(
 
     if coscheduler_name is not None:
         for role_idx, role in enumerate(app.roles):
-            genericitem_pod_group = create_pod_group(role, namespace, unique_app_id)
+            genericitem_pod_group = create_pod_group(
+                app, role, namespace, unique_app_id
+            )
             genericitems.append(genericitem_pod_group)
 
     for role_idx, role in enumerate(app.roles):
@@ -543,7 +553,9 @@ MCAD currently does not support retries. Role {role.name} configured with restar
 
     service_port = get_port_for_service(app)
 
-    svc_obj = mcad_svc(unique_app_id, namespace, service_port)
+    svc_obj = mcad_svc(
+        app=app, svc_name=unique_app_id, namespace=namespace, service_port=service_port
+    )
 
     genericitem_svc: Dict[str, Any] = {
         "replicas": 1,
@@ -1137,6 +1149,18 @@ def create_scheduler(session_name: str, **kwargs: Any) -> KubernetesMCADSchedule
     )
 
 
+def object_labels(
+    app: AppDef,
+    app_id: str,
+) -> Dict[str, str]:
+    return {
+        LABEL_APP_NAME: app.name,
+        LABEL_ORGANIZATION: "torchx.pytorch.org",
+        LABEL_VERSION: torchx.__version__,
+        LABEL_UNIQUE_NAME: app_id,
+    }
+
+
 def pod_labels(
     app: AppDef,
     role_idx: int,
@@ -1145,16 +1169,15 @@ def pod_labels(
     coscheduler_name: Optional[str],
     app_id: str,
 ) -> Dict[str, str]:
-    labels = {
-        LABEL_APP_NAME: app.name,
-        LABEL_ORGANIZATION: "torchx.pytorch.org",
-        LABEL_VERSION: torchx.__version__,
-        LABEL_UNIQUE_NAME: app_id,
+    labels = object_labels(app, app_id)
+    pod_labels = {
         LABEL_ROLE_NAME: role.name,
         LABEL_ROLE_INDEX: str(role_idx),
         LABEL_REPLICA_ID: str(replica_id),
     }
     if coscheduler_name is not None:
         pod_group = app_id + "-" + cleanup_str(role.name) + "-pg"
-        labels.update({"pod-group.scheduling.sigs.k8s.io": pod_group})
+        pod_labels.update({"pod-group.scheduling.sigs.k8s.io": pod_group})
+
+    labels.update(pod_labels)
     return labels

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -510,7 +510,12 @@ def app_to_resource(
             )
             pod.metadata.labels.update(
                 pod_labels(
-                    app, role_idx, role, replica_id, coscheduler_name, unique_app_id
+                    app=app,
+                    role_idx=role_idx,
+                    role=role,
+                    replica_id=replica_id,
+                    coscheduler_name=coscheduler_name,
+                    app_id=unique_app_id,
                 )
             )
 
@@ -738,6 +743,14 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
         $ torchx run --scheduler kubernetes_mcad --scheduler_args namespace=default,image_repo=<your_image_repo> utils.echo --image alpine:latest --msg hello
         ...
 
+    The TorchX-MCAD scheduler can be used with a secondary scheduler on Kubernetes.
+    To enable this, the user must provide the name of the coscheduler.
+    With this feature, a PodGroup is defined for each TorchX role and the coscheduler
+    handles secondary scheduling on the Kubernetes cluster. For additional resources, see:
+    1. PodGroups and Coscheduling: https://github.com/kubernetes-sigs/scheduler-plugins/tree/release-1.24/pkg/coscheduling
+    2. Installing Secondary schedulers: https://github.com/kubernetes-sigs/scheduler-plugins/blob/release-1.24/doc/install.md
+    3. PodGroup CRD: https://github.com/kubernetes-sigs/scheduler-plugins/blob/release-1.24/config/crd/bases/scheduling.sigs.k8s.io_podgroups.yaml
+
     **Config Options**
 
     .. runopts::
@@ -906,7 +919,12 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
         ), "coscheduler_name must be a string"
 
         resource = app_to_resource(
-            app, namespace, service_account, image_secret, coscheduler_name, priority
+            app=app,
+            namespace=namespace,
+            service_account=service_account,
+            image_secret=image_secret,
+            coscheduler_name=coscheduler_name,
+            priority=priority,
         )
 
         req = KubernetesMCADJob(

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -141,13 +141,15 @@ TASK_STATE: Dict[str, ReplicaState] = {
     "Unknown": ReplicaState.UNKNOWN,
 }
 
-LABEL_APP_NAME = "app.kubernetes.io/name"
-LABEL_ORGANIZATION = "app.kubernetes.io/part-of"
-LABEL_VERSION = "app.kubernetes.io/version"
-LABEL_UNIQUE_NAME = "app.kubernetes.io/instance"
+LABEL_VERSION = "torchx.pytorch.org/version"
+LABEL_APP_NAME = "torchx.pytorch.org/app-name"
 LABEL_ROLE_INDEX = "torchx.pytorch.org/role-index"
 LABEL_ROLE_NAME = "torchx.pytorch.org/role-name"
 LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
+
+LABEL_KUBE_APP_NAME = "app.kubernetes.io/name"
+LABEL_ORGANIZATION = "app.kubernetes.io/managed-by"
+LABEL_UNIQUE_NAME = "app.kubernetes.io/instance"
 
 ANNOTATION_ISTIO_SIDECAR = "sidecar.istio.io/inject"
 
@@ -1148,18 +1150,15 @@ def create_scheduler(session_name: str, **kwargs: Any) -> KubernetesMCADSchedule
         session_name=session_name,
     )
 
-
 def object_labels(
     app: AppDef,
     app_id: str,
 ) -> Dict[str, str]:
     return {
-        LABEL_APP_NAME: app.name,
+        LABEL_KUBE_APP_NAME: app.name,
         LABEL_ORGANIZATION: "torchx.pytorch.org",
-        LABEL_VERSION: torchx.__version__,
         LABEL_UNIQUE_NAME: app_id,
     }
-
 
 def pod_labels(
     app: AppDef,
@@ -1171,8 +1170,10 @@ def pod_labels(
 ) -> Dict[str, str]:
     labels = object_labels(app, app_id)
     pod_labels = {
-        LABEL_ROLE_NAME: role.name,
+        LABEL_VERSION: torchx.__version__,
+        LABEL_APP_NAME: app.name,
         LABEL_ROLE_INDEX: str(role_idx),
+        LABEL_ROLE_NAME: role.name,
         LABEL_REPLICA_ID: str(replica_id),
     }
     if coscheduler_name is not None:

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -141,9 +141,10 @@ TASK_STATE: Dict[str, ReplicaState] = {
     "Unknown": ReplicaState.UNKNOWN,
 }
 
-# TO DO update to standards
-LABEL_VERSION = "torchx.pytorch.org/version"
-LABEL_APP_NAME = "torchx.pytorch.org/app-name"
+LABEL_APP_NAME = "app.kubernetes.io/name"
+LABEL_ORGANIZATION = "app.kubernetes.io/part-of"
+LABEL_VERSION = "app.kubernetes.io/version"
+LABEL_UNIQUE_NAME = "app.kubernetes.io/instance"
 LABEL_ROLE_INDEX = "torchx.pytorch.org/role-index"
 LABEL_ROLE_NAME = "torchx.pytorch.org/role-name"
 LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
@@ -1136,7 +1137,6 @@ def create_scheduler(session_name: str, **kwargs: Any) -> KubernetesMCADSchedule
     )
 
 
-# TODO update to Kubernetes standard labels (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
 def pod_labels(
     app: AppDef,
     role_idx: int,
@@ -1146,10 +1146,12 @@ def pod_labels(
     app_id: str,
 ) -> Dict[str, str]:
     labels = {
-        LABEL_VERSION: torchx.__version__,
         LABEL_APP_NAME: app.name,
+        LABEL_ORGANIZATION: "torchx.pytorch.org",
+        LABEL_VERSION: torchx.__version__,
+        LABEL_UNIQUE_NAME: app_id,
+        LABEL_ROLE_NAME: role.name, 
         LABEL_ROLE_INDEX: str(role_idx),
-        LABEL_ROLE_NAME: role.name,
         LABEL_REPLICA_ID: str(replica_id),
     }
     if coscheduler_name is not None:

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -13,10 +13,9 @@ components on a Kubernetes cluster via the Multi-Cluster-Application-Dispatcher 
 Prerequisites
 ==============
 
-TorchX kubernetes scheduler depends on AppWrapper + MCAD.
+TorchX Kubernetes_MCAD scheduler depends on AppWrapper + MCAD.
 
-Install MCAD 
-
+Install MCAD: 
 See deploying Multi-Cluster-Application-Dispatcher guide 
 https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/main/doc/deploy/deployment.md
 
@@ -799,6 +798,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             describe: true
             workspaces: true
             mounts: true
+            elasticity: false
     """
 
     def __init__(

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -159,15 +159,9 @@ LABEL_APP_NAME = "torchx.pytorch.org/app-name"
 LABEL_ROLE_INDEX = "torchx.pytorch.org/role-index"
 LABEL_ROLE_NAME = "torchx.pytorch.org/role-name"
 LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
-
-
-LABEL_APP_NAME = "app.kubernetes.io/name"
-LABEL_ORGANIZATION = "app.kubernetes.io/part-of"
-LABEL_VERSION = "app.kubernetes.io/version"
+LABEL_KUBE_APP_NAME = "app.kubernetes.io/name"
+LABEL_ORGANIZATION = "app.kubernetes.io/managed-by"
 LABEL_UNIQUE_NAME = "app.kubernetes.io/instance"
-LABEL_ROLE_INDEX = "torchx.pytorch.org/role-index"
-LABEL_ROLE_NAME = "torchx.pytorch.org/role-name"
-LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
 
 ANNOTATION_ISTIO_SIDECAR = "sidecar.istio.io/inject"
 
@@ -793,11 +787,12 @@ def pod_labels(
     app: AppDef, role_idx: int, role: Role, replica_id: int, app_id: str
 ) -> Dict[str, str]:
     return {
-        LABEL_APP_NAME: app.name,
-        LABEL_ORGANIZATION: "torchx.pytorch.org",
         LABEL_VERSION: torchx.__version__,
-        LABEL_UNIQUE_NAME: app_id,
-        LABEL_ROLE_NAME: role.name,
+        LABEL_APP_NAME: app.name,
         LABEL_ROLE_INDEX: str(role_idx),
+        LABEL_ROLE_NAME: role.name,
         LABEL_REPLICA_ID: str(replica_id),
+        LABEL_KUBE_APP_NAME: app.name,
+        LABEL_ORGANIZATION: "torchx.pytorch.org",
+        LABEL_UNIQUE_NAME: app_id,
     }

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -160,6 +160,15 @@ LABEL_ROLE_INDEX = "torchx.pytorch.org/role-index"
 LABEL_ROLE_NAME = "torchx.pytorch.org/role-name"
 LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
 
+
+LABEL_APP_NAME = "app.kubernetes.io/name"
+LABEL_ORGANIZATION = "app.kubernetes.io/part-of"
+LABEL_VERSION = "app.kubernetes.io/version"
+LABEL_UNIQUE_NAME = "app.kubernetes.io/instance"
+LABEL_ROLE_INDEX = "torchx.pytorch.org/role-index"
+LABEL_ROLE_NAME = "torchx.pytorch.org/role-name"
+LABEL_REPLICA_ID = "torchx.pytorch.org/replica-id"
+
 ANNOTATION_ISTIO_SIDECAR = "sidecar.istio.io/inject"
 
 LABEL_INSTANCE_TYPE = "node.kubernetes.io/instance-type"
@@ -372,7 +381,15 @@ def app_to_resource(
                 replica_role.env["TORCHX_RANK0_HOST"] = "localhost"
 
             pod = role_to_pod(name, replica_role, service_account)
-            pod.metadata.labels.update(pod_labels(app, role_idx, role, replica_id))
+            pod.metadata.labels.update(
+                pod_labels(
+                    app=app,
+                    role_idx=role_idx,
+                    role=role,
+                    replica_id=replica_id,
+                    app_id=unique_app_id,
+                )
+            )
             task: Dict[str, Any] = {
                 "replicas": 1,
                 "name": name,
@@ -773,12 +790,14 @@ def create_scheduler(session_name: str, **kwargs: Any) -> KubernetesScheduler:
 
 
 def pod_labels(
-    app: AppDef, role_idx: int, role: Role, replica_id: int
+    app: AppDef, role_idx: int, role: Role, replica_id: int, app_id: str
 ) -> Dict[str, str]:
     return {
-        LABEL_VERSION: torchx.__version__,
         LABEL_APP_NAME: app.name,
-        LABEL_ROLE_INDEX: str(role_idx),
+        LABEL_ORGANIZATION: "torchx.pytorch.org",
+        LABEL_VERSION: torchx.__version__,
+        LABEL_UNIQUE_NAME: app_id,
         LABEL_ROLE_NAME: role.name,
+        LABEL_ROLE_INDEX: str(role_idx),
         LABEL_REPLICA_ID: str(replica_id),
     }

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -351,9 +351,9 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         app = _test_app()
         unique_app_name = "app-name"
         namespace = "default"
-        podgroup = create_pod_group(app, namespace, unique_app_name)
+        podgroup = create_pod_group(app.roles[0], namespace, unique_app_name)
 
-        pod_group_name = unique_app_name + "-pg"
+        pod_group_name = unique_app_name + "-" + cleanup_str(app.roles[0].name) + "-pg"
         expected_pod_group: Dict[str, Any] = {
             "apiVersion": "scheduling.sigs.k8s.io/v1alpha1",
             "kind": "PodGroup",
@@ -515,7 +515,7 @@ spec:
         metadata:
           labels:
             appwrapper.mcad.ibm.com: app-name
-          name: app-name-pg
+          name: app-name-trainerfoo-pg
           namespace: test_namespace
         spec:
           minMember: 1
@@ -527,7 +527,7 @@ spec:
           annotations:
             sidecar.istio.io/inject: 'false'
           labels:
-            pod-group.scheduling.sigs.k8s.io: app-name-pg
+            pod-group.scheduling.sigs.k8s.io: app-name-trainerfoo-pg
             torchx.pytorch.org/app-name: test
             torchx.pytorch.org/replica-id: '0'
             torchx.pytorch.org/role-index: '0'

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -171,7 +171,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         ) as make_unique_ctx:
             make_unique_ctx.return_value = unique_app_name
             resource = app_to_resource(
-                app, "default", service_account=None, image_secret=None, priority=0
+                app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
             )
             actual_cmd = (
                 resource["spec"]["resources"]["GenericItems"][0]["generictemplate"]
@@ -192,7 +192,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
     def test_retry_policy_not_set(self) -> None:
         app = _test_app()
         resource = app_to_resource(
-            app, "default", service_account=None, image_secret=None, priority=0
+            app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
         self.assertListEqual(
@@ -205,7 +205,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         for role in app.roles:
             role.max_retries = 0
         resource = app_to_resource(
-            app, "default", service_account=None, image_secret=None, priority=0
+            app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
         self.assertFalse("policies" in item0)
@@ -231,6 +231,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         app = _test_app()
         unique_app_name = "app-name"
         image_secret = "secret-name"
+        coscheduler_name = "test-co-scheduler-name"
         pod = role_to_pod(
             "app-name-0",
             unique_app_name,
@@ -238,6 +239,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             app.roles[0],
             service_account="srvacc",
             image_secret=image_secret,
+            coscheduler_name=coscheduler_name,
         )
         imagesecret = V1LocalObjectReference(name=image_secret)
 
@@ -312,6 +314,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                         ),
                     ),
                 ],
+                scheduler_name=coscheduler_name,
                 node_selector={},
             ),
             metadata=V1ObjectMeta(
@@ -470,7 +473,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             {
                 "priority": 0,
                 "namespace": "test_namespace",
-                "coscheduler": True,
+                "coscheduler_name": "test_coscheduler",
             }
         )
         with patch(
@@ -560,6 +563,7 @@ spec:
           - {{}}
           nodeSelector: {{}}
           restartPolicy: Never
+          schedulerName: test_coscheduler
           subdomain: app-name
           volumes:
           - emptyDir:
@@ -1209,6 +1213,7 @@ spec:
             role,
             service_account="",
             image_secret="",
+            coscheduler_name="",
         )
         self.assertEqual(
             pod.spec.volumes,
@@ -1265,6 +1270,7 @@ spec:
             role,
             service_account="",
             image_secret="",
+            coscheduler_name="",
         )
         self.assertEqual(
             pod.spec.volumes[1:],
@@ -1322,6 +1328,7 @@ spec:
             role,
             service_account="",
             image_secret="",
+            coscheduler_name="",
         )
         self.assertEqual(
             pod.spec.containers[0].resources.limits,
@@ -1356,6 +1363,7 @@ spec:
             role,
             service_account="",
             image_secret="",
+            coscheduler_name="",
         )
         self.assertEqual(
             pod.spec.node_selector,
@@ -1709,7 +1717,7 @@ spec:
                 "service_account",
                 "priority",
                 "image_secret",
-                "coscheduler",
+                "coscheduler_name",
             },
         )
 

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -171,7 +171,12 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         ) as make_unique_ctx:
             make_unique_ctx.return_value = unique_app_name
             resource = app_to_resource(
-                app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
+                app,
+                "default",
+                service_account=None,
+                image_secret=None,
+                coscheduler_name=None,
+                priority=0,
             )
             actual_cmd = (
                 resource["spec"]["resources"]["GenericItems"][0]["generictemplate"]
@@ -192,7 +197,12 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
     def test_retry_policy_not_set(self) -> None:
         app = _test_app()
         resource = app_to_resource(
-            app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
+            app,
+            "default",
+            service_account=None,
+            image_secret=None,
+            coscheduler_name=None,
+            priority=0,
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
         self.assertListEqual(
@@ -205,7 +215,12 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         for role in app.roles:
             role.max_retries = 0
         resource = app_to_resource(
-            app, "default", service_account=None, image_secret=None, coscheduler_name=None, priority=0
+            app,
+            "default",
+            service_account=None,
+            image_secret=None,
+            coscheduler_name=None,
+            priority=0,
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
         self.assertFalse("policies" in item0)
@@ -606,7 +621,6 @@ spec:
     def test_get_role_information(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         get_namespaced_custom_object.return_value = _test_mcad_generic_item()
 
         spec = get_namespaced_custom_object.return_value["spec"]
@@ -644,7 +658,6 @@ spec:
     def test_get_role_information_no_generic_items(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0] = {}
         get_namespaced_custom_object.return_value = test_generic_item
@@ -663,7 +676,6 @@ spec:
     def test_get_role_information_no_metadata(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"] = {
             "spec": {
@@ -716,7 +728,6 @@ spec:
     def test_get_role_information_no_label(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "metadata"
@@ -736,7 +747,6 @@ spec:
     def test_get_role_information_no_role_name(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "metadata"
@@ -756,7 +766,6 @@ spec:
     def test_get_role_information_no_specs(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0] = {
             "generictemplate": {
@@ -801,7 +810,6 @@ spec:
     def test_get_role_information_no_image_name(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -865,7 +873,6 @@ spec:
     def test_get_role_information_no_resources(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -922,7 +929,6 @@ spec:
     def test_get_role_information_no_cpu(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -990,7 +996,6 @@ spec:
     def test_get_role_information_no_memory(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -1058,7 +1063,6 @@ spec:
     def test_get_role_information_no_ports(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -1126,7 +1130,6 @@ spec:
     def test_get_role_information_no_volume_mounts(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         test_generic_item = _test_mcad_generic_item()
         test_generic_item["spec"]["resources"]["GenericItems"][0]["generictemplate"][
             "spec"
@@ -1522,7 +1525,6 @@ spec:
 
     @patch("kubernetes.client.CustomObjectsApi.get_namespaced_custom_object")
     def test_describe(self, get_namespaced_custom_object: MagicMock) -> None:
-
         get_namespaced_custom_object.return_value = {
             "status": {
                 "state": "Running",
@@ -1586,7 +1588,6 @@ spec:
     def test_describe_pending_dispatch(
         self, get_namespaced_custom_object: MagicMock
     ) -> None:
-
         get_namespaced_custom_object.return_value = {
             "status": {
                 "state": "Pending",

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -527,12 +527,14 @@ spec:
           annotations:
             sidecar.istio.io/inject: 'false'
           labels:
+            app.kubernetes.io/instance: app-name
+            app.kubernetes.io/name: test
+            app.kubernetes.io/part-of: torchx.pytorch.org
+            app.kubernetes.io/version: {torchx.__version__}
             pod-group.scheduling.sigs.k8s.io: app-name-trainerfoo-pg
-            torchx.pytorch.org/app-name: test
             torchx.pytorch.org/replica-id: '0'
             torchx.pytorch.org/role-index: '0'
             torchx.pytorch.org/role-name: trainer_foo
-            torchx.pytorch.org/version: {torchx.__version__}
           name: app-name-0
           namespace: test_namespace
         spec:

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -2021,7 +2021,3 @@ class KubernetesMCADSchedulerNoImportTest(unittest.TestCase):
 
         with self.assertRaises(ModuleNotFoundError):
             scheduler._submit_dryrun(app, cfg)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -362,8 +362,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                 "namespace": namespace,
                 "labels": {
                     "app.kubernetes.io/name": "test",
-                    "app.kubernetes.io/part-of": "torchx.pytorch.org",
-                    "app.kubernetes.io/version": torchx.__version__,
+                    "app.kubernetes.io/managed-by": "torchx.pytorch.org",
                     "app.kubernetes.io/instance": "app-name",
                     "appwrapper.mcad.ibm.com": unique_app_name,
                 },
@@ -416,8 +415,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                 namespace=namespace,
                 labels={
                     "app.kubernetes.io/name": "test",
-                    "app.kubernetes.io/part-of": "torchx.pytorch.org",
-                    "app.kubernetes.io/version": torchx.__version__,
+                    "app.kubernetes.io/managed-by": "torchx.pytorch.org",
                     "app.kubernetes.io/instance": "test_service",
                 },
             ),
@@ -526,9 +524,8 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/instance: app-name
+            app.kubernetes.io/managed-by: torchx.pytorch.org
             app.kubernetes.io/name: test
-            app.kubernetes.io/part-of: torchx.pytorch.org
-            app.kubernetes.io/version: {torchx.__version__}
             appwrapper.mcad.ibm.com: app-name
           name: app-name-trainerfoo-pg
           namespace: test_namespace
@@ -543,13 +540,14 @@ spec:
             sidecar.istio.io/inject: 'false'
           labels:
             app.kubernetes.io/instance: app-name
+            app.kubernetes.io/managed-by: torchx.pytorch.org
             app.kubernetes.io/name: test
-            app.kubernetes.io/part-of: torchx.pytorch.org
-            app.kubernetes.io/version: {torchx.__version__}
             pod-group.scheduling.sigs.k8s.io: app-name-trainerfoo-pg
+            torchx.pytorch.org/app-name: test
             torchx.pytorch.org/replica-id: '0'
             torchx.pytorch.org/role-index: '0'
             torchx.pytorch.org/role-name: trainer_foo
+            torchx.pytorch.org/version: {torchx.__version__}
           name: app-name-0
           namespace: test_namespace
         spec:
@@ -617,9 +615,8 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/instance: app-name
+            app.kubernetes.io/managed-by: torchx.pytorch.org
             app.kubernetes.io/name: test
-            app.kubernetes.io/part-of: torchx.pytorch.org
-            app.kubernetes.io/version: {torchx.__version__}
           name: app-name
           namespace: test_namespace
         spec:

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -351,7 +351,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         app = _test_app()
         unique_app_name = "app-name"
         namespace = "default"
-        podgroup = create_pod_group(app.roles[0], namespace, unique_app_name)
+        podgroup = create_pod_group(app, app.roles[0], namespace, unique_app_name)
 
         pod_group_name = unique_app_name + "-" + cleanup_str(app.roles[0].name) + "-pg"
         expected_pod_group: Dict[str, Any] = {
@@ -361,6 +361,10 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                 "name": pod_group_name,
                 "namespace": namespace,
                 "labels": {
+                    "app.kubernetes.io/name": "test",
+                    "app.kubernetes.io/part-of": "torchx.pytorch.org",
+                    "app.kubernetes.io/version": torchx.__version__,
+                    "app.kubernetes.io/instance": "app-name",
                     "appwrapper.mcad.ibm.com": unique_app_name,
                 },
             },
@@ -398,10 +402,11 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             V1VolumeMount,
         )
 
+        app = _test_app()
         service_name = "test_service"
         service_port = "1234"
         namespace = "default"
-        test_service = mcad_svc(service_name, namespace, service_port)
+        test_service = mcad_svc(app, service_name, namespace, service_port)
 
         want = V1Service(
             api_version="v1",
@@ -409,6 +414,12 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             metadata=V1ObjectMeta(
                 name=service_name,
                 namespace=namespace,
+                labels={
+                    "app.kubernetes.io/name": "test",
+                    "app.kubernetes.io/part-of": "torchx.pytorch.org",
+                    "app.kubernetes.io/version": torchx.__version__,
+                    "app.kubernetes.io/instance": "test_service",
+                },
             ),
             spec=V1ServiceSpec(
                 cluster_ip="None",
@@ -514,6 +525,10 @@ spec:
         kind: PodGroup
         metadata:
           labels:
+            app.kubernetes.io/instance: app-name
+            app.kubernetes.io/name: test
+            app.kubernetes.io/part-of: torchx.pytorch.org
+            app.kubernetes.io/version: {torchx.__version__}
             appwrapper.mcad.ibm.com: app-name
           name: app-name-trainerfoo-pg
           namespace: test_namespace
@@ -600,6 +615,11 @@ spec:
         apiVersion: v1
         kind: Service
         metadata:
+          labels:
+            app.kubernetes.io/instance: app-name
+            app.kubernetes.io/name: test
+            app.kubernetes.io/part-of: torchx.pytorch.org
+            app.kubernetes.io/version: {torchx.__version__}
           name: app-name
           namespace: test_namespace
         spec:
@@ -2001,3 +2021,7 @@ class KubernetesMCADSchedulerNoImportTest(unittest.TestCase):
 
         with self.assertRaises(ModuleNotFoundError):
             scheduler._submit_dryrun(app, cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -277,12 +277,13 @@ spec:
           sidecar.istio.io/inject: 'false'
         labels:
           app.kubernetes.io/instance: app-name-42
+          app.kubernetes.io/managed-by: torchx.pytorch.org
           app.kubernetes.io/name: test
-          app.kubernetes.io/part-of: torchx.pytorch.org
-          app.kubernetes.io/version: {torchx.__version__}
+          torchx.pytorch.org/app-name: test
           torchx.pytorch.org/replica-id: '0'
           torchx.pytorch.org/role-index: '0'
           torchx.pytorch.org/role-name: trainer_foo
+          torchx.pytorch.org/version: {torchx.__version__}
       spec:
         containers:
         - command:

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -276,11 +276,13 @@ spec:
         annotations:
           sidecar.istio.io/inject: 'false'
         labels:
-          torchx.pytorch.org/app-name: test
+          app.kubernetes.io/instance: app-name-42
+          app.kubernetes.io/name: test
+          app.kubernetes.io/part-of: torchx.pytorch.org
+          app.kubernetes.io/version: {torchx.__version__}
           torchx.pytorch.org/replica-id: '0'
           torchx.pytorch.org/role-index: '0'
           torchx.pytorch.org/role-name: trainer_foo
-          torchx.pytorch.org/version: {torchx.__version__}
       spec:
         containers:
         - command:


### PR DESCRIPTION
Kubernetes recommends a set of standard labels for Kubernetes Objects. By updating some of the current TorchX Pod, Service, and PodGroup labels to match the recommended Kubernetes labels, this PR aims to improve the interoperability of TorchX on Kubernetes with common cloud tools. For more information on recommended Kubernetes labels, see https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

Test plan:
Updated the CI tests for kubernetes_mcad, kubernetes, and impacted KubeFlow Pipelines adapter
