### PR TITLE
fixes #775

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -516,6 +516,7 @@ class AWSBatchScheduler(DockerWorkspaceMixin, Scheduler[AWSBatchOpts]):
                     TAG_TORCHX_VER: torchx.__version__,
                     TAG_TORCHX_APPNAME: app.name,
                     TAG_TORCHX_USER: cfg.get("user"),
+                    **app.metadata,
                 },
             },
             **({"schedulingPriority": priority} if share_id is not None else {}),

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -54,7 +54,7 @@ def _test_app() -> specs.AppDef:
         ],
     )
 
-    return specs.AppDef("test", roles=[trainer_role])
+    return specs.AppDef("test", roles=[trainer_role], metadata={"FIZZ": "buzz"})
 
 
 @contextmanager
@@ -144,6 +144,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                 "torchx.pytorch.org/version": torchx.__version__,
                 "torchx.pytorch.org/app-name": "test",
                 "torchx.pytorch.org/user": "testuser",
+                "FIZZ": "buzz",
             },
             info.request.job_def["tags"],
         )
@@ -231,6 +232,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                     "torchx.pytorch.org/version": torchx.__version__,
                     "torchx.pytorch.org/app-name": "test",
                     "torchx.pytorch.org/user": "testuser",
+                    "FIZZ": "buzz",
                 },
             },
         )


### PR DESCRIPTION
passing AppDef metadata to job tags for AWS Batch scheduler

Test plan:
* updated the unit tests
