### PR TITLE
Revert "torchx/schedulers"

### DIFF
--- a/torchx/schedulers/gcp_batch_scheduler.py
+++ b/torchx/schedulers/gcp_batch_scheduler.py
@@ -205,14 +205,12 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
             if cpu <= 0:
                 cpu = 1
             MILLI = 1000
-            # pyre-fixme[8]: Attribute has type `Field`; used as `int`.
             res.cpu_milli = cpu * MILLI
             memMB = resource.memMB
             if memMB < 0:
                 raise ValueError(
                     f"memMB should to be set to a positive value, got {memMB}"
                 )
-            # pyre-fixme[8]: Attribute has type `Field`; used as `int`.
             res.memory_mib = memMB
 
             # TODO support named resources
@@ -360,13 +358,11 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
             return None
 
         gpu = 0
-        # pyre-fixme[16]: `Field` has no attribute `instances`.
         if len(job.allocation_policy.instances) != 0:
             gpu_type = job.allocation_policy.instances[0].policy.machine_type
             gpu = GPU_TYPE_TO_COUNT[gpu_type]
 
         roles = {}
-        # pyre-fixme[16]: `RepeatedField` has no attribute `__iter__`.
         for tg in job.task_groups:
             env = tg.task_spec.environment.variables
             role = env["TORCHX_ROLE_NAME"]
@@ -390,7 +386,6 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
         # TODO map role/replica status
         desc = DescribeAppResponse(
             app_id=app_id,
-            # pyre-fixme[16]: `Field` has no attribute `state`.
             state=JOB_STATE[job.status.state.name],
             roles=list(roles.values()),
         )

--- a/torchx/schedulers/test/gcp_batch_scheduler_test.py
+++ b/torchx/schedulers/test/gcp_batch_scheduler_test.py
@@ -83,9 +83,7 @@ class GCPBatchSchedulerTest(unittest.TestCase):
         env["TORCHX_ROLE_NAME"] = "trainer"
         env["FOO"] = "bar"
         res = batch_v1.ComputeResource()
-        # pyre-fixme[8]: Attribute has type `Field`; used as `int`.
         res.cpu_milli = 2000
-        # pyre-fixme[8]: Attribute has type `Field`; used as `int`.
         res.memory_mib = 3000
         allocationPolicy = batch_v1.AllocationPolicy(
             instances=[


### PR DESCRIPTION
This reverts commit 19497eb1d2649f66cd12ca1eeed77353085f07e0.

Causes pyre checks to fail

Test plan:

CI
