### PR TITLE
(torchx/local_scheduler) Cleanup auto_set_cuda_visible_devices logic …

### DIFF
--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -283,7 +283,7 @@ def ddp(
                 args=["-c", _args_join(cmd)],
                 env=env,
                 port_map={
-                    "c10d": 29500,
+                    "c10d": rdzv_port,
                 },
                 max_retries=max_retries,
                 mounts=specs.parse_mounts(mounts) if mounts else [],

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -763,7 +763,7 @@ class LocalScheduler(Scheduler[LocalOpts]):
             request, lambda p: pprint.pformat(asdict(p), indent=2, width=80)
         )
 
-    def _device_count(self) -> int:
+    def _cuda_device_count(self) -> int:
         # this method deliberately does not use ``torch.cuda.device_count()``
         # to avoid taking a dependency on pytorch
         # this make sit possible to avoid a BUCK dependency (internally at Meta)
@@ -844,7 +844,7 @@ set the `auto_set_cuda_visible_devices = True` scheduler runopt
                 )
             return
 
-        device_count = self._device_count()
+        device_count = self._cuda_device_count()
         if total_requested_gpus > device_count:
             log.warning(
                 f"""\n


### PR DESCRIPTION
Summary
--------------

1. Cleans up the logic to auto-set CUDA_VISIBLE_DEVICES in local_scheduler.
2. Adds more testing around it
3. Fixes a small bug in `dist.ddp` where the port mapping on the ddp role was hard-coded to 29500 rather than using `rdzv_port`.

Test plan
------------
```
$ pytest
```