### PR TITLE
Fix: Distributed Training Rendezvous error with MCAD v.1.34.1

### DIFF
--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -436,7 +436,7 @@ def mcad_svc(
                     target_port=int(service_port),
                 )
             ],
-            selector={"appwrapper.workload.codeflare.dev": svc_name},
+            selector={LABEL_UNIQUE_NAME: svc_name},
             session_affinity="None",
             type="ClusterIP",
         ),

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -450,7 +450,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                         target_port=int(service_port),
                     )
                 ],
-                selector={"appwrapper.workload.codeflare.dev": service_name},
+                selector={"app.kubernetes.io/instance": service_name},
                 session_affinity="None",
                 type="ClusterIP",
             ),

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -667,7 +667,7 @@ spec:
             targetPort: 1234
           publishNotReadyAddresses: true
           selector:
-            appwrapper.workload.codeflare.dev: app-name
+            app.kubernetes.io/instance: app-name
           sessionAffinity: None
           type: ClusterIP
         status:


### PR DESCRIPTION
Some releases of MCAD (starting with v1.34.1) incorrectly autogenerated pod labels with the old appwrapper identifier labels added. Since the Kubernetes service deployed by TorchX-MCAD relied on the correct label, distributed jobs failed due to rendezvous errors. This PR moves the generated Kubernetes Service selector to the standard `app.kubernetes.io/instance` label to cover any versions of MCAD that may be in deployment.

Test plan:
Updated the corresponding TorchX-MCAD tests.