### PR TITLE
fixing unitest warnings

### DIFF
--- a/torchx/apps/utils/booth_main.py
+++ b/torchx/apps/utils/booth_main.py
@@ -36,9 +36,9 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--trial_idx",
-        type=int,
+        type=str,
         help="trial index (ignore if not running hpo)",
-        default=0,
+        default="0",
     )
     return parser.parse_args(argv)
 

--- a/torchx/apps/utils/test/booth_test.py
+++ b/torchx/apps/utils/test/booth_test.py
@@ -25,4 +25,4 @@ class BoothTest(unittest.TestCase):
         booth.main(["--x1", "1", "--x2", "3", "--tracker_base", self.test_dir])
 
         tracker = FsspecResultTracker(self.test_dir)
-        self.assertEqual(0.0, tracker[0]["booth_eval"])
+        self.assertEqual(0.0, tracker["0"]["booth_eval"])

--- a/torchx/cli/test/cmd_log_test.py
+++ b/torchx/cli/test/cmd_log_test.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Iterator, Optional
 from unittest.mock import MagicMock, patch
 
+import pytest
 from torchx.cli.cmd_log import _prefix_line, ENDC, get_logs, GREEN, validate
 from torchx.runner.api import Runner
 from torchx.schedulers.api import Stream
@@ -191,7 +192,7 @@ class CmdLogTest(unittest.TestCase):
         # errors out; we raise the exception all the way through
         with patch.object(mock_runner, "log_lines") as log_lines_mock:
             log_lines_mock.side_effect = RuntimeError
-            with self.assertRaises(RuntimeError):
+            with pytest.raises(RuntimeError):
                 get_logs(
                     sys.stdout,
                     "local://test-session/SparseNNAppDef/trainer/0,1",

--- a/torchx/components/structured_arg.py
+++ b/torchx/components/structured_arg.py
@@ -226,7 +226,8 @@ class StructuredJArgument:
                     f" This may lead to under-utilization or an error. "
                     f" If this was intentional, ignore this warning."
                     f" Otherwise set `-j {nnodes}` to auto-set nproc_per_node"
-                    f" to the number of GPUs on the host."
+                    f" to the number of GPUs on the host.",
+                    ResourceWarning,
                 )
         else:
             raise ValueError(

--- a/torchx/components/test/structured_arg_test.py
+++ b/torchx/components/test/structured_arg_test.py
@@ -6,6 +6,7 @@
 import unittest
 from unittest import mock
 
+import pytest
 from torchx.components.structured_arg import StructuredJArgument, StructuredNameArgument
 
 WARNINGS_WARN = "torchx.components.structured_arg.warnings.warn"
@@ -71,18 +72,21 @@ class ArgJTest(unittest.TestCase):
             StructuredJArgument(nnodes=2, nproc_per_node=8),
             StructuredJArgument.parse_from(h="aws_p4d.24xlarge", j="2"),
         )
-        self.assertEqual(
-            StructuredJArgument(nnodes=2, nproc_per_node=4),
-            StructuredJArgument.parse_from(h="aws_p4d.24xlarge", j="2x4"),
-        )
-        self.assertEqual(
-            StructuredJArgument(nnodes=2, nproc_per_node=16),
-            StructuredJArgument.parse_from(h="aws_p4d.24xlarge", j="2x16"),
-        )
-        self.assertEqual(
-            StructuredJArgument(nnodes=2, nproc_per_node=8),
-            StructuredJArgument.parse_from(h="aws_trn1.2xlarge", j="2x8"),
-        )
+        with pytest.warns(ResourceWarning):
+            self.assertEqual(
+                StructuredJArgument(nnodes=2, nproc_per_node=4),
+                StructuredJArgument.parse_from(h="aws_p4d.24xlarge", j="2x4"),
+            )
+        with pytest.warns(ResourceWarning):
+            self.assertEqual(
+                StructuredJArgument(nnodes=2, nproc_per_node=16),
+                StructuredJArgument.parse_from(h="aws_p4d.24xlarge", j="2x16"),
+            )
+        with pytest.warns(ResourceWarning):
+            self.assertEqual(
+                StructuredJArgument(nnodes=2, nproc_per_node=8),
+                StructuredJArgument.parse_from(h="aws_trn1.2xlarge", j="2x8"),
+            )
 
         with self.assertRaisesRegex(
             ValueError,

--- a/torchx/examples/apps/lightning/model.py
+++ b/torchx/examples/apps/lightning/model.py
@@ -21,7 +21,7 @@ import pytorch_lightning as pl
 import torch
 import torch.jit
 from torch.nn import functional as F
-from torchmetrics import Accuracy
+from torchmetrics.classification import MulticlassAccuracy
 from torchvision.models.resnet import BasicBlock, ResNet
 
 
@@ -47,8 +47,8 @@ class TinyImageNetModel(pl.LightningModule):
         m.fc.out_features = 200
         self.model: ResNet = m
 
-        self.train_acc = Accuracy()
-        self.val_acc = Accuracy()
+        self.train_acc = MulticlassAccuracy(m.fc.out_features)
+        self.val_acc = MulticlassAccuracy(m.fc.out_features)
 
     # pyre-fixme[14]
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -69,7 +69,7 @@ class TinyImageNetModel(pl.LightningModule):
     def _step(
         self,
         step_name: str,
-        acc_metric: Accuracy,
+        acc_metric: MulticlassAccuracy,
         batch: Tuple[torch.Tensor, torch.Tensor],
         batch_idx: int,
     ) -> torch.Tensor:

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from typing import Generator, List, Mapping, Optional
 from unittest.mock import MagicMock, patch
 
+import pytest
 from torchx.runner import get_runner, Runner
 from torchx.schedulers.api import DescribeAppResponse, ListAppResponse, Scheduler
 from torchx.schedulers.local_scheduler import (
@@ -415,7 +416,7 @@ class RunnerTest(TestWithTmpDir):
             )
             app_handle = runner.run(AppDef(app_id, roles=[role]), scheduler="local_dir")
             status = none_throws(runner.status(app_handle))
-            self.assertEquals(resp.ui_url, status.ui_url)
+            self.assertEqual(resp.ui_url, status.ui_url)
 
     @patch("json.dumps")
     def test_status_structured_msg(self, json_dumps_mock: MagicMock, _) -> None:
@@ -439,7 +440,7 @@ class RunnerTest(TestWithTmpDir):
             )
             app_handle = runner.run(AppDef(app_id, roles=[role]), scheduler="local_dir")
             status = none_throws(runner.status(app_handle))
-            self.assertEquals(resp.structured_error_msg, status.structured_error_msg)
+            self.assertEqual(resp.structured_error_msg, status.structured_error_msg)
 
     def test_wait_unknown_app(self, _) -> None:
         with self.get_runner() as runner:
@@ -458,7 +459,10 @@ class RunnerTest(TestWithTmpDir):
 
     def test_stop(self, _) -> None:
         with self.get_runner() as runner:
-            self.assertIsNone(runner.stop("local_dir://test_session/unknown_app_id"))
+            with pytest.warns(PendingDeprecationWarning):
+                self.assertIsNone(
+                    runner.stop("local_dir://test_session/unknown_app_id")
+                )
 
     def test_log_lines_unknown_app(self, _) -> None:
         with self.get_runner() as runner:
@@ -550,7 +554,7 @@ class RunnerTest(TestWithTmpDir):
             local_sched_mock.submit.called_once_with(app, {})
 
     def test_run_from_module(self, _: str) -> None:
-        runner = get_runner(name="test_session")
+        runner = get_runner()
         app_args = ["--image", "dummy_image", "--script", "test.py"]
         with patch.object(runner, "schedule"), patch.object(
             runner, "dryrun"

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -27,7 +27,7 @@ from torchx.specs import AppDef, AppDryRunInfo, CfgVal, runopts
 from torchx.test.fixtures import TestWithTmpDir
 
 
-class TestScheduler(Scheduler):
+class SchedulerTester(Scheduler):
     def __init__(self, session_name: str) -> None:
         super().__init__("test", session_name)
 
@@ -341,7 +341,7 @@ image = foobar_custom
 
     @patch(
         TORCHX_GET_SCHEDULER_FACTORIES,
-        return_value={"test": TestScheduler},
+        return_value={"test": SchedulerTester},
     )
     def test_apply_default(self, _) -> None:
         with patch(
@@ -357,7 +357,7 @@ image = foobar_custom
 
     @patch(
         TORCHX_GET_SCHEDULER_FACTORIES,
-        return_value={"test": TestScheduler},
+        return_value={"test": SchedulerTester},
     )
     def test_apply_dirs(self, _) -> None:
         cfg: Dict[str, CfgVal] = {"s": "runtime_value"}
@@ -376,7 +376,7 @@ image = foobar_custom
 
     @patch(
         TORCHX_GET_SCHEDULER_FACTORIES,
-        return_value={"test": TestScheduler},
+        return_value={"test": SchedulerTester},
     )
     def test_dump_only_required(self, _) -> None:
         sfile = StringIO()
@@ -393,7 +393,7 @@ image = foobar_custom
 
     @patch(
         TORCHX_GET_SCHEDULER_FACTORIES,
-        return_value={"test": TestScheduler},
+        return_value={"test": SchedulerTester},
     )
     def test_load_invalid_runopt(self, _) -> None:
         cfg = {}
@@ -407,7 +407,7 @@ image = foobar_custom
         # this makes things super hard to guarantee BC - stale config file will fail
         # to run, we don't want that)
 
-        self.assertEquals("option_that_exists", cfg.get("s"))
+        self.assertEqual("option_that_exists", cfg.get("s"))
 
     def test_load_no_section(self) -> None:
         cfg = {}
@@ -429,7 +429,7 @@ image = foobar_custom
 
     @patch(
         TORCHX_GET_SCHEDULER_FACTORIES,
-        return_value={"test": TestScheduler},
+        return_value={"test": SchedulerTester},
     )
     def test_dump_and_load_all_runopt_types(self, _) -> None:
         sfile = StringIO()
@@ -441,7 +441,7 @@ image = foobar_custom
         load(scheduler="test", f=sfile, cfg=cfg)
 
         # all runopts in the TestScheduler have defaults, just check against those
-        for opt_name, opt in TestScheduler("test").run_opts():
+        for opt_name, opt in SchedulerTester("test").run_opts():
             self.assertEqual(cfg.get(opt_name), opt.default)
 
     def test_dump_and_load_all_registered_schedulers(self) -> None:

--- a/torchx/runtime/tracking/test/api_test.py
+++ b/torchx/runtime/tracking/test/api_test.py
@@ -35,13 +35,13 @@ class ApiTest(unittest.TestCase):
 
     def test_get_missing_key(self) -> None:
         tracker = FsspecResultTracker(self.test_dir)
-        res = tracker[1]
+        res = tracker["1"]
         self.assertFalse(res)
 
     def test_put_get_x2(self) -> None:
         tracker = FsspecResultTracker(self.test_dir)
-        tracker[1] = {"l2norm": 1}
-        tracker[1] = {"l2norm": 2}
+        tracker["1"] = {"l2norm": 1}
+        tracker["1"] = {"l2norm": 2}
 
         self.assertEqual(2, tracker["1"]["l2norm"])
         self.assertEqual(2, tracker["1"]["l2norm"])

--- a/torchx/schedulers/devices.py
+++ b/torchx/schedulers/devices.py
@@ -35,7 +35,7 @@ def get_device_mounts(devices: Dict[str, int]) -> List[DeviceMount]:
     device_mounts = []
     for device_name, num_devices in devices.items():
         if device_name not in DEVICES:
-            warnings.warn(f"Could not find named device: {device_name}")
+            warnings.warn(f"Could not find named device: {device_name}", RuntimeWarning)
             continue
         device_mounts += DEVICES[device_name](num_devices)
     return device_mounts

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -478,7 +478,7 @@ def get_unique_truncated_appid(app: AppDef) -> str:
     if unique_id_size <= 3:
         msg = "Name size has too many characters for some Kubernetes objects. Truncating \
 application name."
-        warnings.warn(msg)
+        warnings.warn(msg, RuntimeWarning)
         end = 63 - uid_chars - pg_chars
         substring = app.name[0:end]
         app.name = substring
@@ -501,7 +501,7 @@ def get_port_for_service(app: AppDef) -> str:
     if not (0 < int(port) <= 65535):
         msg = """Warning: port_map set to invalid port number. Value must be between 1-65535, with torchx default = 29500. Setting port to default = 29500"""
         port = "29500"
-        warnings.warn(msg)
+        warnings.warn(msg, RuntimeWarning)
 
     return port
 
@@ -1147,7 +1147,7 @@ class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts
             task_count = 0
             for role in roles:
                 msg = "Warning - MCAD does not report individual replica statuses, but overall task status. Replica id  may not match status"
-                warnings.warn(msg)
+                warnings.warn(msg, RuntimeWarning)
 
                 roles_statuses[role] = RoleStatus(role, [])
                 for idx in range(0, roles[role].num_replicas):

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -1002,7 +1002,8 @@ Reduce requested GPU resources or use a host with more GPUs
         if since or until:
             warnings.warn(
                 "Since and/or until times specified for LocalScheduler.log_iter."
-                " These will be ignored and all log lines will be returned"
+                " These will be ignored and all log lines will be returned",
+                RuntimeWarning,
             )
 
         app = self._apps[app_id]

--- a/torchx/schedulers/test/devices_test.py
+++ b/torchx/schedulers/test/devices_test.py
@@ -8,6 +8,7 @@
 
 import unittest
 
+import pytest
 from torchx.schedulers.devices import get_device_mounts
 from torchx.specs.api import DeviceMount
 
@@ -31,5 +32,5 @@ class DevicesTest(unittest.TestCase):
 
     def test_not_found_device_name(self) -> None:
         devices = {"shouldWarn": 1}
-        self.assertEqual(get_device_mounts(devices), [])
-        self.assertWarns(UserWarning, get_device_mounts, devices)
+        with pytest.warns(RuntimeWarning):
+            self.assertEqual(get_device_mounts(devices), [])

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torchx
 from torchx import schedulers, specs
 
@@ -165,8 +166,8 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         self.assertIsInstance(
             scheduler, kubernetes_mcad_scheduler.KubernetesMCADScheduler
         )
-        self.assertEquals(client, scheduler._client)
-        self.assertEquals(docker_client, scheduler._docker_client)
+        self.assertEqual(client, scheduler._client)
+        self.assertEqual(docker_client, scheduler._docker_client)
 
     def test_app_to_resource_resolved_macros(self) -> None:
         app = _test_app()
@@ -489,12 +490,13 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         app.name = (
             "abcdefghijklmnopqrstuvwxyz012345678910111213141516171819202122232425"
         )
-        self.assertEqual(59, len(get_unique_truncated_appid(app)))
-        self.assertIn(
-            "abcdefghijklmnopqrstuvwxyz01234567891011121314151617181",
-            get_unique_truncated_appid(app),
-        )
-        self.assertNotIn("9202122232425", get_unique_truncated_appid(app))
+        with pytest.warns(RuntimeWarning):
+            self.assertEqual(59, len(get_unique_truncated_appid(app)))
+            self.assertIn(
+                "abcdefghijklmnopqrstuvwxyz01234567891011121314151617181",
+                get_unique_truncated_appid(app),
+            )
+            self.assertNotIn("9202122232425", get_unique_truncated_appid(app))
 
     def test_get_port_for_service(self) -> None:
         scheduler = create_scheduler("test")
@@ -513,7 +515,8 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
         scheduler = create_scheduler("test")
         app = _test_app()
         app.roles[0].port_map = {"foo": 65536}
-        test_port = get_port_for_service(app)
+        with pytest.warns(RuntimeWarning):
+            test_port = get_port_for_service(app)
         self.assertEqual(test_port, "29500")
 
     def test_get_pending_appwrapper_status(self) -> None:
@@ -1662,10 +1665,10 @@ spec:
                 },
             },
         }
-
         app_id = "foo:bar"
         scheduler = create_scheduler("foo")
-        info = scheduler.describe(app_id)
+        with pytest.warns(RuntimeWarning):
+            info = scheduler.describe(app_id)
         call = get_namespaced_custom_object.call_args
         args, kwargs = call
 
@@ -1736,7 +1739,8 @@ spec:
 
         app_id = "foo:bar"
         scheduler = create_scheduler("foo")
-        info = scheduler.describe(app_id)
+        with pytest.warns(RuntimeWarning):
+            info = scheduler.describe(app_id)
 
         self.assertEqual(
             info,

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -96,8 +96,8 @@ class KubernetesSchedulerTest(unittest.TestCase):
         docker_client = MagicMock
         scheduler = create_scheduler("foo", client=client, docker_client=docker_client)
         self.assertIsInstance(scheduler, kubernetes_scheduler.KubernetesScheduler)
-        self.assertEquals(scheduler._docker_client, docker_client)
-        self.assertEquals(scheduler._client, client)
+        self.assertEqual(scheduler._docker_client, docker_client)
+        self.assertEqual(scheduler._client, client)
 
     def test_app_to_resource_resolved_macros(self) -> None:
         app = _test_app()

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -23,6 +23,7 @@ from typing import Callable, Dict, Generator, List, Optional
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import pytest
 from torchx.schedulers.api import DescribeAppResponse
 from torchx.schedulers.local_scheduler import (
     _join_PATH,
@@ -661,12 +662,13 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
             self.assertEqual(str(i), line.strip())
 
         # since and until ignored
-        for i, line in enumerate(
-            self.scheduler.log_iter(
-                app_id, "role1", k=0, since=datetime.now(), until=datetime.now()
-            )
-        ):
-            self.assertEqual(str(i), line.strip())
+        with pytest.warns(RuntimeWarning):
+            for i, line in enumerate(
+                self.scheduler.log_iter(
+                    app_id, "role1", k=0, since=datetime.now(), until=datetime.now()
+                )
+            ):
+                self.assertEqual(str(i), line.strip())
 
         for i, line in enumerate(
             self.scheduler.log_iter(app_id, "role1", k=0, regex=r"[02468]")

--- a/torchx/schedulers/test/ray_scheduler_test.py
+++ b/torchx/schedulers/test/ray_scheduler_test.py
@@ -388,7 +388,7 @@ if has_ray():
             )
             _scheduler_with_client = RayScheduler("client_session", ray_client)
             scheduler_client = _scheduler_with_client._get_ray_client()
-            self.assertDictContainsSubset(scheduler_client._headers, headers)
+            assert scheduler_client._headers.items() <= headers.items()
 
     class RayClusterSetup:
         _instance = None  # pyre-ignore

--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -53,7 +53,8 @@ def instance_type_from_resource(resource: Resource) -> str:
     instance_type = resource.capabilities.get(K8S_ITYPE)
     if instance_type is None:
         warnings.warn(
-            "Cannot determine resource instance type which can cause issues for non-homogeneous CEs and multinode jobs. Consider providing torchx.specs.named_resources_aws:K8S_TYPE resource capability."
+            "Cannot determine resource instance type which can cause issues for non-homogeneous CEs and multinode jobs. Consider providing torchx.specs.named_resources_aws:K8S_TYPE resource capability.",
+            ResourceWarning,
         )
     return instance_type
 

--- a/torchx/specs/test/builders_test.py
+++ b/torchx/specs/test/builders_test.py
@@ -46,12 +46,12 @@ def get_dummy_application(role: str) -> AppDef:
     return AppDef(name="test_app", roles=[trainer])
 
 
-def test_empty_fn() -> AppDef:
+def empty_fn() -> AppDef:
     """Empty function that returns dummy app"""
     return get_dummy_application("trainer")
 
 
-def test_fn_with_bool(flag: bool = False) -> AppDef:
+def fn_with_bool(flag: bool = False) -> AppDef:
     """Dummy app with or without flag
 
     Args:
@@ -63,7 +63,7 @@ def test_fn_with_bool(flag: bool = False) -> AppDef:
         return get_dummy_application("trainer-without-flag")
 
 
-def test_fn_with_bool_optional(flag: Optional[bool] = None) -> AppDef:
+def fn_with_bool_optional(flag: Optional[bool] = None) -> AppDef:
     """Dummy app with or without flag
 
     Args:
@@ -75,7 +75,7 @@ def test_fn_with_bool_optional(flag: Optional[bool] = None) -> AppDef:
         return get_dummy_application("trainer-without-flag")
 
 
-def test_empty_fn_no_docstring() -> AppDef:
+def empty_fn_no_docstring() -> AppDef:
     return get_dummy_application("trainer")
 
 
@@ -232,7 +232,7 @@ class AppDefLoadTest(unittest.TestCase):
         ]
 
     def test_load_from_fn_empty(self) -> None:
-        actual_app = materialize_appdef(test_empty_fn, [])
+        actual_app = materialize_appdef(empty_fn, [])
         expected_app = get_dummy_application("trainer")
         self.assert_apps(expected_app, actual_app)
 
@@ -273,7 +273,7 @@ class AppDefLoadTest(unittest.TestCase):
 
     def test_bool_true(self) -> None:
         app_def = materialize_appdef(
-            test_fn_with_bool,
+            fn_with_bool,
             [
                 "--flag",
                 "True",
@@ -281,7 +281,7 @@ class AppDefLoadTest(unittest.TestCase):
         )
         self.assertEqual("trainer-with-flag", app_def.roles[0].name)
         app_def = materialize_appdef(
-            test_fn_with_bool,
+            fn_with_bool,
             [
                 "--flag",
                 "true",
@@ -291,7 +291,7 @@ class AppDefLoadTest(unittest.TestCase):
 
     def test_bool_false(self) -> None:
         app_def = materialize_appdef(
-            test_fn_with_bool,
+            fn_with_bool,
             [
                 "--flag",
                 "False",
@@ -299,7 +299,7 @@ class AppDefLoadTest(unittest.TestCase):
         )
         self.assertEqual("trainer-without-flag", app_def.roles[0].name)
         app_def = materialize_appdef(
-            test_fn_with_bool,
+            fn_with_bool,
             [
                 "--flag",
                 "false",
@@ -309,7 +309,7 @@ class AppDefLoadTest(unittest.TestCase):
 
     def test_bool_none(self) -> None:
         app_def = materialize_appdef(
-            test_fn_with_bool_optional,
+            fn_with_bool_optional,
             [],
         )
         self.assertEqual("trainer-without-flag", app_def.roles[0].name)

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -280,7 +280,7 @@ class GetBuiltinSourceTest(unittest.TestCase):
 
         runner = get_runner()
 
-        trial_idx = 0
+        trial_idx = "0"
         tracker_base = str(self.test_dir / "tracking")
 
         app_handle = runner.run_component(

--- a/torchx/tracker/test/api_test.py
+++ b/torchx/tracker/test/api_test.py
@@ -34,7 +34,7 @@ RunId = str
 DEFAULT_SOURCE: str = "__parent__"
 
 
-class TestTrackerBackend(TrackerBase):
+class TrackerBackendTester(TrackerBase):
     def __init__(self, config_path: Optional[str] = None) -> None:
         self._artifacts: DefaultDict[
             RunId,
@@ -104,7 +104,7 @@ class TestTrackerBackend(TrackerBase):
 class AppRunApiTest(TestCase):
     def setUp(self) -> None:
         os.environ[ENV_TORCHX_JOB_ID] = "scheduler://session/app_id"
-        self.tracker = TestTrackerBackend()
+        self.tracker = TrackerBackendTester()
         self.run_id = "run_id"
         self.model_run = AppRun(self.run_id, [self.tracker])
 
@@ -130,7 +130,7 @@ class AppRunApiTest(TestCase):
             self.assertEqual(1, len(trackers))
 
             tracker = trackers[0]
-            self.assertEqual(TestTrackerBackend, type(tracker))
+            self.assertEqual(TrackerBackendTester, type(tracker))
 
             sources = list(tracker.sources("run_id"))
             self.assertEqual(1, len(sources))
@@ -184,7 +184,7 @@ class AppRunApiTest(TestCase):
 
 
 def tracker_factory(config: Optional[str] = None) -> TrackerBase:
-    return TestTrackerBackend(config)
+    return TrackerBackendTester(config)
 
 
 class TrackerFactoryMethodsTest(TestCase):
@@ -203,7 +203,7 @@ class TrackerFactoryMethodsTest(TestCase):
         ):
             trackers = trackers_from_environ()
             self.assertEqual(1, len(list(trackers)))
-            self.assertEqual(TestTrackerBackend, type(trackers[0]))
+            self.assertEqual(TrackerBackendTester, type(trackers[0]))
 
     @mock.patch.dict(
         os.environ,
@@ -218,7 +218,7 @@ class TrackerFactoryMethodsTest(TestCase):
             return_value={"tracker1": tracker_factory},
         ):
             trackers = trackers_from_environ()
-            tracker = cast(TestTrackerBackend, list(trackers)[0])
+            tracker = cast(TrackerBackendTester, list(trackers)[0])
             self.assertEqual("myconfig.txt", tracker.config_path)
 
     def test_tracker_from_environ_that_wasnt_setup(self) -> None:


### PR DESCRIPTION
<!-- Change Summary -->
Went through the warning list from pytest and tryed to fix as many warning as i could that should not be raised within testing.
This allows relevant warnings to not be lost within a lot of irrelevant warnings.
I didn't touch the KFP, ray and kubernetes warnings, i will leave those to people with more contextual knowledge.

Fixes included:
- remediation for deprecation
- catching warnings if they are expected to be thrown
- renaming of test helper functions/class that were being picked up wrongly by unitest (names starting with test)
