### PR TITLE
Torchx mcad advanced networking and bug fixes

### DIFF
--- a/docs/source/app_best_practices.rst
+++ b/docs/source/app_best_practices.rst
@@ -105,7 +105,7 @@ model definition from a python file and then you'll load the weights and state
 dict from a ``.ckpt`` or ``.pt`` file.
 
 This is how Pytorch Lightning's
-`ModelCheckpoint <https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.callbacks.ModelCheckpoint.html>`__ hook works.
+`ModelCheckpoint <https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html>`__ hook works.
 
 This is the most common but makes it harder to make a reusable app since your
 trainer app needs to include the model definition code.

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -447,7 +447,7 @@ def cleanup_str(data: str) -> str:
     if data.startswith("-"):
         data = data[1:]
     pattern = r"[a-z0-9\-]"
-    return "".join(re.findall(pattern, data.lower()))
+    return "".join(re.findall(pattern, data.lower())).lstrip("0123456789")
 
 
 def get_port_for_service(app: AppDef) -> str:
@@ -577,7 +577,7 @@ MCAD currently does not support retries. Role {role.name} configured with restar
     resource: Dict[str, object] = {
         "apiVersion": "mcad.ibm.com/v1beta1",
         "kind": "AppWrapper",
-        "metadata": {"name": unique_app_id},
+        "metadata": {"name": unique_app_id, "namespace": namespace},
         "spec": job_spec,
     }
     return resource

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -779,6 +779,12 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
     2. Installing Secondary schedulers: https://github.com/kubernetes-sigs/scheduler-plugins/blob/release-1.24/doc/install.md
     3. PodGroup CRD: https://github.com/kubernetes-sigs/scheduler-plugins/blob/release-1.24/config/crd/bases/scheduling.sigs.k8s.io_podgroups.yaml
 
+    The MCAD scheduler supports priorities at the AppWrapper level and optionally at the pod level on clusters with PriorityClass definitions.
+    At the AppWrapper level, higher integer values means higher priorities. Kubernetes clusters may have additional priorityClass
+    definitions that can be applied at the pod level. While these different levels of priorities can be set independently, 
+    it is recommended to check with your Kubernetes cluster admin to see if additional guidance is in place. For more on Kubernetes
+    PriorityClass, see: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/ .
+
     In order to use the network option, the Kubernetes cluster must have multus installed.
     For multus installation instructions and how to set up a network custom network attachment definition, see:
     https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -162,6 +162,7 @@ def sanitize_for_serialization(obj: object) -> object:
     api = client.ApiClient()
     return api.sanitize_for_serialization(obj)
 
+
 def role_to_pod(
     name: str,
     unique_app_id: str,
@@ -330,13 +331,12 @@ def role_to_pod(
 
     # Get correct formatting for image secret
     imagesecret = V1LocalObjectReference(name=image_secret)
-    metadata=V1ObjectMeta(
+    metadata = V1ObjectMeta(
         name=name,
         annotations={
             # Disable the istio sidecar as it prevents the containers from
             # exiting once finished.
             ANNOTATION_ISTIO_SIDECAR: "false",
-            #"k8s.v1.cni.cncf.io/networks": network,
         },
         labels={},
         namespace=namespace,
@@ -781,7 +781,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
 
     The MCAD scheduler supports priorities at the AppWrapper level and optionally at the pod level on clusters with PriorityClass definitions.
     At the AppWrapper level, higher integer values means higher priorities. Kubernetes clusters may have additional priorityClass
-    definitions that can be applied at the pod level. While these different levels of priorities can be set independently, 
+    definitions that can be applied at the pod level. While these different levels of priorities can be set independently,
     it is recommended to check with your Kubernetes cluster admin to see if additional guidance is in place. For more on Kubernetes
     PriorityClass, see: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/ .
 
@@ -958,13 +958,11 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
 
         priority_class_name = cfg.get("priority_class_name")
         assert priority_class_name is None or isinstance(
-           priority_class_name, str 
+            priority_class_name, str
         ), "priority_class_name must be a string"
 
         network = cfg.get("network")
-        assert network is None or isinstance(
-           network, str
-        ), "network must be a string" 
+        assert network is None or isinstance(network, str), "network must be a string"
 
         resource = app_to_resource(
             app=app,
@@ -1043,7 +1041,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
         opts.add(
             "network",
             type_=str,
-            help="Name of additional pod-to-pod network beyond default Kubernetes network" 
+            help="Name of additional pod-to-pod network beyond default Kubernetes network",
         )
         return opts
 

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -176,6 +176,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                 service_account=None,
                 image_secret=None,
                 coscheduler_name=None,
+                priority_class_name=None,
                 priority=0,
             )
             actual_cmd = (
@@ -202,6 +203,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             service_account=None,
             image_secret=None,
             coscheduler_name=None,
+            priority_class_name=None,
             priority=0,
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
@@ -220,6 +222,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             service_account=None,
             image_secret=None,
             coscheduler_name=None,
+            priority_class_name=None,
             priority=0,
         )
         item0 = resource["spec"]["resources"]["GenericItems"][0]
@@ -247,6 +250,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         unique_app_name = "app-name"
         image_secret = "secret-name"
         coscheduler_name = "test-co-scheduler-name"
+        priority_class_name = "default-priority"
         pod = role_to_pod(
             "app-name-0",
             unique_app_name,
@@ -255,6 +259,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             service_account="srvacc",
             image_secret=image_secret,
             coscheduler_name=coscheduler_name,
+            priority_class_name=priority_class_name,
         )
         imagesecret = V1LocalObjectReference(name=image_secret)
 
@@ -331,6 +336,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                 ],
                 scheduler_name=coscheduler_name,
                 node_selector={},
+                priority_class_name=priority_class_name,
             ),
             metadata=V1ObjectMeta(
                 annotations={
@@ -1238,6 +1244,7 @@ spec:
             service_account="",
             image_secret="",
             coscheduler_name="",
+            priority_class_name="",
         )
         self.assertEqual(
             pod.spec.volumes,
@@ -1295,6 +1302,7 @@ spec:
             service_account="",
             image_secret="",
             coscheduler_name="",
+            priority_class_name="",
         )
         self.assertEqual(
             pod.spec.volumes[1:],
@@ -1353,6 +1361,7 @@ spec:
             service_account="",
             image_secret="",
             coscheduler_name="",
+            priority_class_name="",
         )
         self.assertEqual(
             pod.spec.containers[0].resources.limits,
@@ -1388,6 +1397,7 @@ spec:
             service_account="",
             image_secret="",
             coscheduler_name="",
+            priority_class_name="", 
         )
         self.assertEqual(
             pod.spec.node_selector,
@@ -1498,6 +1508,24 @@ spec:
         del cfg["priority"]
         info = scheduler._submit_dryrun(app, cfg)
         self.assertIn("'priority': None", str(info.request.resource))
+
+    def test_submit_dryrun_priority_class_name(self) -> None:
+        scheduler = create_scheduler("test")
+        self.assertIn("priority_class_name", scheduler.run_opts()._opts)
+        app = _test_app()
+        cfg = KubernetesMCADOpts(
+            {
+                "namespace": "testnamespace",
+                "priority_class_name": "test-priority",
+            }
+        )
+
+        info = scheduler._submit_dryrun(app, cfg)
+        self.assertIn("'priority_class_name': 'test-priority'", str(info.request.resource))
+
+        del cfg["priority_class_name"]
+        info = scheduler._submit_dryrun(app, cfg)
+        self.assertIn("'priority_class_name': None", str(info.request.resource))
 
     @patch("kubernetes.client.CustomObjectsApi.create_namespaced_custom_object")
     def test_submit(self, create_namespaced_custom_object: MagicMock) -> None:
@@ -1738,6 +1766,7 @@ spec:
                 "image_repo",
                 "service_account",
                 "priority",
+                "priority_class_name",
                 "image_secret",
                 "coscheduler_name",
             },

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -254,7 +254,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         image_secret = "secret-name"
         coscheduler_name = "test-co-scheduler-name"
         priority_class_name = "default-priority"
-        network = "test-network-conf" 
+        network = "test-network-conf"
         pod = role_to_pod(
             "app-name-0",
             unique_app_name,
@@ -346,7 +346,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
             metadata=V1ObjectMeta(
                 annotations={
                     "sidecar.istio.io/inject": "false",
-                    "k8s.v1.cni.cncf.io/networks": "test-network-conf",  
+                    "k8s.v1.cni.cncf.io/networks": "test-network-conf",
                 },
                 labels={},
                 name="app-name-0",
@@ -1408,7 +1408,7 @@ spec:
             service_account="",
             image_secret="",
             coscheduler_name="",
-            priority_class_name="", 
+            priority_class_name="",
             network="",
         )
         self.assertEqual(
@@ -1533,7 +1533,9 @@ spec:
         )
 
         info = scheduler._submit_dryrun(app, cfg)
-        self.assertIn("'priority_class_name': 'test-priority'", str(info.request.resource))
+        self.assertIn(
+            "'priority_class_name': 'test-priority'", str(info.request.resource)
+        )
 
         del cfg["priority_class_name"]
         info = scheduler._submit_dryrun(app, cfg)
@@ -1551,7 +1553,10 @@ spec:
         )
 
         info = scheduler._submit_dryrun(app, cfg)
-        self.assertIn("'k8s.v1.cni.cncf.io/networks': 'test-network-conf'", str(info.request.resource))
+        self.assertIn(
+            "'k8s.v1.cni.cncf.io/networks': 'test-network-conf'",
+            str(info.request.resource),
+        )
 
         del cfg["network"]
         info = scheduler._submit_dryrun(app, cfg)

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -452,6 +452,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         self.assertEqual("abcd123", cleanup_str("-/_a/b/CD!123!"))
         self.assertEqual("a-bcd123", cleanup_str("-a-bcd123"))
         self.assertEqual("", cleanup_str("!!!"))
+        self.assertEqual("abcd1234", cleanup_str("1234abcd1234"))
 
     def test_get_port_for_service(self) -> None:
         scheduler = create_scheduler("test")
@@ -514,6 +515,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
 kind: AppWrapper
 metadata:
   name: app-name
+  namespace: test_namespace
 spec:
   priority: 0
   resources:


### PR DESCRIPTION
This pull request adds the following features:

- network - An option to include pod-to-pod networking in addition to standard Kubernetes networks. This option assumes the user has installed multus on their Kubernetes cluster and created an additional network configuration. Documentation updates include references for further details.
- priority_class_name - On some Kubernetes clusters, named pod priority classes may be configured. This option adds the priorityClassName field to the pods. The addition of this feature improves priority scheduling behavior on Kubernetes clusters that use MCAD priorities in combination with pod PriorityClasses.

It also includes the following bug fix:
- Kubernetes services follow the [RFC 1035 naming requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names). This bug fix removes integer values at the start of the Kubernetes object names via the cleanup_str function. 

Finally, there is a small update to the AppWrapper metadata to include the Kubernetes namespace.

Test plan:
Each item listed above includes updates to the Kubernetes-MCAD CI tests.
