### PR TITLE
Fix too long locker_docker scheduler hostname

### DIFF
--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -224,7 +224,8 @@ class DockerScheduler(DockerWorkspaceMixin, Scheduler[DockerOpts]):
 
         app_id = make_unique(app.name)
         req = DockerJob(app_id=app_id, containers=[])
-        rank0_name = f"{app_id}-{app.roles[0].name}-0"
+        # trim app_id and role name in case name is longer than 64 letters
+        rank0_name = f"{app_id[-30:]}-{app.roles[0].name[:30]}-0"
         for role in app.roles:
             mounts = []
             devices = []
@@ -263,7 +264,8 @@ class DockerScheduler(DockerWorkspaceMixin, Scheduler[DockerOpts]):
                     rank0_env="TORCHX_RANK0_HOST",
                 )
                 replica_role = values.apply(role)
-                name = f"{app_id}-{role.name}-{replica_id}"
+                # trim app_id and role name in case name is longer than 64 letters. Assume replica_id is less than 10_000.
+                name = f"{app_id[-30:]}-{role.name[:30]}-{replica_id}"
 
                 env = default_env.copy()
                 if replica_role.env:

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -200,6 +200,19 @@ class DockerSchedulerTest(unittest.TestCase):
             },
         )
 
+    def test_long_hostname(self) -> None:
+        app = _test_app()
+        for role in app.roles:
+            role.name = "ethology_explore_magic_calliope_divisive_whirl_dealt_lotus_oncology_facet_deerskin_blum_elective_spill_trammel_trainer"
+        with patch("torchx.schedulers.docker_scheduler.make_unique") as make_unique_ctx:
+            make_unique_ctx.return_value = "ethology_explore_magic_calliope_divisive_whirl_dealt_lotus_oncology_facet_deerskin_blum_elective_spill_trammel_12345"
+            info = self.scheduler._submit_dryrun(app, DockerOpts())
+        for container in info.request.containers:
+            assert "name" in container.kwargs
+            name = container.kwargs["name"]
+            assert isinstance(name, str)
+            assert len(name) < 65
+
 
 if has_docker():
     # These are the live tests that require a local docker instance.


### PR DESCRIPTION
<!-- Change Summary -->
To fix this issue: https://github.com/pytorch/torchx/issues/823

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
```
pytest torchx/schedulers/test/docker_scheduler_test.py
```