### PR TITLE
(torchx/python) Drop support for python 3.7

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -10,7 +10,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
         platform: [ubuntu-20.04]
         include:
           - python-version: 3.9

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ aiobotocore==2.4.2
 ax-platform[mysql]==0.2.3
 black==23.3.0
 boto3==1.24.59
+boto3-stubs[batch]
 captum>=0.4.0
 flake8==3.9.0
 fsspec[s3]==2023.1.0

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ def get_nightly_version():
 
 
 if __name__ == "__main__":
-    if sys.version_info < (3, 7):
-        sys.exit("python >= 3.7 required for torchx-sdk")
+    if sys.version_info < (3, 8):
+        sys.exit("python >= 3.8 required for torchx-sdk")
 
     name = "torchx"
     NAME_ARG = "--override-name"


### PR DESCRIPTION
Summary
-----------
Following torch-2.0, drops support for python 3.7.
Resolves: https://github.com/pytorch/torchx/issues/709

FWIW python 3.7 currently doesn't work due to torchx requiring `mlflow-skinny>=2` but `mlflow-skinny` v2 not being available for python 3.7.

Test plan:
-----------
CI
