### PR TITLE
dependencies: unpin pyre and fix issues

### DIFF
--- a/.github/workflows/pyre.yaml
+++ b/.github/workflows/pyre.yaml
@@ -21,7 +21,5 @@ jobs:
         run: |
           set -eux
           pip install -e .[dev]
-          VERSION=$(grep "version" .pyre_configuration | sed -n -e 's/.*\(0\.0\.[0-9]*\).*/\1/p')
-          pip install pyre-check-nightly==$VERSION
       - name: Run Pyre
         run: scripts/pyre.sh

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -17,6 +17,5 @@
   "search_path": [
     "stubs"
   ],
-  "strict": true,
-  "version": "0.0.101662549039"
+  "strict": true
 }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,8 @@ hydra-core
 ipython
 kfp==1.8.9
 moto==4.1.3
-pyre-extensions==0.0.29
+pyre-extensions
+pyre-check
 pytest
 pytorch-lightning==1.5.10
 torch-model-archiver>=0.4.2

--- a/scripts/kfpint.py
+++ b/scripts/kfpint.py
@@ -66,7 +66,6 @@ T = TypeVar("T")
 
 def get_fn_name(fn: Callable[..., T]) -> str:
     if hasattr(fn, "__qualname__"):
-        # pyre-ignore[16]
         return fn.__qualname__
     elif hasattr(fn, "__name__"):
         return fn.__name__

--- a/torchx/components/component_test_base.py
+++ b/torchx/components/component_test_base.py
@@ -68,7 +68,10 @@ class ComponentTestCase(unittest.TestCase):
         """
 
         # make it the same as a custom component (e.g. /abs/path/to/component.py:train)
-        component_id = f"{os.path.abspath(module.__file__)}:{function_name}"
+        module_path = module.__file__
+        assert module_path, f"module must have __file__: {module_path}"
+        module_path = os.path.abspath(module_path)
+        component_id = f"{module_path}:{function_name}"
         component_def = get_component(component_id)
 
         # on `--help` argparse will print the help message and exit 0

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -244,7 +244,6 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         expected_app_id = make_unique(app.name)
         cfg = {"log_dir": self.test_dir}
         with patch(LOCAL_SCHEDULER_MAKE_UNIQUE, return_value=expected_app_id):
-
             app_id = self.scheduler.submit(app, cfg)
 
         self.assertEqual(f"{expected_app_id}", app_id)
@@ -282,7 +281,9 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         app = AppDef(name="test_app", roles=[role])
         self.scheduler.submit(app, cfg={})
         self.scheduler.close()
-        self.assertFalse(os.path.exists(self.scheduler._base_log_dir))
+        base_log_dir = self.scheduler._base_log_dir
+        self.assertIsNotNone(base_log_dir)
+        self.assertFalse(os.path.exists(base_log_dir))
         self.assertTrue(self.scheduler._created_tmp_log_dir)
 
     def test_macros_env(self) -> None:

--- a/torchx/specs/finder.py
+++ b/torchx/specs/finder.py
@@ -223,7 +223,9 @@ class ModuleComponentsFinder(ComponentsFinder):
         functions = getmembers(module, isfunction)
         component_defs = []
 
-        module_path = os.path.abspath(module.__file__)
+        module_path = module.__file__
+        assert module_path, f"module must have __file__: {module_path}"
+        module_path = os.path.abspath(module_path)
         rel_module_name = module_relname(module, relative_to=self.base_module)
         for function_name, function in functions:
             linter_errors = validate(module_path, function_name)


### PR DESCRIPTION
<!-- Change Summary -->

This makes us use the stable pyre release and should resolve typing issues to our CI using an outdated pyre version

https://github.com/pytorch/torchx/issues/705

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pip install -r dev-requirements.txt --upgrade
pyre
```