### PR TITLE
Update torchx for fsspec 2023.10

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ boto3==1.24.59
 captum>=0.4.0
 docker
 flake8==3.9.0
-fsspec[s3]==2023.1.0
+fsspec[s3]==2023.10.0
 google-api-core
 google-cloud-batch>=0.5.0
 google-cloud-logging>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ importlib-metadata
 pyyaml
 docker
 filelock
-# more recent versions of fsspec causes torchx/workspace/test/dir_workspace_test#test_torchcxignore to fail
-fsspec==2023.1.0
+fsspec==2023.10.0
 # To resolve confliciting dependencies for urllib3: https://github.com/pytorch/torchx/actions/runs/3484190429/jobs/5828784263#step:4:552
 urllib3<1.27,>=1.21.1
 tabulate

--- a/torchx/workspace/test/dir_workspace_test.py
+++ b/torchx/workspace/test/dir_workspace_test.py
@@ -92,11 +92,10 @@ class DirWorkspaceTest(unittest.TestCase):
 
         files = fs.glob("torchxignoredest/*") + fs.glob("torchxignoredest/**/*")
         # strip prefix
-        files = [
+        files = {
             os.path.normpath(file.partition("torchxignoredest/")[2]) for file in files
-        ]
-        print(files)
-        self.assertCountEqual(
+        }
+        self.assertSetEqual(
             files,
             {
                 ".torchxignore",


### PR DESCRIPTION
This updates the code to the latest version of fsspec, updating the test to work around https://github.com/fsspec/filesystem_spec/issues/1394.

I have written the test so that it should actually be compatible with *both* the old and new versions of fsspec, but for testing purposes updated the requirements.txt as well.

Supersedes https://github.com/pytorch/torchx/pull/783 (so it can be merged separately from the internal diff).