### PR TITLE
fix slurm integration tests

### DIFF
--- a/.github/workflows/slurm-local-integration-tests.yaml
+++ b/.github/workflows/slurm-local-integration-tests.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   slurm:
-    runs-on: ubuntu-20.04
+    runs-on: linux.20_04.4x
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
<!-- Change Summary -->

Integration test was running out of disk space. This uses a larger Linux worker which should have more disk.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI
