### PR TITLE
feat: add verbose flag to docker mixin

### DIFF
--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -700,6 +700,7 @@ spec:
         self.assertEqual(
             set(runopts._opts.keys()),
             {
+                "quiet",
                 "queue",
                 "namespace",
                 "image_repo",


### PR DESCRIPTION
It's hard to debug Docker image building issues, e.g. why it was triggered, where exactly it's rebuilding, which layer is taking too long to build, etc.

Luckily Docker client already provides the stream of events (e.g. stdout, stderr) in a form of a stream of JSON objects.

Adding a new `runopts` for Docker workspace mixin called `verbose` (`False` by default) that when set logs these events via `info`:

`torchx run -s local_docker --scheduler_args verbose=true ...`

```
torchx 2024-04-08 17:24:44 INFO     Building workspace docker image (this may take a while)...
torchx 2024-04-08 17:24:44 INFO     {'stream': 'Step 1/6 : ARG IMAGE'}
torchx 2024-04-08 17:24:44 INFO     {'stream': '\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': 'Step 2/6 : ARG WORKSPACE'}
torchx 2024-04-08 17:24:44 INFO     {'stream': '\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': 'Step 3/6 : FROM $IMAGE'}
torchx 2024-04-08 17:24:44 INFO     {'stream': '\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': ' ---> 5621c45253de\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': 'Step 4/6 : WORKDIR /workspace/'}
torchx 2024-04-08 17:24:44 INFO     {'stream': '\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': ' ---> Using cache\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': ' ---> e3cfe1e2c953\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': 'Step 5/6 : COPY . .'}
torchx 2024-04-08 17:24:44 INFO     {'stream': '\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': ' ---> Using cache\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': ' ---> d543a05148aa\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': 'Step 6/6 : LABEL torchx.pytorch.org/version=0.7.0dev0'}
torchx 2024-04-08 17:24:44 INFO     {'stream': '\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': ' ---> Using cache\n'}
torchx 2024-04-08 17:24:44 INFO     {'stream': ' ---> 5feac9877804\n'}
torchx 2024-04-08 17:24:44 INFO     {'aux': {'ID': 'sha256:5feac987780469c34d2e9a37ca54cde8579cc11ba73a5794f769bd2b4b23e28e'}}
torchx 2024-04-08 17:24:44 INFO     {'stream': 'Successfully built 5feac9877804\n'}
```

Test plan:
See the above

Closes https://github.com/pytorch/torchx/issues/813
