### PR TITLE
(torchx/schedulers) AWSBatchScheduler; add privileged option to enabl…

### DIFF
--- a/torchx/tracker/api.py
+++ b/torchx/tracker/api.py
@@ -281,7 +281,7 @@ class AppRun:
             for tracker in trackers:
                 tracker.add_source(torchx_job_id, parent_run_id, artifact_name=None)
 
-        return AppRun(id=torchx_job_id, backends=trackers_from_environ())
+        return AppRun(id=torchx_job_id, backends=trackers)
 
     def add_metadata(self, **kwargs: object) -> None:
         """Stores metadata for the current run"""


### PR DESCRIPTION
1. Adds privileged runopt to aws batch scheduler
2. Also fixes a double call to create trackers from env in `tracker/api.py`, which discards parent run source information since a new set of trackers are created and hooked to the AppRun.

Test plan:

Added unittests to cover relevant changes
