### PR TITLE
(torchx/cli)(bugfix) print dryrun info in CLI rather than using log.info

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -198,12 +198,12 @@ class CmdRun(SubCommand):
                     cfg=cfg,
                     parent_run_id=args.parent_run_id,
                 )
-                logger.info(
+                print(
                     "\n=== APPLICATION ===\n"
                     f"{pformat(asdict(dryrun_info._app), indent=2, width=80)}"
                 )
 
-                logger.info("\n=== SCHEDULER REQUEST ===\n" f"{dryrun_info}")
+                print("\n=== SCHEDULER REQUEST ===\n" f"{dryrun_info}")
             else:
                 app_handle = runner.run_component(
                     component,


### PR DESCRIPTION
`torchx run --dryrun` is meant to actually print the results of the dryrun to STDOUT. We were using `log.info()` to print out the dryrun information which stopped producing any output when the default log level of the CLI was changed to WARNING in this commit (https://github.com/pytorch/torchx/commit/47976f77df0f50128658ba947efadb88235c66d1). Changed to `print()`. 

Test plan:
-----------------

Validated that with no changes to loglevel I get output from `torchx run --dryrun`

```
(ape) ubuntu@ip-10-2-87-95(main↑1|●1…1)% torchx run --dryrun  -- -j 1x2 --script ape/examples/distributed/ddp.py
/home/ubuntu/workspace/ape/ape/components/__init__.py:276: UserWarning: In `-j 1x2` you specified nproc_per_node=2 which does not equal the number of GPUs on a p4d.24xlarge: 8. This may lead to under-utilization or an error.  If this was intentional, ignore this warning. Otherwise set `-j 1` to auto-set nproc_per_node to the number of GPUs on the host.
  warnings.warn(

=== APPLICATION ===
{ 'metadata': {},
  'name': 'ddp',
  'roles': [ { 'args': [ '-c',
                         'torchrun --rdzv_backend c10d --rdzv_endpoint '
                         "localhost:0 --rdzv_id '${app_id}' --nnodes 1 "
                         "--nproc_per_node 2 --tee 3 --role '' "
                         'ape/examples/distributed/ddp.py'],
               'base_image': None,
               'entrypoint': 'bash',
               'env': { 'APE_TRACKING_EXPERIMENT_NAME': 'default-experiment/ubuntu/ip-10-2-87-95.us-west-2.compute.internal',
                        'FI_EFA_USE_DEVICE_RDMA': '1',
                        'FI_PROVIDER': 'efa',
                        'LOGLEVEL': 'WARNING',
                        'NCCL_SOCKET_IFNAME': 'eth,ens',
                        'PATH': '/home/ubuntu/workspace/ape',
                        'TORCHX_JOB_ID': 'local_cwd://torchx/${app_id}',
                        'TORCHX_TRACKERS': 'mlflow',
                        'TORCHX_TRACKER_MLFLOW_CONFIG': './',
                        'TORCHX_TRACKING_EXPERIMENT_NAME': 'default-experiment'},
               'image': '763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:1.13.1-gpu-py39-cu117-ubuntu20.04-ec2',
               'max_retries': 0,
               'metadata': {},
               'min_replicas': 1,
               'mounts': [],
               'name': 'ddp',
               'num_replicas': 1,
               'port_map': {'c10d': 29500},
               'resource': { 'capabilities': { 'node.kubernetes.io/instance-type': 'p4d.24xlarge'},
                             'cpu': 96,
                             'devices': {'vpc.amazonaws.com/efa': 4},
                             'gpu': 8,
                             'memMB': 1143265},
               'retry_policy': <RetryPolicy.APPLICATION: 'APPLICATION'>}]}

=== SCHEDULER REQUEST ===
{ 'app_id': 'ddp-ztrtm7p5v2n4wc',
  'log_dir': '/tmp/torchx_2o2yk2uy/torchx/ddp-ztrtm7p5v2n4wc',
  'role_log_dirs': { 'ddp': [ '/tmp/torchx_2o2yk2uy/torchx/ddp-ztrtm7p5v2n4wc/ddp/0']},
  'role_params': { 'ddp': [ { 'args': [ 'bash',
                                        '-c',
                                        'torchrun --rdzv_backend c10d '
                                        '--rdzv_endpoint localhost:0 --rdzv_id '
                                        "'ddp-ztrtm7p5v2n4wc' --nnodes 1 "
                                        "--nproc_per_node 2 --tee 3 --role '' "
                                        'ape/examples/distributed/ddp.py'],
                              'combined': '/tmp/torchx_2o2yk2uy/torchx/ddp-ztrtm7p5v2n4wc/ddp/0/combined.log',
                              'cwd': '/home/ubuntu/workspace/ape',
                              'env': { 'APE_TRACKING_EXPERIMENT_NAME': 'default-experiment/ubuntu/ip-10-2-87-95.us-west-2.compute.internal',
                                       'CUDA_VISIBLE_DEVICES': '0,1,2,3,4,5,6,7',
                                       'FI_EFA_USE_DEVICE_RDMA': '1',
                                       'FI_PROVIDER': 'efa',
                                       'LOGLEVEL': 'WARNING',
                                       'NCCL_SOCKET_IFNAME': 'eth,ens',
                                       'PATH': '/home/ubuntu/workspace/ape',
                                       'PET_LOG_DIR': '/tmp/torchx_2o2yk2uy/torchx/ddp-ztrtm7p5v2n4wc/torchelastic/ddp',
                                       'TORCHELASTIC_ERROR_FILE': '/tmp/torchx_2o2yk2uy/torchx/ddp-ztrtm7p5v2n4wc/ddp/0/error.json',
                                       'TORCHX_JOB_ID': 'local_cwd://torchx/ddp-ztrtm7p5v2n4wc',
                                       'TORCHX_RANK0_HOST': 'localhost',
                                       'TORCHX_TRACKERS': 'mlflow',
                                       'TORCHX_TRACKER_MLFLOW_CONFIG': './',
                                       'TORCHX_TRACKING_EXPERIMENT_NAME': 'default-experiment'},
                              'stderr': '/tmp/torchx_2o2yk2uy/torchx/ddp-ztrtm7p5v2n4wc/ddp/0/stderr.log',
                              'stdout': '/tmp/torchx_2o2yk2uy/torchx/ddp-ztrtm7p5v2n4wc/ddp/0/stdout.log'}]}}
```
