### PR TITLE
Fixed Multiple Args Testing Issue

### DIFF
--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -61,7 +61,7 @@ class CmdRunTest(unittest.TestCase):
 
         args = [
             "--scheduler",
-            "local_conda",
+            "local_cwd",
             "--scheduler",
             "local_cwd",
         ]

--- a/torchx/cli/test/main_test.py
+++ b/torchx/cli/test/main_test.py
@@ -13,6 +13,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from torchx.cli.argparse_util import ArgOnceAction, torchxconfig
+
 from torchx.cli.cmd_base import SubCommand
 from torchx.cli.main import get_sub_cmds, main
 
@@ -37,6 +39,8 @@ class CLITest(unittest.TestCase):
 
     def tearDown(self) -> None:
         os.chdir(self.old_cwd)
+        ArgOnceAction.called_args = set()
+        torchxconfig.called_args = set()
 
     def test_run_abs_config_path(self) -> None:
         main(


### PR DESCRIPTION
Summary: The purpose of the test was to check removal of multiple args. It passed internally using a facebook option but failed externally because the option didn't exist.

Differential Revision: D55525717


