### PR TITLE
[ci-fix] Fix failing doc-build due to sagemaker scheduler from https:…

### DIFF
--- a/torchx/schedulers/aws_sagemaker_scheduler.py
+++ b/torchx/schedulers/aws_sagemaker_scheduler.py
@@ -167,7 +167,7 @@ class AWSSageMakerScheduler(DockerWorkspaceMixin, Scheduler[AWSSageMakerOpts]): 
     **Config Options**
 
     .. runopts::
-        class: torchx.schedulers.sagemaker_scheduler.create_scheduler
+        class: torchx.schedulers.aws_sagemaker_scheduler.create_scheduler
 
     **Compatibility**
 


### PR DESCRIPTION
Merging https://github.com/pytorch/torchx/pull/801 broke the CI doc-build. Should've checked the [HUD](https://hud.pytorch.org/hud/pytorch/torchx/main) more carefully before merging. 

~~NOTE: so haven't been able to validate a successful doc build yet. Going to see if this fixes the doc-build in CI while pip installs (slooooowly) torch on my new virtualenv.~~ edit - doc-build succeeds in CI

this PR should fix the failing docbuild, apologies again for not checking CI status prior to merging.