### PR TITLE
remove log_dir from LaunchConfig

### DIFF
--- a/torchx/test/fixtures.py
+++ b/torchx/test/fixtures.py
@@ -190,8 +190,6 @@ class DistributedTestCase(TestWithTmpDir):
             rdzv_endpoint="localhost:0",
             max_restarts=0,
             monitor_interval=0.01,
-            log_dir=str(self.tmpdir),
-            tee=Std.ALL,
         )
 
         return elastic_launch(config, entrypoint=fn)


### PR DESCRIPTION
Summary:
D55562170 was trying to add a pyre-fixme.
This diff removes the log_dir from arguments.

Differential Revision: D55592319


