### PR TITLE
component_integration_tests: use compute_world instead of dummy_app

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,7 @@ hydra-core
 ipython
 kfp==1.8.9
 mlflow-skinny
-moto==4.1.3
+moto==4.1.6
 pyre-extensions
 pyre-check
 pytest

--- a/scripts/component_integration_tests.py
+++ b/scripts/component_integration_tests.py
@@ -166,6 +166,12 @@ def _mock_aws_batch() -> None:
     This sets up a mock AWS batch backend that uses Docker to execute the jobs
     locally.
     """
+    # setup the docker network so DNS works correctly
+    from torchx.schedulers.docker_scheduler import ensure_network, NETWORK
+
+    ensure_network()
+    os.environ.setdefault("MOTO_DOCKER_NETWORK_NAME", NETWORK)
+
     from moto import mock_batch, mock_ec2, mock_ecs, mock_iam, mock_logs
 
     mock_batch().__enter__()

--- a/torchx/components/integration_tests/component_provider.py
+++ b/torchx/components/integration_tests/component_provider.py
@@ -37,12 +37,15 @@ class ComponentProvider(ABC):
 class DDPComponentProvider(ComponentProvider):
     def get_app_def(self) -> AppDef:
         return dist_components.ddp(
-            script="torchx/components/integration_tests/test/dummy_app.py",
+            m="torchx.examples.apps.compute_world_size.main",
             name="ddp-trainer",
             image=self._image,
             cpu=1,
             j="2x2",
             max_retries=3,
+            env={
+                "LOGLEVEL": "INFO",
+            },
         )
 
 


### PR DESCRIPTION
<!-- Change Summary -->

This switches component_integration_tests to use an app that actually tests connectivity between nodes instead of just exiting.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
scripts/component_integration_tests.py --scheduler local_docker --container_repo ""
```
