### PR TITLE
(torchx/tracking)(bugfix) Allow multiple ranks to properly add artifa…

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -16,6 +16,9 @@ jobs:
           - python-version: 3.9
             platform: macos-12-xl
       fail-fast: false
+    env:
+      OS: ${{ matrix.platform }}
+      PYTHON: ${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Python ${{ matrix.python-version }}
@@ -28,16 +31,16 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
-          pip install coverage codecov
+          pip install pytest pytest-cov
           pip install -e .[dev]
       - name: Run tests
-        run: coverage run -m unittest discover --verbose --start-directory . --pattern "*_test.py"
-      - name: Coverage
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: |
-          set -eux
-          coverage report -m
-          coverage xml
-
-          codecov
+        run: pytest --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          files: ./coverage.xml,!./cache
+          flags: unittests
+          verbose: true

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,6 @@ aiobotocore==2.4.2
 ax-platform[mysql]==0.2.3
 black==23.3.0
 boto3==1.24.59
-boto3-stubs[batch]
 captum>=0.4.0
 flake8==3.9.0
 fsspec[s3]==2023.1.0

--- a/torchx/distributed/__init__.py
+++ b/torchx/distributed/__init__.py
@@ -17,9 +17,9 @@ from typing import Any, Iterator
 import torch
 import torch.distributed as dist
 from torch.distributed.distributed_c10d import _get_default_group
-from typing_extensions import Literal
 
 from torchx.util.cuda import has_cuda_devices
+from typing_extensions import Literal
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ log: logging.Logger = logging.getLogger(__name__)
 def local_rank() -> int:
     """
     Returns the local rank (aka rank within the node) of this process.
-    Typically the local rank is used to set the CUDA device on the node.
+    Typically, the local rank is used to set the CUDA device on the node.
 
     .. warning::
         This function only works correctly if the invoker of the program sets ``LOCAL_RANK`` env var
@@ -37,23 +37,22 @@ def local_rank() -> int:
 
     """
 
-    if not dist.is_initialized():
-        return 0
-
-    if "LOCAL_RANK" not in os.environ:
-        warnings.warn(
-            "\n"
-            "==============================================================================================\n"
-            "`LOCAL_RANK` environment variable is not set. Will trivially return 0 for local_rank.\n"
-            " It is recommended to use torchrun/torchx to run your script or set the `LOCAL_RANK` manually.\n"
-            " For additional details see:\n"
-            "  1) https://pytorch.org/torchx/latest/components/distributed.html\n"
-            "  2) https://pytorch.org/docs/stable/elastic/run.html\n"
-            "=============================================================================================="
-        )
-        return 0
-    else:
+    if "LOCAL_RANK" in os.environ:
         return int(os.environ["LOCAL_RANK"])
+    else:  # "LOCAL_RANK" not in os.environ
+        if dist.is_initialized():
+            warnings.warn(
+                "\n"
+                "==============================================================================================\n"
+                " The default torch.distributed process group is initialized\n"
+                " but the `LOCAL_RANK` environment variable is not set. Will trivially return 0 for local_rank.\n"
+                " It is recommended to use torchrun/torchx to run your script or set the `LOCAL_RANK` manually.\n"
+                " For additional details see:\n"
+                "  1) https://pytorch.org/torchx/latest/components/distributed.html\n"
+                "  2) https://pytorch.org/docs/stable/elastic/run.html\n"
+                "=============================================================================================="
+            )
+        return 0
 
 
 def local_cuda_device() -> torch.device:

--- a/torchx/examples/apps/compute_world_size/config/defaults.yaml
+++ b/torchx/examples/apps/compute_world_size/config/defaults.yaml
@@ -6,5 +6,7 @@ main:
   rank: 0
   world_size: 1
   master_addr: localhost
-  master_port: 29500
+  # specifying 0 as master_port makes TCPStore chose a free random port
+  # but this only works for single node (for multi-node you must specify a static port)
+  master_port: 0
   throws: False

--- a/torchx/examples/apps/compute_world_size/module/test/util_test.py
+++ b/torchx/examples/apps/compute_world_size/module/test/util_test.py
@@ -13,10 +13,10 @@ from torchx.examples.apps.compute_world_size.module.util import compute_world_si
 
 
 class UtilTest(unittest.TestCase):
-
     # clears env vars like MASTER_PORT, MASTER_ADDR that may be lingering from other tests
     # when running as a part of a test suite
     mock.patch.dict(os.environ, clear=True)
+
     def test_compute_world_size(self) -> None:
         cfg = DictConfig(
             content={

--- a/torchx/examples/apps/compute_world_size/module/test/util_test.py
+++ b/torchx/examples/apps/compute_world_size/module/test/util_test.py
@@ -3,15 +3,20 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
+import os
 import random
 import unittest
+from unittest import mock
 
 from omegaconf import DictConfig
 from torchx.examples.apps.compute_world_size.module.util import compute_world_size
 
 
 class UtilTest(unittest.TestCase):
+
+    # clears env vars like MASTER_PORT, MASTER_ADDR that may be lingering from other tests
+    # when running as a part of a test suite
+    mock.patch.dict(os.environ, clear=True)
     def test_compute_world_size(self) -> None:
         cfg = DictConfig(
             content={

--- a/torchx/examples/apps/compute_world_size/module/util.py
+++ b/torchx/examples/apps/compute_world_size/module/util.py
@@ -14,19 +14,16 @@ from omegaconf import DictConfig
 
 
 def compute_world_size(cfg: DictConfig) -> int:
-    rank = int(os.getenv("RANK", cfg.main.rank))
-    world_size = int(os.getenv("WORLD_SIZE", cfg.main.world_size))
-    master_addr = os.getenv("MASTER_ADDR", cfg.main.master_addr)
-    master_port = int(os.getenv("MASTER_PORT", cfg.main.master_port))
+    # required env vars for initializing pg with the default init_method (env://)
+    os.environ["RANK"] = str(cfg.main.rank)
+    os.environ["WORLD_SIZE"] = str(cfg.main.world_size)
+    os.environ["MASTER_ADDR"] = cfg.main.master_addr
+    os.environ["MASTER_PORT"] = str(cfg.main.master_port)
+
     backend = cfg.main.backend
 
     print(f"initializing `{backend}` process group")
-    dist.init_process_group(
-        backend=backend,
-        init_method=f"tcp://{master_addr}:{master_port}",
-        rank=rank,
-        world_size=world_size,
-    )
+    dist.init_process_group(backend=backend)
     print("successfully initialized process group")
 
     rank = dist.get_rank()

--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -18,7 +18,7 @@ Prerequisites
 You'll need to create an AWS Batch queue configured for multi-node parallel jobs.
 
 See
-https://docs.aws.amazon.com/batch/latest/userguide/Batch_GetStarted.html#first-run-step-2
+https://docs.aws.amazon.com/batch/latest/userguide/Batch_GetStarted.html
 for how to setup a job queue and compute environment. It needs to be backed by
 EC2 for multi-node parallel jobs.
 

--- a/torchx/tracker/mlflow.py
+++ b/torchx/tracker/mlflow.py
@@ -20,11 +20,11 @@ from mlflow.entities import Experiment, Run
 from torchx.distributed import on_rank0_first
 from torchx.runner.config import get_configs
 from torchx.tracker.api import (
+    ENV_TORCHX_JOB_ID,
     Lineage,
     TrackerArtifact,
     TrackerBase,
     TrackerSource,
-    ENV_TORCHX_JOB_ID,
 )
 
 log: Logger = getLogger(__name__)

--- a/torchx/util/cuda.py
+++ b/torchx/util/cuda.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+
+def has_cuda_devices() -> bool:
+    """
+    Checks if the host that is running this function has CUDA (GPU) devices
+    and that the installed version of PyTorch is CUDA-capable (PyTorch can be installed
+    as CPU-only). If this function returns ``True`` then it means that the caller
+    can actually allocate tensors on the GPU.
+
+    .. note::
+        ``torch.cuda.is_available()`` returns ``True`` if a GPU-capable
+         version of torch is installed (even on a CPU-only host).
+         So that call alone will not tell us whether we can actually
+         put tensors and modules on a CUDA device.
+         Hence this method checks that the host has both:
+         1) GPU-capable version of torch installed
+         2) Actually has at least one physical CUDA device
+
+    """
+
+    #
+    return torch.cuda.is_available() and torch.cuda.device_count() > 0

--- a/torchx/util/test/cuda_test.py
+++ b/torchx/util/test/cuda_test.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+from torchx.util.cuda import has_cuda_devices
+
+TORCH_CUDA_IS_AVAIL = "torch.cuda.is_available"
+TORCH_CUDA_DEVICE_COUNT = "torch.cuda.device_count"
+
+
+class CudaTest(unittest.TestCase):
+    @mock.patch(TORCH_CUDA_IS_AVAIL, return_value=True)
+    def test_has_cuda_devices_cuda_is_available(self, _: MagicMock) -> None:
+        with mock.patch(TORCH_CUDA_DEVICE_COUNT, return_value=1):
+            self.assertTrue(has_cuda_devices())
+
+        with mock.patch(TORCH_CUDA_DEVICE_COUNT, return_value=0):
+            self.assertFalse(has_cuda_devices())
+
+    @mock.patch(TORCH_CUDA_IS_AVAIL, return_value=False)
+    def test_has_cuda_devices_cuda_is_not_available(self, _: MagicMock) -> None:
+        with mock.patch(TORCH_CUDA_DEVICE_COUNT, return_value=1):
+            self.assertFalse(has_cuda_devices())
+
+        with mock.patch(TORCH_CUDA_DEVICE_COUNT, return_value=0):
+            self.assertFalse(has_cuda_devices())


### PR DESCRIPTION
Summary
----------------

Fixes a bug when calling `apprun.add_artifact()` with the mlflow tracker in a distributed setting, only the artifact that is logged from the rank that won the race to first create the run. This happened b/c the ranks that lost the race and fell back to searching for the run were not setting the run_id as the "active_run" (mlflow uses a global var to store the "current active run" which is only set when you call `mlflow.start_run(run_id)`)

Misc
------

Some misc fixes in `torchx.distributed` are bundled with this PR since they were necessary for me to author a dummy app to integ test against an actual mlflow endpoint.

Test plan
-----------

Added unittest to cover this case.

Validated that artifacts from multiple ranks can indeed be logged against an actual mlflow endpoint
![image](https://user-images.githubusercontent.com/43595115/232165881-bb10ee60-b1e6-499b-b982-87f858300c5e.png)
