### PR TITLE
fix warning B908(2) in api_test.py

### DIFF
--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -82,16 +82,16 @@ class RunnerTest(TestWithTmpDir):
 
     def test_validate_invalid_replicas(self, _) -> None:
         with self.get_runner() as runner:
+            role = Role(
+                "invalid replicas",
+                image="torch",
+                entrypoint="echo",
+                args=["hello_world"],
+                num_replicas=0,
+                resource=Resource(cpu=1, gpu=0, memMB=500),
+            )
+            app = AppDef("invalid replicas", roles=[role])
             with self.assertRaises(ValueError):
-                role = Role(
-                    "invalid replicas",
-                    image="torch",
-                    entrypoint="echo",
-                    args=["hello_world"],
-                    num_replicas=0,
-                    resource=Resource(cpu=1, gpu=0, memMB=500),
-                )
-                app = AppDef("invalid replicas", roles=[role])
                 runner.run(app, scheduler="local_dir")
 
     def test_run(self, _) -> None:


### PR DESCRIPTION

<!-- Change Summary -->
Fix the warning on the code:

B908: Contexts with exceptions assertions like with self.assertRaises or with pytest.raises should not have multiple top-level statements. Each statement should be in its own context. That way, the test ensures that the exception is raised only in the exact statement where you expect it. This warning is raised by flake8-bugbear: https://github.com/PyCQA/flake8-bugbear

Test plan:
auto tests from CI.
