### PR TITLE
fix warning B908

### DIFF
--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -64,8 +64,8 @@ class RunnerTest(TestWithTmpDir):
 
     def test_validate_no_roles(self, _) -> None:
         with self.get_runner() as runner:
+            app = AppDef("no roles")
             with self.assertRaises(ValueError):
-                app = AppDef("no roles")
                 runner.run(app, scheduler="local_dir")
 
     def test_validate_no_resource(self, _) -> None:


### PR DESCRIPTION
Summary:
Fix the warning on the code:

B908: Contexts with exceptions assertions like with self.assertRaises or with pytest.raises should not have multiple top-level statements. Each statement should be in its own context. That way, the test ensures that the exception is raised only in the exact statement where you expect it.

This warning is raised by flake8-bugbear: https://github.com/PyCQA/flake8-bugbear

This diff fixed it by mimicking D50647471.

Differential Revision: D53461157


