### PR TITLE
(NOT READY FOR REVIEW)(torchx/components) Add aws.spmd component, a specialization of the d…

### DIFF
--- a/torchx/components/aws.py
+++ b/torchx/components/aws.py
@@ -1,0 +1,275 @@
+
+"""
+This module contains a custom ``spmd`` component to use with AWS Batch.
+It differs from the default ``spmd`` component in that it has hard-coded certain configurations (env vars, torchrun parameters etc).
+that makes distributed (DDP or FSDP) scripts run smoothly on AWS Batch.
+
+Notable differences:
+
+#. Uses ``static`` rendezvous backend to pin AWS Batch assigned node 0 for elastic agent 0
+#. Sets ``NCCL_SOCKET_IFNAME=eth,ens`` to be compatible with the network iface names on AWS instances when 
+    provisioned with the DeepLearning AMI (Ubuntu and AmazonLinux 2).
+#. Sets ``FI_PROVIDER=efa`` and ``FI_EFA_USE_DEVICE_RDMA=1`` to let PyTorch (via NCCL) run collectives over EFA (AWS's proprietary NIC).
+
+
+For usage run:
+
+.. code-block:: shell-session
+
+    $ torchx run amzn.spmd --help
+    torchx 2023-02-23 22:41:26 INFO     loaded configs from /home/ubuntu/workspace/torchx/.torchxconfig
+    usage: torchx run <run args...> spmd  [--help] [--script SCRIPT] [-m M] [--image IMAGE] [--name NAME] [-h H]
+                                      [-j J] [--env ENV] [--max_retries MAX_RETRIES] [--mounts MOUNTS]
+                                      [--debug DEBUG]
+                                      ...
+
+    Usage (by script): torchx run spmd -j 2x8 -h p4d.24xlarge --name my_experiment/trial_1 --script
+    path/to/my/trainer.py -foo bar ...
+
+    positional arguments:
+      args                  the arguments to the main module or script (e.g. my/trainer.py -foo bar) (for docker based
+                            runs) the script path must be relative to the WORKDIR of the image (required)
+
+    optional arguments:
+      --help                show this help message and exit
+      --script SCRIPT
+      -m M, --m M           the main module name (e.g. my.module.trainer). When this option is used, the `script_args`
+                            are passed as the arguments to the main module). Invoking my module is useful when the
+                            relative/absolute path of the main script is unknown w.r.t the WORKDIR of the image. Use
+                            this option when it makes sense to invoke the main script via `python -m <MAIN.MODULE>`.
+                            (default: None)
+      --image IMAGE         the base docker image of the workspace, if workspace is disabled, then the image of the
+                            job (default: 763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:1.13.1-gpu-
+                            py39-cu117-ubuntu20.04-ec2)
+      --name NAME           {experimentname}/{runname} (defaults to `default_experiment_{USER}_{HOST}/{scriptname}`)
+                            (default: None)
+      -h H, --h H           the type of host to run on (e.g. p4d.24xlarge). Must be one of the registered named
+                            resources
+      -j J, --j J           {nnodes}x{nproc_per_node}, for gpu hosts, nproc_per_node must not exceed num gpus
+                            (default: 1x1)
+      --env ENV             environment varibles to be passed to the run (e.g. ENV1=v1,ENV2=v2,ENV3=v3) (default:
+                            None)
+      --max_retries MAX_RETRIES
+                            the number of scheduler retries allowed (default: 0)
+      --mounts MOUNTS       (for docker based runs only) mounts to mount into the worker environment/container (ex.
+                            type=<bind/volume>,src=/host,dst=/job[,readonly]). (default: None)
+      --debug DEBUG         whether to run with preset debug flags enabled (default: False)
+
+"""
+import os
+
+from getpass import getuser
+from typing import Dict, List, Optional
+
+from torchx import specs
+from torchx.components.dist import (
+    _args_join,
+    _noquote,
+    _TORCH_DEBUG_FLAGS,
+    get_role_name,
+)
+from torchx.components.structured_arg import StructuredJArgument, StructuredNameArgument
+from torchx.util.aws.region import get_region
+
+MINUTES = 60
+EFA_DEVICE = "vpc.amazonaws.com/efa"
+
+
+class DLContainer:
+    """
+    Provides docker container image URL to the AWS DL container images.
+    https://github.com/aws/deep-learning-containers/blob/master/available_images.md
+    """
+
+    @property
+    def ECR_URL(self) -> str:
+        return f"763104351884.dkr.ecr.{get_region()}.amazonaws.com"
+
+    @property
+    def PYTORCH_TRAINING_1_13_1_GPU(self) -> str:
+        return f"{self.ECR_URL}/pytorch-training:1.13.1-gpu-py39-cu117-ubuntu20.04-ec2"
+
+    @property
+    def PYTORCH_TRAINING_2_0_1_GPU(self) -> str:
+        return f"{self.ECR_URL}/pytorch-training:2.0.1-gpu-py310-cu118-ubuntu20.04-ec2"
+
+
+def default_experiment_name() -> str:
+    return f"default-experiment-{getuser()}"
+
+
+def is_efa_enabled(resource: specs.Resource) -> bool:
+    return EFA_DEVICE in resource.devices
+
+def spmd(
+    *args: str,
+    script: Optional[str] = None,
+    m: Optional[str] = None,
+    image: Optional[str] = None,
+    name: str = "/",
+    h: str = "aws_p3_2xlarge",
+    j: str = "1x1",
+    env: Optional[Dict[str, str]] = None,
+    max_retries: int = 0,
+    mounts: Optional[List[str]] = None,
+    local: bool = False,
+    debug: bool = False,
+) -> specs.AppDef:
+    """
+    Usage (by script): torchx run spmd -j 2x8 -h p4d.24xlarge --name my_experiment/trial_1 --script path/to/my/trainer.py -foo bar
+
+    Usage (by module): torchx run spmd -j 2x8 -h p4d.24xlarge --name my_experiment/trial_1 -m path.to.my.trainer -foo bar
+
+    Usage (infer GPU count): torchx run spmd -j 2 -h p4d.24xlarge ... (same as -j 2x8)
+
+    Creates a torchx.specs.AppDef (Job Definition) for a Single-Process-Multiple-Data (SPMD)
+    style application. See: https://en.wikipedia.org/wiki/Single_program,_multiple_data.
+
+    SPMD launches `n x m` (set via the `-j nxm` option) copies of the same program,
+    where `n` is the number of nodes (hosts) and `m` is the number of processes on each node.
+
+    If you have a distributed PyTorch script (DDP, FSDP, RPC) use this component to launch
+    the distributed application. You can also use `-j 1x1` to launch a single process application
+    which would be equivalent to launching with regular `python` except that your application
+    can safely call `torch.distributed.init_process_group(backend)`.
+
+    Note: For multi-node distributed runs, the hosts MUST have a network route to each other
+          AND port 29500 should be open on all hosts. Please check your security group settings.
+
+
+    Args:
+        args: the arguments to the main module or script (e.g. my/trainer.py -foo bar)
+            (for docker based runs) the script path must be relative to the WORKDIR of the image
+        script:
+        m: the main module name (e.g. my.module.trainer). When this option is used, the `script_args` are passed
+           as the arguments to the main module). Invoking my module is useful when the relative/absolute path
+           of the main script is unknown w.r.t the WORKDIR of the image. Use this option when it makes sense to
+           invoke the main script via `python -m <MAIN.MODULE>`.
+        image: the base docker image of the workspace, if workspace is disabled, then the image of the job
+        name: {experimentname}/{runname} (defaults to `default_experiment_{USER}_{HOST}/{scriptname}`)
+        h: the type of host to run on (e.g. p4d.24xlarge). Must be one of the registered named resources
+        j: {nnodes}x{nproc_per_node}. For GPU hosts omitting nproc_per_node will infer it from the GPU count on the host
+        env: environment varibles to be passed to the run (e.g. ENV1=v1,ENV2=v2,ENV3=v3)
+        max_retries: the number of scheduler retries allowed
+        rdzv_port: the port on rank0's host to use for hosting the c10d store used for rendezvous.
+                   Only takes effect when running multi-node. When running single node, this parameter
+                   is ignored and a random free port is chosen.
+        mounts: (for docker based runs only) mounts to mount into the worker environment/container
+                (ex. type=<bind/volume>,src=/host,dst=/job[,readonly]).
+        local: when set to `True` makes it possible to run with `nnodes > 1` on a multi-gpu host
+        debug: whether to run with preset debug flags enabled
+
+    """
+
+    if image is None:
+        image = DLContainer().PYTORCH_TRAINING_2_0_1_GPU
+
+    resource = specs.get_named_resources(h)
+
+    if env is None:
+        env = {}
+
+    if is_efa_enabled(resource):
+        # DL container sets NCCL_SOCKET_IFNAME=^docker0 in /etc/nccl.conf
+        # so we need to override it here so that NCCL properly establishes sockets
+        # select eth or ens network interfaces (ens is used in modern OS like ubuntu 20)
+        env["NCCL_SOCKET_IFNAME"] = "eth,ens"
+        env["FI_PROVIDER"] = "efa"
+        env["FI_EFA_USE_DEVICE_RDMA"] = "1"
+
+    structured_name = StructuredNameArgument.parse_from(
+        name=name,
+        m=m,
+        script=script,
+        default_experiment_name=default_experiment_name(),
+    )
+
+    structured_j = StructuredJArgument.parse_from(h, j)
+
+    rdzv_backend = "c10d"
+    if structured_j.nnodes == 1:
+        # using port 0 makes elastic chose a free random port which is ok
+        # for single-node jobs since all workers run under a single agent
+        # When nnodes is 0 and max_nnodes is 1, it's stil a single node job
+        # but pending until the resources become available
+
+        rdzv_endpoint = "localhost:0"
+    else:
+        # for multi-node, rely on the rank0_env environment variable set by
+        # the schedulers (see scheduler implementation for the actual env var this maps to)
+        # some schedulers (e.g. aws batch) make the rank0's ip-addr available on all BUT on rank0
+        # so default to "localhost" if the env var is not set or is empty
+        # rdzv_endpoint bash resolves to something to the effect of
+        # ${TORCHX_RANK0_HOST:=localhost}:29500
+        # use $$ in the prefix to escape the '$' literal (rather than a string Template substitution argument)
+        rdzv_endpoint = _noquote(f"$${{{specs.macros.rank0_env}:=localhost}}:29500")
+
+    env.setdefault("LOGLEVEL", os.getenv("LOGLEVEL", "INFO"))
+    if debug:
+        env.update(_TORCH_DEBUG_FLAGS)
+    env["TORCHX_TRACKING_EXPERIMENT_NAME"] = structured_name.experiment_name
+    env["TORCHX_USER"] = getuser()
+    # Increase timeout and retry values for requests made to Instance Metadata server.
+    env["AWS_METADATA_SERVICE_TIMEOUT"] = "5"  # seconds
+    env["AWS_METADATA_SERVICE_NUM_ATTEMPTS"] = "10"
+    env["APE_COMPONENT_NAME"] = "spmd"
+    env["APE_NNODES"] = str(structured_j.nnodes)
+    env["APE_NPROC_PER_NODE"] = str(structured_j.nproc_per_node)
+
+    cmd = [
+        "torchrun",
+        "--rdzv_backend",
+        rdzv_backend,
+        "--rdzv_endpoint",
+        rdzv_endpoint,
+        "--rdzv_id",
+        f"{specs.macros.app_id}",
+        "--rdzv_conf",
+        # configure various rdzv timeouts
+        # see: https://github.com/pytorch/pytorch/blob/main/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py#L1216
+        # join_timeout == wait 30 minutes for other nodes to join the job
+        # close_timeout == wait 10 minutes for all nodes to close rdzv
+        # timeout == 30min (catch-all) not really used for c10d rdzv but having it here in case we switch to another backend
+        f"join_timeout={30 * MINUTES},close_timeout={10 * MINUTES},timeout={30*MINUTES}",
+        "--nnodes",
+        str(structured_j.nnodes),
+        "--nproc_per_node",
+        str(structured_j.nproc_per_node),
+        "--tee",
+        "3",
+        "--role",
+        "",
+    ]
+    if script is not None:
+        cmd += [script]
+    else:  # m is not None (this is checked in StructuredNameArgument.parse_from() call above)
+        cmd += ["-m", m]
+    cmd += args
+    resource = specs.resource(h=h)
+
+    if local:
+        # override num gpus to be equal to the specified nproc_per_node
+        # this makes torchx's LocalScheduler be able to correctly set CUDA_VISIBLE_DEVICES
+        # for each simulated node
+        resource.gpu = structured_j.nproc_per_node
+
+    return specs.AppDef(
+        name=structured_name.run_name,
+        roles=[
+            specs.Role(
+                name=get_role_name(script, m),
+                image=image,
+                min_replicas=structured_j.nnodes,
+                entrypoint="bash",
+                num_replicas=structured_j.nnodes,
+                resource=resource,
+                args=["-c", _args_join(cmd)],
+                env=env,
+                port_map={
+                    "c10d": 29500,
+                },
+                max_retries=max_retries,
+                mounts=specs.parse_mounts(mounts) if mounts else [],
+            )
+        ],
+    )

--- a/torchx/components/test/aws_test.py
+++ b/torchx/components/test/aws_test.py
@@ -1,0 +1,190 @@
+
+import shlex
+import unittest
+
+from torchx.components.aws import default_experiment_name, spmd, MINUTES
+from torchx.components.dist import _TORCH_DEBUG_FLAGS
+from torchx.specs import macros
+
+
+class SpmdTest(unittest.TestCase):
+    def test_spmd_call_by_module_or_script_no_name(self) -> None:
+        appdef = spmd(script="foo/bar.py")
+        self.assertEqual("bar", appdef.name)
+        self.assertEqual(
+            default_experiment_name(),
+            appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"],
+        )
+
+        appdef = spmd("-a", "b", script="foo/bar.py")
+        self.assertEqual("bar", appdef.name)
+        self.assertEqual(
+            default_experiment_name(),
+            appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"],
+        )
+
+        appdef = spmd(m="foo.bar")
+        self.assertEqual("bar", appdef.name)
+        self.assertEqual(
+            default_experiment_name(),
+            appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"],
+        )
+
+        appdef = spmd("-a", "b", m="foo.bar")
+        self.assertEqual("bar", appdef.name)
+        self.assertEqual(
+            default_experiment_name(),
+            appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"],
+        )
+
+        with self.assertRaises(ValueError):
+            spmd()
+
+        with self.assertRaises(ValueError):
+            spmd(m="foo.bar", script="foo/bar.py")
+
+    def test_spmd_call_by_module_or_script_with_name(self) -> None:
+        appdef = spmd(script="foo/bar.py", name="baz/trial_1")
+        self.assertEqual("trial_1", appdef.name)
+        self.assertEqual("baz", appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"])
+
+        appdef = spmd("-a", "b", script="foo/bar.py", name="baz/trial_1")
+        self.assertEqual("trial_1", appdef.name)
+        self.assertEqual("baz", appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"])
+
+        appdef = spmd(m="foo.bar", name="baz/trial_1")
+        self.assertEqual("trial_1", appdef.name)
+        self.assertEqual("baz", appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"])
+
+        appdef = spmd("-a", "b", m="foo.bar", name="baz/trial_1")
+        self.assertEqual("trial_1", appdef.name)
+        self.assertEqual("baz", appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"])
+
+    def test_spmd_call_by_module_or_script_with_experiment_name(self) -> None:
+        appdef = spmd(script="foo/bar.py", name="baz/")
+        self.assertEqual("bar", appdef.name)
+        self.assertEqual("baz", appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"])
+
+        appdef = spmd("-a", "b", script="foo/bar.py", name="baz/")
+        self.assertEqual("bar", appdef.name)
+        self.assertEqual("baz", appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"])
+
+        appdef = spmd(m="foo.bar", name="baz/")
+        self.assertEqual("bar", appdef.name)
+        self.assertEqual("baz", appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"])
+
+        appdef = spmd("-a", "b", m="foo.bar", name="baz/")
+        self.assertEqual("bar", appdef.name)
+        self.assertEqual("baz", appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"])
+
+    def test_spmd_call_by_module_or_script_with_run_name(self) -> None:
+        appdef = spmd(script="foo/bar.py", name="/trial_1")
+        self.assertEqual("trial_1", appdef.name)
+        self.assertEqual(
+            default_experiment_name(),
+            appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"],
+        )
+
+        appdef = spmd("-a", "b", script="foo/bar.py", name="/trial_1")
+        self.assertEqual("trial_1", appdef.name)
+        self.assertEqual(
+            default_experiment_name(),
+            appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"],
+        )
+
+        appdef = spmd(m="foo.bar", name="/trial_1")
+        self.assertEqual("trial_1", appdef.name)
+        self.assertEqual(
+            default_experiment_name(),
+            appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"],
+        )
+
+        appdef = spmd("-a", "b", m="foo.bar", name="/trial_1")
+        self.assertEqual("trial_1", appdef.name)
+        self.assertEqual(
+            default_experiment_name(),
+            appdef.roles[0].env["TORCHX_TRACKING_EXPERIMENT_NAME"],
+        )
+
+    def test_spmd_single_node(self) -> None:
+        appdef = spmd(script="foo/bar.py", j="1x4", h="p3.8xlarge")
+        role = appdef.roles[0]
+        args = role.args
+        self.assertEqual("-c", args[0])
+
+        cmd = shlex.split(args[1])
+        self.assertEqual("bash", role.entrypoint)
+        self.assertEqual("c10d", cmd[cmd.index("--rdzv_backend") + 1])
+        self.assertEqual("localhost:0", cmd[cmd.index("--rdzv_endpoint") + 1])
+        self.assertEqual(
+            f"join_timeout={30*MINUTES},close_timeout={10*MINUTES},timeout={30*MINUTES}",
+            cmd[cmd.index("--rdzv_conf") + 1],
+        )
+        self.assertEqual("1", cmd[cmd.index("--nnodes") + 1])
+        self.assertEqual("4", cmd[cmd.index("--nproc_per_node") + 1])
+        self.assertTrue("--node_rank" not in cmd)
+
+    def test_spmd_multi_node(self) -> None:
+        appdef = spmd(script="foo/bar.py", j="2x4", h="p3.8xlarge")
+        role = appdef.roles[0]
+        args = role.args
+
+        self.assertEqual("-c", args[0])
+
+        cmd = shlex.split(args[1])
+        self.assertEqual("bash", role.entrypoint)
+        self.assertEqual("c10d", cmd[cmd.index("--rdzv_backend") + 1])
+        self.assertTrue(
+            f"--rdzv_endpoint $${{{macros.rank0_env}:=localhost}}:29500" in args[1]
+        )
+        self.assertEqual("2", cmd[cmd.index("--nnodes") + 1])
+        self.assertEqual("4", cmd[cmd.index("--nproc_per_node") + 1])
+
+        # by default, we assign 1 gpu per process
+        self.assertEqual(4, role.resource.gpu)
+
+    def test_spmd_multi_node_multi_gpu_per_proc(self) -> None:
+        appdef = spmd(script="foo/bar.py", j="2x4", h="p3.16xlarge")
+        role = appdef.roles[0]
+        args = role.args
+
+        self.assertEqual("-c", args[0])
+
+        cmd = shlex.split(args[1])
+        self.assertEqual("bash", role.entrypoint)
+        self.assertEqual("c10d", cmd[cmd.index("--rdzv_backend") + 1])
+        self.assertTrue(
+            f"--rdzv_endpoint $${{{macros.rank0_env}:=localhost}}:29500" in args[1]
+        )
+        self.assertEqual("2", cmd[cmd.index("--nnodes") + 1])
+        self.assertEqual("4", cmd[cmd.index("--nproc_per_node") + 1])
+
+        # intentional mismatch of the number of GPUs in the node and the number of processes
+        self.assertEqual(8, role.resource.gpu)
+
+    def test_spmd_efa_enabled(self) -> None:
+        appdef = spmd(script="foo/bar.py", h="p4d.24xlarge")
+        env = appdef.roles[0].env
+        self.assertEqual("eth,ens", env["NCCL_SOCKET_IFNAME"])
+        self.assertEqual("1", env["FI_EFA_USE_DEVICE_RDMA"])
+
+    def test_instance_metadata_server_config(self) -> None:
+        appdef = spmd(script="foo/bar.py", h="p4d.24xlarge")
+        env = appdef.roles[0].env
+        self.assertEqual("5", env["AWS_METADATA_SERVICE_TIMEOUT"])
+        self.assertEqual("10", env["AWS_METADATA_SERVICE_NUM_ATTEMPTS"])
+
+    def test_spmd_debug_mode(self) -> None:
+        appdef = spmd(script="foo/bar.py", debug=True)
+        env = appdef.roles[0].env
+
+        for k, v in _TORCH_DEBUG_FLAGS.items():
+            self.assertEqual(v, env[k])
+
+    def test_spmd_custom_env(self) -> None:
+        appdef = spmd(script="foo/bar.py", env={"FOO": "BAR"})
+        self.assertEqual("BAR", appdef.roles[0].env["FOO"])
+
+    def test_spmd_no_main(self) -> None:
+        with self.assertRaisesRegex(ValueError, "No main module or script specified."):
+            spmd()

--- a/torchx/util/aws/imds.py
+++ b/torchx/util/aws/imds.py
@@ -1,0 +1,99 @@
+"""
+EC2 Instance Metadata Service related methods
+"""
+import logging
+import socket
+from dataclasses import dataclass
+from functools import cache
+from typing import Optional
+
+import requests
+
+from requests import HTTPError
+
+IMDS_URL = "http://169.254.169.254/latest"
+IMDS_METADATA_URL = f"{IMDS_URL}/meta-data"
+NULL = "_NULL_"
+
+log: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass
+class InstanceMetadata:
+    """
+    Struct representing the instance metadata as fetched from IMDS on the current host.
+    Use :py:func:`ape.aws.ec2.imds.instance_metadata` to get a filled-out
+    instance of this object.
+    """
+
+    instance_id: str
+    instance_type: str
+    hostname: str
+    public_hostname: str
+    local_hostname: str
+    availability_zone: str
+    region: str
+    ami_id: str
+
+
+@cache
+def imds_fetch(metadata: str = "") -> Optional[str]:
+    """
+    Fetches the specified ``metadata`` from EC2's Instance MetaData Service (IMDS) running
+    on the current host, by sending an HTTP GET request to ``http://169.254.169.254/latest/meta-data/<metadata>``.
+
+    To get a list of all valid values of ``metadata`` run this method with no arguments then split
+    the return value by new-line.
+
+
+    Arguments:
+        metadata: Name of the instance metadata to query (e.g. ``instance-type``)
+
+    Returns:
+        the specified ``metadata`` or ``None`` if IMDS cannot be reached
+
+    """
+    try:
+        response = requests.get(f"{IMDS_METADATA_URL}/{metadata}")
+    except Exception as e:
+        log.warning(
+            "Error querying IMDS instance metadata won't be available", exc_info=e
+        )
+        return None
+
+    if response.ok:
+        return response.text
+    else:  # response NOT ok
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            return None
+
+    assert False, "Unreachable code!"  # pragma: no cover
+
+
+@cache
+def instance_metadata() -> InstanceMetadata:
+    """
+    Fetches the instance metadata for the current host from EC2's Instance Metadata Service (IMDS),
+    which typically runs on localhost at ``http://169.254.169.254``.
+    If IMDS cannot be reached for any reason returns an instance of :py:class:`InstanceMetadata`
+    where all the fields are empty strings.
+
+    .. note::
+        This method is memoized (value is cached) hence, only the first call
+        will actually hit IMDS, and subsequent calls will return the memoized
+        value. Therefore, it is ok to call this function multiple times.
+
+    """
+
+    return InstanceMetadata(
+        instance_id=imds_fetch("instance-id") or "localhost",
+        instance_type=imds_fetch("instance-type") or NULL,
+        availability_zone=imds_fetch("placement/availability-zone") or NULL,
+        region=imds_fetch("placement/region") or NULL,
+        hostname=imds_fetch("hostname") or socket.gethostname(),
+        public_hostname=imds_fetch("public-hostname") or NULL,
+        local_hostname=imds_fetch("local-hostname") or NULL,
+        ami_id=imds_fetch("ami-id") or NULL,
+    )

--- a/torchx/util/aws/region.py
+++ b/torchx/util/aws/region.py
@@ -1,0 +1,21 @@
+import boto3
+
+from torchx.util.aws.imds import instance_metadata
+
+
+def get_region() -> str:
+    """
+    Returns the region name (e.g. us-west-2) by:
+
+    #. First see if the region can be obtained from the session chain
+       e.g. if there is an ~/.aws/config or AWS_DEFAULT_REGION env var is set
+    #. Otherwise, get the region from instance metadata (if running on EC2)
+
+
+    We first use the session chain so that we can override the region using
+    env vars or if we are running outside of an EC2 instance (e.g. laptop)
+    """
+    region = boto3.Session().region_name
+    if not region:
+        region = instance_metadata().region
+    return region

--- a/torchx/util/aws/test/imds_test.py
+++ b/torchx/util/aws/test/imds_test.py
@@ -1,0 +1,91 @@
+import socket
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+from torchx.util.aws.imds import imds_fetch, instance_metadata, NULL
+
+from requests.models import Response
+
+REQUESTS_GET = "requests.get"
+IMDS_FETCH = "torchx.util.aws.imds.imds_fetch"
+
+
+def http_ok(text: str) -> Response:
+    ENCODING = "UTF-8"
+    resp = Response()
+    resp.encoding = ENCODING
+    resp._content = text.encode(ENCODING)
+    resp.status_code = 200
+    return resp
+
+
+def http_error(code: int = 404, reason: str = "Not Found") -> Response:
+    resp = Response()
+    resp.status_code = code
+    resp.reason = reason
+    return resp
+
+
+class IMDSTest(unittest.TestCase):
+    def setUp(self) -> None:
+        imds_fetch.cache_clear()
+        instance_metadata.cache_clear()
+
+    def tearDown(self) -> None:
+        imds_fetch.cache_clear()
+        instance_metadata.cache_clear()
+
+    @mock.patch(REQUESTS_GET, return_value=http_ok("p4d.24xlarge"))
+    def test_imds_fetch(self, _: MagicMock) -> None:
+        self.assertEqual("p4d.24xlarge", imds_fetch("instance-type"))
+
+    @mock.patch(REQUESTS_GET, return_value=http_error())
+    def test_imds_not_available_default(self, _: MagicMock) -> None:
+        self.assertIsNone(imds_fetch("instancetype"))
+
+    @mock.patch(REQUESTS_GET, return_value=http_error())
+    def test_instance_metadata_no_imds(self, _: MagicMock) -> None:
+        self.assertEqual("localhost", instance_metadata().instance_id)
+        self.assertEqual(NULL, instance_metadata().instance_type)
+        self.assertEqual(NULL, instance_metadata().availability_zone)
+        self.assertEqual(NULL, instance_metadata().region)
+        self.assertEqual(socket.gethostname(), instance_metadata().hostname)
+        self.assertEqual(NULL, instance_metadata().local_hostname)
+        self.assertEqual(NULL, instance_metadata().public_hostname)
+        self.assertEqual(NULL, instance_metadata().ami_id)
+
+    def test_instance_metadata(self) -> None:
+        def mock_imds_fetch(metadata: str = "") -> str:
+            if metadata == "":
+                return "ami-id\nami-launch-index\nservices/\nsystem"
+            if metadata == "instance-id":
+                return "i-1a2b3c"
+            elif metadata == "instance-type":
+                return "p4d.24xlarge"
+            elif metadata == "placement/availability-zone":
+                return "us-west-2a"
+            elif metadata == "placement/region":
+                return "us-west-2"
+            elif metadata == "hostname":
+                return "ip-...us-west-2.compute.internal"
+            elif metadata == "public-hostname":
+                return "ec2-...compute.amazonaws.com"
+            elif metadata == "local-hostname":
+                return "ip-...us-west-2.compute.internal"
+            elif metadata == "ami-id":
+                return "ami-1a2b3c"
+            else:
+                raise ValueError(f"No test value mapped for: {metadata}")
+
+        with mock.patch(IMDS_FETCH, wraps=mock_imds_fetch):
+            md = instance_metadata()
+
+            self.assertEqual("i-1a2b3c", md.instance_id)
+            self.assertEqual("p4d.24xlarge", md.instance_type)
+            self.assertEqual("us-west-2a", md.availability_zone)
+            self.assertEqual("us-west-2", md.region)
+            self.assertEqual("ip-...us-west-2.compute.internal", md.hostname)
+            self.assertEqual("ec2-...compute.amazonaws.com", md.public_hostname)
+            self.assertEqual("ip-...us-west-2.compute.internal", md.local_hostname)
+            self.assertEqual("ami-1a2b3c", md.ami_id)

--- a/torchx/util/aws/test/region_test.py
+++ b/torchx/util/aws/test/region_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock
+
+from torchx.util.aws.region import get_region
+from torchx.test.fixtures import TestWithTmpDir
+
+INSTANCE_METADATA = "torchx.util.aws.imds.instance_metadata"
+
+
+class Boto3UtilTest(TestWithTmpDir):
+    @mock.patch(INSTANCE_METADATA)
+    def test_get_region(self, mock_instance_metadata: MagicMock) -> None:
+        # write a region that we would never use as a devasg
+        aws_config_file = self.write(
+            str(Path(".aws") / "config"),
+            [
+                """
+[default]
+region=ap-east-1
+"""
+            ],
+        )
+
+        with mock.patch.dict(
+            os.environ, {"AWS_CONFIG_FILE": str(aws_config_file)}, clear=True
+        ):
+            self.assertEqual("ap-east-1", get_region())
+            mock_instance_metadata.assert_not_called()
+
+    @mock.patch(INSTANCE_METADATA)
+    def test_get_region_fallback_to_imds(
+        self, mock_instance_metadata: MagicMock
+    ) -> None:
+        mock_instance_metadata.return_value.region = "ap-east-1"
+
+        # point the config file to a file that does not exist
+        # to force the fallback
+        with mock.patch.dict(
+            os.environ,
+            {"AWS_CONFIG_FILE": str(self.tmpdir / "non-existent-config")},
+            clear=True,
+        ):
+            self.assertEqual("ap-east-1", get_region())
+            mock_instance_metadata.assert_called_once()


### PR DESCRIPTION
For @seemethere since we discussed the custom component required to run on AWS Batch.
The next step is to figure out a way to bake this into the default ``spmd`` (``torchx.components.dist.spmd``) so that we don't keep two copies of spmd.

Publishing this as a PR so the @seemethere can take a look at what it takes to run on AWS Batch on EFA-enabled instances (e.g p4d). 

Test plan:
Unittests included.
