### PR TITLE
add node_rank to torchrun cmd if rdzv_backend is 'static'

### DIFF
--- a/torchx/components/dist.py
+++ b/torchx/components/dist.py
@@ -266,6 +266,10 @@ def ddp(
         "--role",
         "",
     ]
+    # TODO 'node_rank' is made optional as it currently does not work with the AWS Batch scheduler.
+    # node_rank is only used when rdzv_backend is 'static'
+    if rdzv_backend == "static":
+        cmd += ["--node_rank", f"{macros.replica_id}"]
     if script is not None:
         cmd += [script]
     elif m is not None:

--- a/torchx/components/test/dist_test.py
+++ b/torchx/components/test/dist_test.py
@@ -38,6 +38,12 @@ class DDPTest(ComponentTestCase):
         for k, v in _TORCH_DEBUG_FLAGS.items():
             self.assertEqual(env[k], v)
 
+    def test_ddp_rdzv_backend_static(self) -> None:
+        app = ddp(script="foo.py", rdzv_backend="static")
+        cmd = app.roles[0].args[1]
+        self.assertTrue("--rdzv_backend static" in cmd)
+        self.assertTrue("--node_rank" in cmd)
+
 
 class SpmdTest(ComponentTestCase):
     def test_validate_spmd(self) -> None:


### PR DESCRIPTION
#751 
#759 

This PR adds the torchrun parameter `node_rank` in the cmd creation of `ddp()`. This parameter is needed if a user wants to use `static` rdzv_backend instead of `c10d`. 

The additional parameter is only added when the rdzv_backend is set to `static`.  For more details on why it has been implemented this way please see #759   

Test plan:
This has been tested locally against `dist_test.py` with all 10 tests passing.
