### PR TITLE
Fix broken pyre in CI

### DIFF
--- a/torchx/test/minio.py
+++ b/torchx/test/minio.py
@@ -13,7 +13,8 @@ class MinioFS(s3fs.S3FileSystem):
     tests in minikube.
     """
 
-    protocol = ["torchx_minio", "s3", "s3a"]
+    # pyre-ignore[15] declared in fsspec.spec.AbstractFileSystem.protocol as ClassVar[str | tuple[str, ...]]
+    protocol = ("torchx_minio", "s3", "s3a")
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(


### PR DESCRIPTION
Fixes `pyre` checks broken in main due to fsspec being updated to 2023.1.0.
https://github.com/pytorch/torchx/actions/runs/6734942127/job/18306950235

Oddly, pyre checks passed in the PR (see: https://github.com/pytorch/torchx/actions/runs/6698472480) b/c for some reason pip decided to resolve to `s3fs-0.6.0` (should've been `s3fs-2023.1.0`) when running pyre checks from the PR but `s3fs-2023.1.0` when running pre checks from `main`

Test plan:
========
```
cd ~/workspace/torchx
pip install -U -r dev-requirements.txt
pyre --noninteractive check
2023-11-02 16:50:09,626 [PID 3429811] SUCCESS No type errors found
```
