### PR TITLE
Fix torchx nightly regression

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,6 +19,7 @@ moto==4.2.14
 pyre-extensions
 pyre-check
 pytest
+pytest-cov
 pytorch-lightning==1.5.10
 sagemaker>=2.149.0
 torch-model-archiver>=0.4.2


### PR DESCRIPTION
Summary: Nightly regression failing due to missing python library.

Differential Revision: D55780355


