### PR TITLE
Adding health check settings to Role spec

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -280,6 +280,27 @@ class DeviceMount:
 
 
 @dataclass
+class HealthCheck:
+    """
+    Defines health check settings for a node
+    Args:
+        port: port number for health check
+        regex: regex for health check success
+        timeout_secs: timeout for health check
+        interval_secs: interval between health checks
+        fail_secs: time to fail after health check failure
+        startup_grace_secs: startup grace period
+    """
+
+    port: int
+    regex: str
+    timeout_secs: int = 60
+    interval_secs: int = 15
+    fail_secs: int = 90
+    startup_grace_secs: int = 60
+
+
+@dataclass
 class Role:
     """
     A set of nodes that perform a specific duty within the ``AppDef``.
@@ -331,6 +352,7 @@ class Role:
             metadata: Free form information that is associated with the role, for example
                 scheduler specific data. The key should follow the pattern: ``$scheduler.$key``
             mounts: a list of mounts on the machine
+            health_check: health check settings
     """
 
     name: str
@@ -349,6 +371,7 @@ class Role:
     mounts: List[Union[BindMount, VolumeMount, DeviceMount]] = field(
         default_factory=list
     )
+    health_check: Optional[HealthCheck] = None
 
     def pre_proc(
         self,

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -25,6 +25,7 @@ from torchx.specs.api import (
     AppStatusError,
     CfgVal,
     get_type_name,
+    HealthCheck,
     InvalidRunConfigException,
     macros,
     MalformedAppHandleException,
@@ -311,6 +312,33 @@ class AppDefTest(unittest.TestCase):
         app = AppDef(name="test_app", metadata={"test_key": "test_value"})
         self.assertEqual("test_value", app.metadata["test_key"])
         self.assertEqual(None, app.metadata.get("non_existent"))
+
+
+class HealthCheckTest(unittest.TestCase):
+    def test_healthcheck(self) -> None:
+        health_check = HealthCheck(port=1010, regex="1", timeout_secs=20)
+        trainer = Role(
+            "trainer",
+            "test_image",
+            entrypoint="/bin/sleep",
+            args=["10"],
+            num_replicas=2,
+            health_check=health_check,
+        )
+        app = AppDef(name="test_app", roles=[trainer])
+        self.assertIsNotNone(app.roles[0].health_check)
+        self.assertEqual(health_check, app.roles[0].health_check)
+
+    def test_healthcheck_default(self) -> None:
+        trainer = Role(
+            "trainer",
+            "test_image",
+            entrypoint="/bin/sleep",
+            args=["10"],
+            num_replicas=2,
+        )
+        app = AppDef(name="test_app", roles=[trainer])
+        self.assertIsNone(app.roles[0].health_check)
 
 
 class RunConfigTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
Spec for health check settings for a Role, which can be used for enabling health check of the node.

Health check settings:
```
port: port number for health check
regex: regex for health check success
timeout_secs: timeout for health check
interval_secs: interval between health checks
fail_secs: time to fail after health check failure
startup_grace_secs: startup grace period
```

Health check settings can be used by different schedulers to enable corresponding health check mechanism. By default health check is disabled.

Differential Revision: D55876399


