### PR TITLE
add 'node_rank' to torchrun cmd

### DIFF
--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -261,6 +261,8 @@ def ddp(
         nnodes_rep,
         "--nproc_per_node",
         str(nproc_per_node),
+        "--node_rank",
+        f"{macros.replica_id}",
         "--tee",
         "3",
         "--role",

--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -261,6 +261,7 @@ def ddp(
         nnodes_rep,
         "--nproc_per_node",
         str(nproc_per_node),
+        # node_rank is only used when rdzv_backend is 'static'
         "--node_rank",
         f"{macros.replica_id}",
         "--tee",


### PR DESCRIPTION
This PR adds the `node_rank` parameter to the torchrun command in `dist.py` and sets it to `macros.replica_id` for each node.  

This parameter appears to be required when running torchx with the ray scheduler across multiple nodes. 


Test plan:
This has been tested locally against `dist_test.py` with all 10 tests passing.
