### PR TITLE
dev-requirements: bump kfp version to 1.8.22 to fix PyYaml issue

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,7 @@ google-cloud-logging>=3.0.0
 google-cloud-runtimeconfig>=0.33.2
 hydra-core
 ipython
-kfp==1.8.9
+kfp==1.8.22
 mlflow-skinny
 moto==4.1.6
 pyre-extensions


### PR DESCRIPTION
<!-- Change Summary -->

Work around the PyYaml+cython issue in https://github.com/yaml/pyyaml/issues/601 by bumping kfp version to no longer need pyyaml<6.0

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI

```
pip install -r dev-requirements.txt
```