### PR TITLE
Update GH ReadMe for GCP Batch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ TorchX currently supports:
 * Docker
 * Local
 * Ray (prototype)
+* GCP Batch (prototype)
 
 Need a scheduler not listed? [Let us know!](https://github.com/pytorch/torchx/issues?q=is%3Aopen+is%3Aissue+label%3Ascheduler-request)
 
@@ -62,6 +63,9 @@ pip install "torchx[kubernetes]"
 
 # install torchx Ray support
 pip install "torchx[ray]"
+
+# install torchx GCP Batch support
+pip install "torchx[gcp_batch]"
 ```
 
 ### Nightly


### PR DESCRIPTION
Summary: GCP Batch has been supported since 0.4.0 release, updating ReadMe to reflect the same

Differential Revision: D44443961

