### PR TITLE
(torchx/cli) change the job status to print from log.info in CLI stat…

### DIFF
--- a/torchx/cli/cmd_status.py
+++ b/torchx/cli/cmd_status.py
@@ -52,7 +52,7 @@ class CmdStatus(SubCommand):
         app_status = runner.status(app_handle)
         filter_roles = parse_list_arg(args.roles)
         if app_status:
-            logger.info(app_status.format(filter_roles))
+            print(app_status.format(filter_roles))
         else:
             logger.error(
                 f"AppDef: {app_id},"

--- a/torchx/cli/main.py
+++ b/torchx/cli/main.py
@@ -78,7 +78,7 @@ def create_parser(subcmds: Dict[str, SubCommand]) -> ArgumentParser:
         "--log_level",
         type=str,
         help="Python logging log level",
-        default=os.getenv("LOGLEVEL", "WARNING"),
+        default=os.getenv("LOGLEVEL", "INFO"),
     )
     parser.add_argument(
         "--version",


### PR DESCRIPTION
The rest of the subcommands (run, describe, list, etc) all print (versus `log.info`) to stdout the relevant output. `torchx status` was logging the status information rather than outputting to stdout.

Per some user feedback (that the INFO level logging was actually useful) switching back the default loglevel of the CLI to INFO.

Test plan:
-----------

torchx status
==================

Validated that torchx status outputs as expected

```
(ape) kiuk@ip-10-0-61-167(main↑2|✔)% torchx status aws_batch://torchx/FS-P4D_24XL-Training-us-west-2d:multi_task-2node-fixed-default-bsplt90dl3j0f
AppStatus:
    State: FAILED
    Num Restarts: -1
    Roles:
    Msg: <NONE>
    Structured Error Msg: <NONE>
    UI URL: https://us-west-2.console.aws.amazon.com/batch/home?region=us-west-2#jobs/mnp-job/e54d88ed-cd6c-4a3f-b16d-8d81505deeb3
```

torchx run
===============

Validated that the INFO logging is back

```
(ape) kiuk@ip-10-0-61-167(main↑2|✔)% torchx run -- -j 1x1 --script ape/examples/distributed/ddp.py   ~/workspace/ape
torchx 2023-04-01 00:56:38 INFO     loaded configs from /home/kiuk/workspace/ape/.torchxconfig
/home/kiuk/.pyenv/versions/3.9.16/envs/ape/lib/python3.9/site-packages/ape/components/__init__.py:276: UserWarning: In `-j 1x1` you specified nproc_per_node=1 which does not equal the number of GPUs on a p4d.24xlarge: 8. This may lead t
o under-utilization or an error.  If this was intentional, ignore this warning. Otherwise set `-j 1` to auto-set nproc_per_node to the number of GPUs on the host.
  warnings.warn(
torchx 2023-04-01 00:56:41 INFO     Tracker configurations: {'mlflow': './'}
torchx 2023-04-01 00:56:41 INFO     Log directory not set in scheduler cfg. Creating a temporary log dir that will be deleted on exit. To preserve log directory set the `log_dir` cfg option
torchx 2023-04-01 00:56:41 INFO     Log directory is: /tmp/torchx_svbrpssi
local_cwd://torchx/ddp-ps056x3sjh70q
torchx 2023-04-01 00:56:41 INFO     Waiting for the app to finish...
ddp/0 master_addr is only used for static rdzv_backend and when rdzv_endpoint is not specified.
ddp/0 [0]:2023-04-01 00:56:45 INFO ape.ape_main Environment Variables:
ddp/0 [0]:  TORCHELASTIC_ERROR_FILE= /tmp/torchx_svbrpssi/torchx/ddp-ps056x3sjh70q/torchelastic/ddp/ddp-ps056x3sjh70q_y5b7f1uo/attempt_0/0/error.json
ddp/0 [0]:  NCCL_SOCKET_IFNAME= eth,ens
```

torchx run + pipe to status
================================

pipe the app handle from run to status

```
 torchx run -s aws_batch -- -j 1x1 --script ape/examples/distributed/ddp.py | xargs -I {} torchx status {}
```


