### PR TITLE
Revert "add 'node_rank' to torchrun cmd"

### DIFF
--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -261,9 +261,6 @@ def ddp(
         nnodes_rep,
         "--nproc_per_node",
         str(nproc_per_node),
-        # node_rank is only used when rdzv_backend is 'static'
-        "--node_rank",
-        f"{macros.replica_id}",
         "--tee",
         "3",
         "--role",


### PR DESCRIPTION
Reverts pytorch/torchx#751

Causes AWS Batch builds to fail https://github.com/pytorch/torchx/actions/runs/5859537004/job/15885752605

```
=== BEGIN LOG aws_batch://test-runner/torchx:ddp-trainer-btsg7z9hwbclbc (FAILED)===
main/0 usage: torchrun [-h] [--nnodes NNODES] [--nproc-per-node NPROC_PER_NODE]
main/0                 [--rdzv-backend RDZV_BACKEND] [--rdzv-endpoint RDZV_ENDPOINT]
main/0                 [--rdzv-id RDZV_ID] [--rdzv-conf RDZV_CONF] [--standalone]
main/0                 [--max-restarts MAX_RESTARTS]
main/0                 [--monitor-interval MONITOR_INTERVAL]
main/0                 [--start-method {spawn,fork,forkserver}] [--role ROLE] [-m]
main/0                 [--no-python] [--run-path] [--log-dir LOG_DIR] [-r REDIRECTS]
main/0                 [-t TEE] [--node-rank NODE_RANK] [--master-addr MASTER_ADDR]
main/0                 [--master-port MASTER_PORT] [--local-addr LOCAL_ADDR]
main/0                 training_script ...
main/0 torchrun: error: argument --node-rank/--node_rank: invalid int value: '$AWS_BATCH_JOB_NODE_INDEX'
=== END LOG aws_batch://test-runner/torchx:ddp-trainer-btsg7z9hwbclbc (FAILED) ===
```