### PR TITLE
component_integration_tests: fix fork tests

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -11,6 +11,7 @@
   ],
   "site_package_search_strategy": "all",
   "source_directories": [
+    "scripts",
     "."
   ],
   "search_path": [

--- a/scripts/component_integration_tests.py
+++ b/scripts/component_integration_tests.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 import example_app_defs as examples_app_defs_providers
 import torchx.components.integration_tests.component_provider as component_provider
-from integ_test_utils import build_images, BuildInfo, MissingEnvError, push_images
+from integ_test_utils import build_images, BuildInfo, push_images
 from torchx.cli.colors import BLUE, ENDC, GRAY
 from torchx.components.integration_tests.integ_tests import IntegComponentTest
 from torchx.schedulers import get_scheduler_factories
@@ -26,9 +26,6 @@ logging.basicConfig(
     format=f"{GRAY}%(asctime)s{ENDC} {BLUE}%(name)-12s{ENDC} %(levelname)-8s %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-
-# pyre-ignore-all-errors[21] # Cannot find module utils
-# pyre-ignore-all-errors[11]
 
 
 def build_and_push_image(container_repo: str) -> BuildInfo:
@@ -68,12 +65,12 @@ def main() -> None:
         "lsf",
         "gcp_batch",
     ):
-        try:
-            build = build_and_push_image(args.container_repo)
-            torchx_image = build.torchx_image
-        except MissingEnvError:
-            dryrun = True
-            print("Skip running tests, executed only docker build step")
+        build = build_and_push_image(args.container_repo)
+        torchx_image = build.torchx_image
+
+    if args.container_repo == "" and scheduler == "aws_batch" and not args.mock:
+        dryrun = True
+        print("Skip running tests, executed only docker build step")
 
     run_parameters = {
         "kubernetes": {

--- a/scripts/integ_test_utils.py
+++ b/scripts/integ_test_utils.py
@@ -65,6 +65,8 @@ def build_images() -> BuildInfo:
 
 
 def push_images(build: BuildInfo, container_repo: str) -> None:
+    if container_repo == "":
+        return
     torchx_tag = torchx_container_tag(container_repo=container_repo, id=build.id)
     run("docker", "tag", build.torchx_image, torchx_tag)
     build.torchx_image = torchx_tag

--- a/scripts/kfpint.py
+++ b/scripts/kfpint.py
@@ -49,8 +49,6 @@ from typing import Any, Callable, Iterator, Optional, TypeVar
 
 import kfp
 
-# pyre-ignore-all-errors[21] # Cannot find module utils
-# pyre-ignore-all-errors[11]
 from integ_test_utils import (
     build_images,
     BuildInfo,

--- a/scripts/kube_dist_trainer.py
+++ b/scripts/kube_dist_trainer.py
@@ -12,15 +12,17 @@ Kubernetes integration tests.
 import argparse
 import os
 
-from integ_test_utils import build_images, BuildInfo, MissingEnvError, push_images
+from integ_test_utils import (
+    build_images,
+    BuildInfo,
+    getenv_asserts,
+    MissingEnvError,
+    push_images,
+)
 from torchx.components.dist import ddp as dist_ddp
 from torchx.runner import get_runner
 from torchx.specs import _named_resource_factories, AppState, Resource
 from torchx.util.types import none_throws
-
-
-# pyre-ignore-all-errors[21] # Cannot find module utils
-# pyre-ignore-all-errors[11]
 
 
 GiB: int = 1024
@@ -42,7 +44,7 @@ def register_gpu_resource() -> None:
 
 def build_and_push_image() -> BuildInfo:
     build = build_images()
-    push_images(build, container_repo=os.getenv("CONTAINER_REPO"))
+    push_images(build, container_repo=getenv_asserts("CONTAINER_REPO"))
     return build
 
 


### PR DESCRIPTION
<!-- Change Summary -->

This fixes the component_integration_tests so they only build for remote tests.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
scripts/component_integration_tests.py --scheduler local_docker --container_repo ""
scripts/component_integration_tests.py --scheduler aws_batch --container_repo ""
```