### PR TITLE
use pyre_config version

### DIFF
--- a/.github/workflows/pyre.yaml
+++ b/.github/workflows/pyre.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.10"
           architecture: x64
       - name: Checkout TorchX
         uses: actions/checkout@v2
@@ -21,5 +21,7 @@ jobs:
         run: |
           set -eux
           pip install -e .[dev]
+          VERSION=$(grep "version" .pyre_configuration | sed -n -e 's/.*\(0\.0\.[0-9]*\).*/\1/p')
+          pip install pyre-check-nightly==$VERSION
       - name: Run Pyre
         run: scripts/pyre.sh

--- a/torchx/schedulers/gcp_batch_scheduler.py
+++ b/torchx/schedulers/gcp_batch_scheduler.py
@@ -207,14 +207,12 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
             if cpu <= 0:
                 cpu = 1
             MILLI = 1000
-            # pyre-fixme[8]: Attribute has type `Field`; used as `int`.
             res.cpu_milli = cpu * MILLI
             memMB = resource.memMB
             if memMB < 0:
                 raise ValueError(
                     f"memMB should to be set to a positive value, got {memMB}"
                 )
-            # pyre-fixme[8]: Attribute has type `Field`; used as `int`.
             res.memory_mib = memMB
 
             # TODO support named resources
@@ -362,13 +360,11 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
             return None
 
         gpu = 0
-        # pyre-fixme[16]: `Field` has no attribute `instances`.
         if len(job.allocation_policy.instances) != 0:
             gpu_type = job.allocation_policy.instances[0].policy.machine_type
             gpu = GPU_TYPE_TO_COUNT[gpu_type]
 
         roles = {}
-        # pyre-fixme[16]: `RepeatedField` has no attribute `__iter__`.
         for tg in job.task_groups:
             env = tg.task_spec.environment.variables
             role = env["TORCHX_ROLE_NAME"]
@@ -392,7 +388,6 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
         # TODO map role/replica status
         desc = DescribeAppResponse(
             app_id=app_id,
-            # pyre-fixme[16]: `Field` has no attribute `state`.
             state=JOB_STATE[job.status.state.name],
             roles=list(roles.values()),
         )

--- a/torchx/schedulers/test/gcp_batch_scheduler_test.py
+++ b/torchx/schedulers/test/gcp_batch_scheduler_test.py
@@ -85,9 +85,7 @@ class GCPBatchSchedulerTest(unittest.TestCase):
         env["TORCHX_ROLE_NAME"] = "trainer"
         env["FOO"] = "bar"
         res = batch_v1.ComputeResource()
-        # pyre-fixme[8]: Attribute has type `Field`; used as `int`.
         res.cpu_milli = 2000
-        # pyre-fixme[8]: Attribute has type `Field`; used as `int`.
         res.memory_mib = 3000
         allocationPolicy = batch_v1.AllocationPolicy(
             instances=[

--- a/torchx/test/fixtures.py
+++ b/torchx/test/fixtures.py
@@ -182,7 +182,6 @@ class DistributedTestCase(TestWithTmpDir):
 
         See class docstring for usage example.
         """
-        # pyre-fixme[28]: Unexpected keyword argument `log_dir`.
         config = LaunchConfig(
             min_nodes=1,
             max_nodes=1,


### PR DESCRIPTION
<!-- Change Summary -->

This undoes https://github.com/pytorch/torchx/pull/706 since we want Pyre to be in sync across environments. This should fix the broken OSS pyre build.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI