### PR TITLE
Log cpu and wall time for torchx events

### DIFF
--- a/torchx/runner/events/api.py
+++ b/torchx/runner/events/api.py
@@ -30,6 +30,8 @@ class TorchxEvent:
         image: Image/container bundle that is used to execute request.
         runcfg: Run config that was used to schedule app.
         source: Type of source the event is generated.
+        cpu_time_usec: CPU time spent in usec
+        wall_time_usec: Wall time spent in usec
     """
 
     session: str
@@ -40,6 +42,8 @@ class TorchxEvent:
     runcfg: Optional[str] = None
     raw_exception: Optional[str] = None
     source: SourceType = SourceType.UNKNOWN
+    cpu_time_usec: Optional[int] = None
+    wall_time_usec: Optional[int] = None
 
     def __str__(self) -> str:
         return self.serialize()

--- a/torchx/runner/events/test/lib_test.py
+++ b/torchx/runner/events/test/lib_test.py
@@ -94,14 +94,6 @@ class LogEventTest(unittest.TestCase):
 
     def test_record_event(self, record_mock: MagicMock) -> None:
         cfg = json.dumps({"test_key": "test_value"})
-        expected_torchx_event = TorchxEvent(
-            "test_app_id",
-            "local",
-            "test_call",
-            "test_app_id",
-            app_image="test_app_image_id",
-            runcfg=cfg,
-        )
         with log_event(
             "test_call",
             "local",
@@ -110,6 +102,17 @@ class LogEventTest(unittest.TestCase):
             runcfg=cfg,
         ) as ctx:
             pass
+
+        expected_torchx_event = TorchxEvent(
+            "test_app_id",
+            "local",
+            "test_call",
+            "test_app_id",
+            app_image="test_app_image_id",
+            runcfg=cfg,
+            cpu_time_usec=ctx._torchx_event.cpu_time_usec,
+            wall_time_usec=ctx._torchx_event.wall_time_usec,
+        )
         self.assert_torchx_event(expected_torchx_event, ctx._torchx_event)
 
     def test_record_event_with_exception(self, record_mock: MagicMock) -> None:


### PR DESCRIPTION
Summary:
This diff adds support to log cpu and wall times for torchx events. These numbers can provide an over all time to submit/launch estimate.

Will export this diff to github as well after I have landed the sync diff in the this stack

Reviewed By: kurman

Differential Revision: D48375892

