### PR TITLE
Make --log wait automatically in run

### DIFF
--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -101,12 +101,14 @@ def get_logs(
     if len(path) == 4:
         replica_ids = [(role_name, int(id)) for id in path[3].split(",") if id]
     else:
-        for i in range(10):
+        display_waiting = True
+        while True:
             status = runner.status(app_handle)
             if status and is_started(status.state):
                 break
-            if i == 0:
-                logger.info("Waiting for app to start before logging...")
+            elif display_waiting:
+                logger.info("Waiting for app state response before fetching logs...")
+                display_waiting = False
             time.sleep(1)
 
         app = none_throws(runner.describe(app_handle))

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -223,7 +223,7 @@ class CmdRun(SubCommand):
                     app_status = runner.status(app_handle)
                     if app_status:
                         logger.info(app_status.format())
-                    if args.wait:
+                    if args.wait or args.log:
                         self._wait_and_exit(runner, app_handle, log=args.log)
 
         except (ComponentValidationException, ComponentNotFoundException) as e:


### PR DESCRIPTION
Summary: I generally used to find it confusing and assume that `--log` was broken before realizing I always need to specify `--wait` to make it work -- I think it would be better to have `--log` automatically wait for the job to finish.

Differential Revision: D48874784

