### PR TITLE
Fix install command on quickstart tutorial

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -25,7 +25,7 @@ the CLI and the library.
 <!-- #md -->
 ```sh
 # install torchx with all dependencies
-$ pip install torchx[dev]
+$ pip install "torchx[dev]"
 ```
 <!-- #endmd -->
 


### PR DESCRIPTION
<!-- Change Summary -->

Fixes install command on quickstart tutorial (fixes #849).

Test plan:
This is a documentation change, and does not require an test case.
