### PR TITLE
(torchx/tracker)(bugfix) honor tracker config in the usual .torchxcon…

### DIFF
--- a/torchx/cli/argparse_util.py
+++ b/torchx/cli/argparse_util.py
@@ -5,13 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from argparse import Action, ArgumentParser, Namespace
-from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Text
 
 from torchx.runner import config
-
-
-CONFIG_DIRS = [str(Path.home()), str(Path.cwd())]
 
 
 class _torchxconfig(Action):
@@ -40,7 +36,6 @@ class _torchxconfig(Action):
             config.get_configs(
                 prefix="cli",
                 name=subcmd,
-                dirs=CONFIG_DIRS,
             ),
         )
 

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -15,7 +15,7 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple
 
 import torchx.specs as specs
-from torchx.cli.argparse_util import CONFIG_DIRS, torchxconfig_run
+from torchx.cli.argparse_util import torchxconfig_run
 from torchx.cli.cmd_base import SubCommand
 from torchx.cli.cmd_log import get_logs
 from torchx.runner import config, get_runner, Runner
@@ -182,12 +182,11 @@ class CmdRun(SubCommand):
 
         scheduler_opts = runner.scheduler_run_opts(args.scheduler)
         cfg = scheduler_opts.cfg_from_str(args.scheduler_args)
-        config.apply(scheduler=args.scheduler, cfg=cfg, dirs=CONFIG_DIRS)
+        config.apply(scheduler=args.scheduler, cfg=cfg)
 
         component, component_args = _parse_component_name_and_args(
             args.component_name_and_args,
             none_throws(self._subparser),
-            dirs=CONFIG_DIRS,
         )
         try:
             if args.dryrun:
@@ -243,7 +242,8 @@ class CmdRun(SubCommand):
 
     def run(self, args: argparse.Namespace) -> None:
         os.environ["TORCHX_CONTEXT_NAME"] = os.getenv("TORCHX_CONTEXT_NAME", "cli_run")
-        component_defaults = load_sections(prefix="component", dirs=CONFIG_DIRS)
+        component_defaults = load_sections(prefix="component")
+
         with get_runner(component_defaults=component_defaults) as runner:
             self._run(runner, args)
 

--- a/torchx/cli/main.py
+++ b/torchx/cli/main.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 import sys
 from argparse import ArgumentParser
 from typing import Dict, List
@@ -75,9 +76,9 @@ def create_parser(subcmds: Dict[str, SubCommand]) -> ArgumentParser:
     parser = ArgumentParser(description="torchx CLI")
     parser.add_argument(
         "--log_level",
-        type=int,
+        type=str,
         help="Python logging log level",
-        default=logging.INFO,
+        default=os.getenv("LOGLEVEL", "WARNING"),
     )
     parser.add_argument(
         "--version",

--- a/torchx/cli/test/argparse_util_test.py
+++ b/torchx/cli/test/argparse_util_test.py
@@ -4,38 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import shutil
-import tempfile
-import unittest
 from argparse import ArgumentParser
-from pathlib import Path
 from unittest import mock
 
 from torchx.cli import argparse_util
 from torchx.cli.argparse_util import torchxconfig_run
+from torchx.test.fixtures import TestWithTmpDir
+
+DEFAULT_CONFIG_DIRS = "torchx.runner.config.DEFAULT_CONFIG_DIRS"
 
 
-CONFIG_DIRS = "torchx.cli.argparse_util.CONFIG_DIRS"
-
-
-class ArgparseUtilTest(unittest.TestCase):
-    def _write(self, filename: str, content: str) -> Path:
-        f = Path(self.test_dir) / filename
-        f.parent.mkdir(parents=True, exist_ok=True)
-        with open(f, "w") as fp:
-            fp.write(content)
-        return f
-
+class ArgparseUtilTest(TestWithTmpDir):
     def setUp(self) -> None:
-        self.test_dir = tempfile.mkdtemp(prefix="torchx_argparse_util_test")
+        super().setUp()
         argparse_util._torchxconfig._subcmd_configs.clear()
 
-    def tearDown(self) -> None:
-        shutil.rmtree(self.test_dir)
-
     def test_torchxconfig_action(self) -> None:
-        with mock.patch(CONFIG_DIRS, [self.test_dir]):
-            self._write(
+        with mock.patch(DEFAULT_CONFIG_DIRS, [str(self.tmpdir)]):
+            self.write(
                 ".torchxconfig",
                 """
 [cli:run]
@@ -64,8 +50,8 @@ workspace = baz
             self.assertEqual("baz", args.workspace)
 
     def test_torchxconfig_action_argparse_default(self) -> None:
-        with mock.patch(CONFIG_DIRS, [self.test_dir]):
-            self._write(
+        with mock.patch(DEFAULT_CONFIG_DIRS, [str(self.tmpdir)]):
+            self.write(
                 ".torchxconfig",
                 """
 [cli:run]
@@ -89,8 +75,8 @@ workspace = baz
             self.assertEqual("foo", args.workspace)
 
     def test_torchxconfig_action_required(self) -> None:
-        with mock.patch(CONFIG_DIRS, [self.test_dir]):
-            self._write(
+        with mock.patch(DEFAULT_CONFIG_DIRS, [str(self.tmpdir)]):
+            self.write(
                 ".torchxconfig",
                 """
 [cli:run]
@@ -120,8 +106,8 @@ workspace = bazz
 
     def test_torchxconfig_action_aliases(self) -> None:
         # for aliases, the config file needs to declare the original arg
-        with mock.patch(CONFIG_DIRS, [self.test_dir]):
-            self._write(
+        with mock.patch(DEFAULT_CONFIG_DIRS, [str(self.tmpdir)]):
+            self.write(
                 ".torchxconfig",
                 """
 [cli:run]

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -134,7 +134,9 @@ class CmdRunTest(unittest.TestCase):
     def test_conf_file_missing(self) -> None:
         # guards against existing .torchxconfig files
         # in user's $HOME or the CWD where the test is launched from
-        with patch("torchx.cli.cmd_run.CONFIG_DIRS", return_value=[self.tmpdir]):
+        with patch(
+            "torchx.runner.config.DEFAULT_CONFIG_DIRS", return_value=[self.tmpdir]
+        ):
             with self.assertRaises(SystemExit):
                 args = self.parser.parse_args(
                     [

--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -169,6 +169,7 @@ from torchx.specs.api import runopt
 CONFIG_FILE = ".torchxconfig"
 CONFIG_PREFIX_DELIM = ":"
 ENV_TORCHXCONFIG = "TORCHXCONFIG"
+DEFAULT_CONFIG_DIRS = [str(Path.home()), str(Path.cwd())]
 
 _NONE = "None"
 
@@ -390,6 +391,9 @@ def load_sections(
                 section = sections.setdefault(name, {})
                 for key, value in config.items(section_name):
                     if key not in section:
+                        log.debug(
+                            f"Loaded config: {prefix}.{key}={value} from {configfile}"
+                        )
                         section[key] = value
 
     return sections
@@ -457,8 +461,8 @@ def find_configs(dirs: Optional[Iterable[str]] = None) -> List[str]:
        the ``dirs`` parameter is NOT searched.
     2. Otherwise, a ``.torchxconfig`` file is looked for in ``dirs`` and
        the filepaths to existing config files are returned. If ``dirs`` is
-       not specified or is empty then, this method looks for a ``.torchxconfig`` file
-       in CWD (current working dir) and returns the filepath to it if one exists.
+       not specified or is empty then ``dirs`` defaults to ``[$HOME, $CWD]``
+       where CWD is current working dir.
 
     """
 
@@ -473,7 +477,7 @@ def find_configs(dirs: Optional[Iterable[str]] = None) -> List[str]:
     else:
         config_files = []
         if not dirs:
-            dirs = [str(Path.cwd())]
+            dirs = DEFAULT_CONFIG_DIRS
         for d in dirs:
             configfile = Path(d) / CONFIG_FILE
             if configfile.exists():

--- a/torchx/test/fixtures.py
+++ b/torchx/test/fixtures.py
@@ -18,6 +18,8 @@ from typing import Callable, Dict, Iterable, List, TypeVar, Union
 from torch.distributed.elastic.multiprocessing import Std
 from torch.distributed.launcher import elastic_launch, LaunchConfig
 
+from torchx.schedulers.test import test_util
+
 IS_CI: bool = os.getenv("CI", "false").lower() == "true"
 IS_MACOS: bool = sys.platform == "darwin"
 
@@ -90,6 +92,29 @@ class TestWithTmpDir(unittest.TestCase):
         with open(f, "w") as fout:
             fout.writelines(content)
         return f
+
+    def write_shell_script(self, script_path: str, content: List[str]) -> Path:
+        """
+        Writes a bash script with the body as provided by ``content`` in the test's tmp directory.
+        The content should not include the shebang (``#!/bin/bash``) header as one is added automatically.
+        The shell script is also made executable (``chmod 755``) so that it can be run from test methods.
+
+        Usage:
+
+        .. code-block:: python
+
+         p = self.write_shell_script("echo.sh", ["echo hello", "echo world"])
+         assert p == self.tmpdir / "echo.sh"
+
+         p = self.write_shell_script("bin/echo.sh", ["echo hello", "echo world"])
+         assert p == self.tmpdir / "bin" / "echo.sh")
+
+        Returns: The path to the written shell script.
+
+        """
+        return Path(
+            test_util.write_shell_script(str(self.tmpdir), script_path, content)
+        )
 
     def read(self, filepath: Union[str, Path]) -> List[str]:
         """

--- a/torchx/tracker/__init__.py
+++ b/torchx/tracker/__init__.py
@@ -91,8 +91,8 @@ To accomplish that define entrypoint in the distribution in `entry_points.txt` a
     entry_point_name=my_module:create_tracker_fn
 
 
-Aquiring :py:class:`~torchx.tracker.api.AppRun` instance
---------------------------------------------------------
+Acquiring :py:class:`~torchx.tracker.api.AppRun` instance
+-------------------------------------------------------------
 
 Use :py:meth:`~torchx.tracker.app_run_from_env`:
 


### PR DESCRIPTION
Bug Description
-----------------
When getting the configured trackers in [`runner.api.get_configured_trackers()`](https://github.com/pytorch/torchx/blob/main/torchx/runner/api.py#L56) we were not passing the `dir` argument to `get_configs(prefix="torchx", name="tracker")` hence we were ignoring any overriden tracker config from `$HOME/.torchxconfig`. 

Bug Fix
-----------------
Make `find_config()` look for `.torchxconfig` in `[$HOME, $CWD]` (previously was just defaulting to `[$CWD]`) if `dirs` is not specified + removed overriding `dirs` in all calls to `get_config()`. 

> Note: this makes it easy for us to put the config loading hierarchy logic in one place (eventually get rid of `dirs` argument altogether) therefore will make it easier to revamp `.torchxconfig` to use structured configs with well-defined config loading hierarchy.

Also Changed
-----------------
* Extract env vars like `"TORCHX_JOB_ID", "TORCHX_PARENT_RUN_ID"` as constants
* Cleaned up log messages in `tracker.api`
* Make use to `torchx.test.fixtures.TestWithTmpDir` to make the tests classes that I touched cleaner.

Test plan
-----------

Added unittests for the pieces of code I touched.
