### PR TITLE
Fix argument parsing bug

### DIFF
--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -135,7 +135,7 @@ def materialize_appdef(
         parameter_type = parameter.annotation
         parameter_type = decode_optional(parameter_type)
         if is_bool(parameter_type):
-            arg_value = arg_value.lower() == "true"
+            arg_value = arg_value and arg_value.lower() == "true"
         elif not is_primitive(parameter_type):
             arg_value = decode_from_string(arg_value, parameter_type)
         if parameter.kind == inspect.Parameter.VAR_POSITIONAL:

--- a/torchx/specs/test/builders_test.py
+++ b/torchx/specs/test/builders_test.py
@@ -63,7 +63,7 @@ def test_fn_with_bool(flag: bool = False) -> AppDef:
         return get_dummy_application("trainer-without-flag")
 
 
-def test_fn_with_bool_opional(flag: Optional[bool] = None) -> AppDef:
+def test_fn_with_bool_optional(flag: Optional[bool] = None) -> AppDef:
     """Dummy app with or without flag
 
     Args:
@@ -309,7 +309,7 @@ class AppDefLoadTest(unittest.TestCase):
 
     def test_bool_none(self) -> None:
         app_def = materialize_appdef(
-            test_fn_with_bool,
+            test_fn_with_bool_optional,
             [],
         )
         self.assertEqual("trainer-without-flag", app_def.roles[0].name)


### PR DESCRIPTION
Summary: Ran into an error when I had a component function with an optional bool argument that was being set to None; realized that the unit tests had the function defined but didn't actually use it yet.

Differential Revision: D48384586

