### PR TITLE
Move to MCAD v1.34.1

### DIFF
--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -805,7 +805,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
     co-scheduler.
     For installation instructions see: https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/main/doc/deploy/deployment.md
 
-    This has been confirmed to work with MCAD main branch and OpenShift Kubernetes
+    This has been confirmed to work with MCAD main branch v1.34.1 or higher and OpenShift Kubernetes
     Client Version: 4.10.13
     Server Version: 4.9.18
     Kubernetes Version: v1.22.3+e790d7f

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -19,6 +19,8 @@ Install MCAD:
 See deploying Multi-Cluster-Application-Dispatcher guide 
 https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/main/doc/deploy/deployment.md
 
+This implementation requires MCAD v1.34.1 or higher.
+
 TorchX uses `torch.distributed.run <https://pytorch.org/docs/stable/elastic/run.html>`_ to run distributed training.
 
 Learn more about running distributed trainers :py:mod:`torchx.components.dist`
@@ -369,7 +371,7 @@ def create_pod_group(
     pod_group_name = app_id + "-pg" + str(role_idx)
 
     labels = object_labels(app, app_id)
-    labels.update({"appwrapper.mcad.ibm.com": app_id})
+    labels.update({"appwrapper.workload.codeflare.dev": app_id})
 
     pod_group: Dict[str, Any] = {
         "apiVersion": "scheduling.sigs.k8s.io/v1alpha1",
@@ -434,7 +436,7 @@ def mcad_svc(
                     target_port=int(service_port),
                 )
             ],
-            selector={"appwrapper.mcad.ibm.com": svc_name},
+            selector={"appwrapper.workload.codeflare.dev": svc_name},
             session_affinity="None",
             type="ClusterIP",
         ),
@@ -596,7 +598,7 @@ def app_to_resource(
 
     """
     Create Service:
-    The selector will have the key 'appwrapper.mcad.ibm.com', and the value will be 
+    The selector will have the key 'appwrapper.workload.codeflare.dev', and the value will be 
     the appwrapper name
     """
 
@@ -627,7 +629,7 @@ def app_to_resource(
         enable_retry(job_spec, appwrapper_retries, total_pods)
 
     resource: Dict[str, object] = {
-        "apiVersion": "mcad.ibm.com/v1beta1",
+        "apiVersion": "workload.codeflare.dev/v1beta1",
         "kind": "AppWrapper",
         "metadata": {"name": unique_app_id, "namespace": namespace},
         "spec": job_spec,
@@ -947,7 +949,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
 
         try:
             resp = self._custom_objects_api().create_namespaced_custom_object(
-                group="mcad.ibm.com",
+                group="workload.codeflare.dev",
                 version="v1beta1",
                 namespace=namespace,
                 plural="appwrappers",
@@ -1035,7 +1037,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
     def _cancel_existing(self, app_id: str) -> None:
         namespace, name = app_id.split(":")
         self._custom_objects_api().delete_namespaced_custom_object(
-            group="mcad.ibm.com",
+            group="workload.codeflare.dev",
             version="v1beta1",
             namespace=namespace,
             plural="appwrappers",
@@ -1096,7 +1098,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
 
         # Production section
         api_instance = self._custom_objects_api
-        group = "mcad.ibm.com"
+        group = "workload.codeflare.dev"
         version = "v1beta1"
         plural = "appwrappers"
         try:
@@ -1214,7 +1216,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
         namespace = active_context["context"]["namespace"]
 
         resp = self._custom_objects_api().list_namespaced_custom_object(
-            group="mcad.ibm.com",
+            group="workload.codeflare.dev",
             version="v1beta1",
             namespace=namespace,
             plural="appwrappers",

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -381,7 +381,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                     "app.kubernetes.io/name": "test",
                     "app.kubernetes.io/managed-by": "torchx.pytorch.org",
                     "app.kubernetes.io/instance": "app-name",
-                    "appwrapper.mcad.ibm.com": unique_app_name,
+                    "appwrapper.workload.codeflare.dev": unique_app_name,
                 },
             },
             "spec": {
@@ -446,7 +446,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                         target_port=int(service_port),
                     )
                 ],
-                selector={"appwrapper.mcad.ibm.com": service_name},
+                selector={"appwrapper.workload.codeflare.dev": service_name},
                 session_affinity="None",
                 type="ClusterIP",
             ),
@@ -550,7 +550,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
 
         self.assertEqual(
             resource,
-            f"""apiVersion: mcad.ibm.com/v1beta1
+            f"""apiVersion: workload.codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   name: app-name
@@ -567,7 +567,7 @@ spec:
             app.kubernetes.io/instance: app-name
             app.kubernetes.io/managed-by: torchx.pytorch.org
             app.kubernetes.io/name: test
-            appwrapper.mcad.ibm.com: app-name
+            appwrapper.workload.codeflare.dev: app-name
           name: app-name-pg0
           namespace: test_namespace
         spec:
@@ -663,7 +663,7 @@ spec:
             targetPort: 1234
           publishNotReadyAddresses: true
           selector:
-            appwrapper.mcad.ibm.com: app-name
+            appwrapper.workload.codeflare.dev: app-name
           sessionAffinity: None
           type: ClusterIP
         status:
@@ -1607,7 +1607,7 @@ spec:
         self.assertEqual(id, "testnamespace:testid")
         call = create_namespaced_custom_object.call_args
         args, kwargs = call
-        self.assertEqual(kwargs["group"], "mcad.ibm.com")
+        self.assertEqual(kwargs["group"], "workload.codeflare.dev")
         self.assertEqual(kwargs["version"], "v1beta1")
         self.assertEqual(kwargs["namespace"], "testnamespace")
         self.assertEqual(kwargs["plural"], "appwrappers")
@@ -1665,7 +1665,7 @@ spec:
         call = get_namespaced_custom_object.call_args
         args, kwargs = call
 
-        assert "mcad.ibm.com" in args
+        assert "workload.codeflare.dev" in args
         assert "v1beta1" in args
         assert "appwrappers" in args
         assert "foo" in args
@@ -1767,7 +1767,7 @@ spec:
         call = get_namespaced_custom_object.call_args
         args, kwargs = call
 
-        assert "mcad.ibm.com" in args
+        assert "workload.codeflare.dev" in args
         assert "v1beta1" in args
         assert "appwrappers" in args
         assert "foo" in args
@@ -1844,7 +1844,7 @@ spec:
         self.assertEqual(
             kwargs,
             {
-                "group": "mcad.ibm.com",
+                "group": "workload.codeflare.dev",
                 "version": "v1beta1",
                 "namespace": "testnamespace",
                 "plural": "appwrappers",
@@ -1866,7 +1866,7 @@ spec:
             self.assertEqual(
                 kwargs,
                 {
-                    "group": "mcad.ibm.com",
+                    "group": "workload.codeflare.dev",
                     "version": "v1beta1",
                     "namespace": "default",
                     "plural": "appwrappers",
@@ -1877,12 +1877,12 @@ spec:
     @patch("kubernetes.client.CustomObjectsApi.list_namespaced_custom_object")
     def test_list_values(self, list_namespaced_custom_object: MagicMock) -> None:
         list_namespaced_custom_object.return_value = {
-            "apiVersion": "mcad.ibm.com/v1beta1",
+            "apiVersion": "workload.codeflare.dev/v1beta1",
             "name": "test-training",
             "namespace": "default",
             "items": [
                 {
-                    "apiVersion": "mcad.ibm.com/v1beta1",
+                    "apiVersion": "workload.codeflare.dev/v1beta1",
                     "kind": "AppWrapper",
                     "metadata": {
                         "name": "test-training",
@@ -1935,7 +1935,7 @@ spec:
                     },
                 },
                 {
-                    "apiVersion": "mcad.ibm.com/v1beta1",
+                    "apiVersion": "workload.codeflare.dev/v1beta1",
                     "kind": "AppWrapper",
                     "metadata": {
                         "name": "test-training",


### PR DESCRIPTION
The recent release of [MCAD v1.34.1](https://github.com/project-codeflare/multi-cluster-app-dispatcher/tree/v1.34.1) renames appwrapper resources from `appwrapper.mcad.ibm.com` to `appwrapper.workload.codeflare.dev` and corresponding API Group identifier to `workload.codeflare.dev`. The MCAD project opted for a one shot update without backwards compatibility for this resource. This PR migrates the TorchX - MCAD integration to MCAD v1.34.1. Ideally the timing of this PR could be coordinated after the next release of TorchX and instead considered for TorchX 0.7.0dev 

Test plan:
Tests updated to reflect the name changes.
