### PR TITLE
Unpin docstring-parser in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyre-extensions
-docstring-parser==0.8.1
+docstring-parser>=0.8.1
 importlib-metadata
 pyyaml
 docker


### PR DESCRIPTION
Resolves: https://github.com/pytorch/torchx/issues/771

Test plan:

Ran unittests after upgrading `docstring-parser` to the latest (0.15)

```
$ pip uninstall docstring-parser
$ pip install -U -r requirements.txt
$ pip show docstring-parser
Name: docstring-parser
Version: 0.15
Summary: Parse Python docstrings in reST, Google and Numpydoc format
Home-page: https://github.com/rr-/docstring_parser
Author: Marcin Kurczewski
Author-email: dash@wind.garden
License: MIT
Location: /usr/local/google/home/kiuk/.pyenv/versions/3.10.12/envs/torchx_310/lib/python3.10/site-packages
Requires:
Required-by: kfp

$ pytest
<... TEST LOG OUTPUT OMITTED FOR BREVITY ...>
================================================================================================ 618 passed, 90 warnings in 90.51s (0:01:30) ================================================================================================
```
