### PR TITLE
Migrate Batch integration tests to use AWS resources in different region

### DIFF
--- a/.github/workflows/aws-batch-integration-tests.yaml
+++ b/.github/workflows/aws-batch-integration-tests.yaml
@@ -23,14 +23,14 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1.6.1
         with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-west-1
+          role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}
           role-session-name: github-torchx
         continue-on-error: true
       - name: Configure Docker
         run: |
           set -eux
-          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 495572122715.dkr.ecr.us-west-2.amazonaws.com
+          aws ecr get-login-password --region us-west-1 | docker login --username AWS --password-stdin 495572122715.dkr.ecr.us-west-1.amazonaws.com
         continue-on-error: true
       - name: Install dependencies
         run: |
@@ -38,7 +38,7 @@ jobs:
           pip install -e .[dev]
       - name: Run AWS Batch Integration Tests
         env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+          AWS_ROLE_ARN: ${{ secrets.TF_AWS_ROLE_ARN }}
         run: |
           set -ex
 

--- a/scripts/awsbatchint.sh
+++ b/scripts/awsbatchint.sh
@@ -21,7 +21,7 @@ cd "$DIR"
 cat <<EOT > .torchxconfig
 [aws_batch]
 queue=torchx
-image_repo=495572122715.dkr.ecr.us-west-2.amazonaws.com/torchx/integration-tests
+image_repo=495572122715.dkr.ecr.us-west-1.amazonaws.com/torchx/integration-tests
 EOT
 
 cat <<EOT > main.py


### PR DESCRIPTION
Summary:
Use us-west-1 resources as part of Devops efforts.

The resources will mirror original state and once things are stable we can turn off original region/resources.

Differential Revision: D49363140


