### PR TITLE
fix google batch logs

### DIFF
--- a/torchx/schedulers/gcp_batch_scheduler.py
+++ b/torchx/schedulers/gcp_batch_scheduler.py
@@ -412,8 +412,10 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
             raise ValueError(f"app not found: {app_id}")
 
         job_uid = job.uid
-        filters = [f"labels.job_uid={job_uid}"]
-        filters.append(f"resource.labels.task_id:task/{job_uid}-group0-{k}")
+        filters = [
+            f"labels.job_uid={job_uid}",
+            f"labels.task_id:{job_uid}-group0-{k}",
+        ]
 
         if since is not None:
             filters.append(f'timestamp>="{str(since.isoformat())}"')
@@ -434,7 +436,7 @@ class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
 
         logger = logging.Client().logger(BATCH_LOGGER_NAME)
         for entry in logger.list_entries(filter_=filter):
-            yield entry.payload
+            yield entry.payload + "\n"
 
     def _job_full_name_to_app_id(self, job_full_name: str) -> str:
         """

--- a/torchx/schedulers/test/gcp_batch_scheduler_test.py
+++ b/torchx/schedulers/test/gcp_batch_scheduler_test.py
@@ -245,7 +245,7 @@ class GCPBatchSchedulerTest(unittest.TestCase):
         filter = "labels.job_uid=j-82c8495f-8cc9-443c-9e33-4904fcb1test"
         lines = scheduler._batch_log_iter(filter=filter)
         for l in lines:
-            self.assertEqual(l, "log line")
+            self.assertEqual(l, "log line\n")
         mock_log_client.assert_called()
         mock_logging_client.logger.assert_called_once_with("batch_task_logs")
         mock_logger.list_entries.assert_called_once_with(filter_=filter)
@@ -433,7 +433,7 @@ class GCPBatchSchedulerTest(unittest.TestCase):
         )
         scheduler._batch_log_iter.assert_called_once_with(
             f'labels.job_uid=j-82c8495f-8cc9-443c-9e33-4904fcb1test \
-AND resource.labels.task_id:task/j-82c8495f-8cc9-443c-9e33-4904fcb1test-group0-1 \
+AND labels.task_id:j-82c8495f-8cc9-443c-9e33-4904fcb1test-group0-1 \
 AND timestamp>="{str(datetime.fromtimestamp(0).isoformat())}" \
 AND textPayload =~ "foo.*"'
         )
@@ -444,7 +444,7 @@ AND textPayload =~ "foo.*"'
         logs = scheduler.log_iter(app_id)
         scheduler._batch_log_iter.assert_called_once_with(
             f'labels.job_uid=j-82c8495f-8cc9-443c-9e33-4904fcb1test \
-AND resource.labels.task_id:task/j-82c8495f-8cc9-443c-9e33-4904fcb1test-group0-0 \
+AND labels.task_id:j-82c8495f-8cc9-443c-9e33-4904fcb1test-group0-0 \
 AND timestamp>="{str(datetime.fromtimestamp(0).isoformat())}"'
         )
         self.assertEqual(


### PR DESCRIPTION
<!-- Change Summary -->

This fixes the Google Batch integration test. 

The task_id key in the log filters changed so it wasn't returning any logs.

New format:

```js
{
insertId: "1qzr7ype7vibt"
labels: {
hostname: "dummyapp-q1q4tjgx0-751b88f7-0510-45220-group0-0-lhkl"
job_uid: "dummyapp-q1q4tjgx0-751b88f7-0510-45220"
task_group_name: "projects/508676514268/locations/us-central1/jobs/dummyapp-q1q4tjgx0qglnd/taskGroups/group0"
task_id: "dummyapp-q1q4tjgx0-751b88f7-0510-45220-group0-1"
}
logName: "projects/pytorch-ecosystem-gcp/logs/batch_task_logs"
receiveTimestamp: "2024-03-27T21:31:58.071402179Z"
resource: {
labels: {
job_id: "dummyapp-q1q4tjgx0-751b88f7-0510-45220"
location: "us-central1-c"
resource_container: "pytorch-ecosystem-gcp"
}
type: "batch.googleapis.com/Job"
}
severity: "INFO"
textPayload: "[0]:hi from main"
timestamp: "2024-03-27T21:31:56.974198477Z"
}
```

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
tristanr@devvm17560 ~/torchx (d4l3k/fix_batch)> torchx log gcp_batch://torchx/pytorch-ecosystem-gcp:us-central1:dummyapp-q1q4tjgx0qglnd                                                 (torchx3.10) 
dummy_app/1 [2024-03-27 21:31:15,281] torch.distributed.run: [WARNING] 
dummy_app/1 [2024-03-27 21:31:15,281] torch.distributed.run: [WARNING] *****************************************
dummy_app/1 [2024-03-27 21:31:15,281] torch.distributed.run: [WARNING] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
dummy_app/1 [2024-03-27 21:31:15,281] torch.distributed.run: [WARNING] *****************************************
dummy_app/1 [0]:hi from main
dummy_app/1 [1]:hi from main
dummy_app/0 [2024-03-27 21:31:50,575] torch.distributed.run: [WARNING] 
dummy_app/0 [2024-03-27 21:31:50,575] torch.distributed.run: [WARNING] *****************************************
dummy_app/0 [2024-03-27 21:31:50,575] torch.distributed.run: [WARNING] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
dummy_app/0 [2024-03-27 21:31:50,575] torch.distributed.run: [WARNING] *****************************************
dummy_app/0 [0]:hi from main
dummy_app/0 [1]:hi from main
```

CI