### PR TITLE
Support home directory sign (~) in BindMount path

### DIFF
--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -10,6 +10,7 @@ import argparse
 import inspect
 from argparse import Namespace
 from typing import Any, Callable, Dict, List, Mapping, Optional, Union
+import os
 
 from torchx.specs.api import BindMount, MountType, VolumeMount
 from torchx.specs.file_linter import get_fn_docstring, TorchXArgumentHelpFormatter
@@ -250,9 +251,12 @@ def parse_mounts(opts: List[str]) -> List[Union[BindMount, VolumeMount, DeviceMo
     for opts in mount_opts:
         typ = opts.get("type")
         if typ == MountType.BIND:
+            src_path = opts["src"]
+            if src_path.startswith('~'):
+                src_path = os.path.expanduser(src_path)
             mounts.append(
                 BindMount(
-                    src_path=opts["src"],
+                    src_path=src_path,
                     dst_path=opts["dst"],
                     read_only="readonly" in opts,
                 )

--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -8,9 +8,9 @@
 
 import argparse
 import inspect
+import os
 from argparse import Namespace
 from typing import Any, Callable, Dict, List, Mapping, Optional, Union
-import os
 
 from torchx.specs.api import BindMount, MountType, VolumeMount
 from torchx.specs.file_linter import get_fn_docstring, TorchXArgumentHelpFormatter
@@ -252,7 +252,7 @@ def parse_mounts(opts: List[str]) -> List[Union[BindMount, VolumeMount, DeviceMo
         typ = opts.get("type")
         if typ == MountType.BIND:
             src_path = opts["src"]
-            if src_path.startswith('~'):
+            if src_path.startswith("~"):
                 src_path = os.path.expanduser(src_path)
             mounts.append(
                 BindMount(

--- a/torchx/specs/test/builders_test.py
+++ b/torchx/specs/test/builders_test.py
@@ -10,9 +10,9 @@ import argparse
 import sys
 import unittest
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
-from pathlib import Path
 
 from torchx.specs.api import AppDef, Resource, Role
 from torchx.specs.builders import (

--- a/torchx/specs/test/builders_test.py
+++ b/torchx/specs/test/builders_test.py
@@ -12,6 +12,7 @@ import unittest
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
+from pathlib import Path
 
 from torchx.specs.api import AppDef, Resource, Role
 from torchx.specs.builders import (
@@ -522,6 +523,9 @@ class MountsTest(unittest.TestCase):
                     "src=foo",
                     "dst=bar",
                     "perm=rw",
+                    "type=bind",
+                    "src=~/foo",
+                    "dst=dst",
                 ]
             ),
             [
@@ -530,6 +534,7 @@ class MountsTest(unittest.TestCase):
                 VolumeMount(src="foo2", dst_path="dst2", read_only=True),
                 DeviceMount(src_path="duck", dst_path="duck", permissions="rwm"),
                 DeviceMount(src_path="foo", dst_path="bar", permissions="rw"),
+                BindMount(src_path=f"{str(Path.home())}/foo", dst_path="dst"),
             ],
         )
 


### PR DESCRIPTION
<!-- Change Summary -->
This PR is to support home directory sign (~) in BindMount path. 

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Unit tests
```
pytest torchx/specs/test/builders_test.py
```

Manually tested with local_docker and the config like below:
```
[component:dist.ddp]
mounts=type=bind,src=~/.config/gcloud/application_default_credentials.json,dst=/creds.json
```
``torchx run`` would fail before the change and work after.
