### PR TITLE
no fail on codecov errors

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -43,7 +43,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
-          fail_ci_if_error: true
           files: ./coverage.xml,!./cache
           flags: unittests
           verbose: true


### PR DESCRIPTION
<!-- Change Summary -->

Fixes issues like: https://github.com/pytorch/torchx/actions/runs/8647196759/job/23719835670?pr=874

This seems to be a recent codecov regression for forks https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954

We could expose the token but... it's not a huge deal if we don't have coverage on forks.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

CI