### PR TITLE
runopts: infer from TypedDict

### DIFF
--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Generic, Iterable, List, Optional, TypeVar
 
+import typing_inspect
+
 from torchx.specs import (
     AppDef,
     AppDryRunInfo,
@@ -23,6 +25,7 @@ from torchx.specs import (
     runopts,
 )
 from torchx.workspace.api import WorkspaceMixin
+from typing_extensions import final
 
 
 DAYS_IN_2_WEEKS = 14
@@ -184,6 +187,7 @@ class Scheduler(abc.ABC, Generic[T]):
     def _submit_dryrun(self, app: AppDef, cfg: T) -> AppDryRunInfo:
         raise NotImplementedError()
 
+    @final
     def run_opts(self) -> runopts:
         """
         Returns the run configuration options expected by the scheduler.
@@ -195,6 +199,11 @@ class Scheduler(abc.ABC, Generic[T]):
         return opts
 
     def _run_opts(self) -> runopts:
+        # pyre-fixme[16]: no attribute __orig_bases__
+        for base in self.__class__.__orig_bases__:
+            if typing_inspect.get_origin(base) == Scheduler:
+                return runopts.from_typed_dict(typing_inspect.get_args(base)[0])
+
         return runopts()
 
     @abc.abstractmethod

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -35,7 +35,6 @@ from torchx.specs.api import (
     ReplicaStatus,
     Role,
     RoleStatus,
-    runopts,
     VolumeMount,
 )
 from torchx.workspace.docker_workspace import DockerWorkspaceMixin
@@ -95,6 +94,13 @@ def has_docker() -> bool:
 
 
 class DockerOpts(TypedDict, total=False):
+    """
+    Attributes
+    ----------
+    copy_env:
+        list of glob patterns of environment variables to copy if not set in AppDef. Ex: FOO_*",
+    """
+
     copy_env: Optional[List[str]]
 
 
@@ -340,16 +346,6 @@ class DockerScheduler(DockerWorkspaceMixin, Scheduler[DockerOpts]):
         containers = self._get_containers(app_id)
         for container in containers:
             container.stop()
-
-    def _run_opts(self) -> runopts:
-        opts = runopts()
-        opts.add(
-            "copy_env",
-            type_=List[str],
-            default=None,
-            help="list of glob patterns of environment variables to copy if not set in AppDef. Ex: FOO_*",
-        )
-        return opts
 
     def _get_app_state(self, container: "Container") -> AppState:
         if container.status == "exited":

--- a/torchx/schedulers/gcp_batch_scheduler.py
+++ b/torchx/schedulers/gcp_batch_scheduler.py
@@ -315,7 +315,7 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
 
         return AppDryRunInfo(req, repr)
 
-    def run_opts(self) -> runopts:
+    def _run_opts(self) -> runopts:
         opts = runopts()
         opts.add(
             "project",

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -15,8 +15,8 @@ Prerequisites
 
 TorchX Kubernetes_MCAD scheduler depends on AppWrapper + MCAD.
 
-Install MCAD: 
-See deploying Multi-Cluster-Application-Dispatcher guide 
+Install MCAD:
+See deploying Multi-Cluster-Application-Dispatcher guide
 https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/main/doc/deploy/deployment.md
 
 TorchX uses `torch.distributed.run <https://pytorch.org/docs/stable/elastic/run.html>`_ to run distributed training.
@@ -560,7 +560,7 @@ MCAD currently does not support retries. Role {role.name} configured with restar
 
     """
     Create Service:
-    The selector will have the key 'appwrapper.mcad.ibm.com', and the value will be 
+    The selector will have the key 'appwrapper.mcad.ibm.com', and the value will be
     the appwrapper name
     """
 
@@ -945,7 +945,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
         if image_secret is not None and service_account is not None:
             msg = """Service Account and Image Secret names are both provided.
  Depending on the Service Account configuration, an ImagePullSecret may be defined in your Service Account.
- If this is the case, check service account and image secret configurations to understand the expected behavior for 
+ If this is the case, check service account and image secret configurations to understand the expected behavior for
  patched image push access."""
             warnings.warn(msg)
         namespace = cfg.get("namespace")
@@ -1000,18 +1000,13 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             name=name,
         )
 
-    def run_opts(self) -> runopts:
+    def _run_opts(self) -> runopts:
         opts = runopts()
         opts.add(
             "namespace",
             type_=str,
             help="Kubernetes namespace to schedule job in",
             default="default",
-        )
-        opts.add(
-            "image_repo",
-            type_=str,
-            help="The image repository to use when pushing patched images, must have push access. Ex: example.com/your/container",
         )
         opts.add(
             "service_account",


### PR DESCRIPTION
<!-- Change Summary -->

This adds a new `runopts.from_typed_dict` method and uses it to generate the runopts from the typed dict field, annotations, default parameters and docstring.

This simplifies adding new fields to schedulers since you only need to define it in a single spot.

I've migrated DockerScheduler to use the new runopts and will do the rest in a follow up PR.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pytest torchx/specs/test/api_test.py torchx/schedulers/test/api_test.py

(torchx) rice@ariel ~/D/torchx (runopts_typedict)> torchx runopts local_docker
local_docker:
    usage:
        [copy_env=COPY_ENV],[image_repo=IMAGE_REPO]

    optional arguments:
        copy_env=COPY_ENV (typing.List[str], None)
            list of glob patterns of environment variables to copy if not set in AppDef. Ex: FOO_*",
        image_repo=IMAGE_REPO (str, None)
            (remote jobs) the image repository to use when pushing patched images, must have push access. Ex: example.com/your/con
tainer

```
