### PR TITLE
Fix broken link

### DIFF
--- a/torchx/schedulers/lsf_scheduler.py
+++ b/torchx/schedulers/lsf_scheduler.py
@@ -19,7 +19,7 @@ You'll need either an existing LSF cluster to run your jobs or for individuals
 you can install LSF Community Edition.
 
 See the LSF documentation for more details:
-https://www.ibm.com/support/pages/where-do-i-download-lsf-community-edition
+https://www.ibm.com/docs/en/cloud-private/3.2.x?topic=paks-spectrum-lsf-community-edition
 """
 import os.path
 import re


### PR DESCRIPTION
Summary:
https://www.ibm.com/support/pages/where-do-i-download-lsf-community-edition is broken and causes  https://github.com/pytorch/torchx/actions/runs/4566862341/jobs/8062047280 to fail.
Fixing that with a link to the latest lsf community edition doc.

Differential Revision: D44598111

