### PR TITLE
Remove TORCHX_COMPONENT_ARGS env var from role

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -324,6 +324,10 @@ class Runner:
 
         configured_trackers = get_configured_trackers()
 
+        app_handle = make_app_handle(scheduler, self._name, macros.app_id)
+
+        os.environ[ENV_TORCHX_JOB_ID] = app_handle
+
         for role in app.roles:
             if not role.entrypoint:
                 raise ValueError(
@@ -342,9 +346,7 @@ class Runner:
             #    - inject it as TORCHX_TRACKERS=names (it is expected that entrypoints are defined)
             #    - for each backend check configuration file, if exists:
             #        - inject it as TORCHX_TRACKER_<name>_CONFIGFILE=filename
-            role.env[ENV_TORCHX_JOB_ID] = make_app_handle(
-                scheduler, self._name, macros.app_id
-            )
+            role.env[ENV_TORCHX_JOB_ID] = app_handle
 
             if parent_run_id:
                 role.env[ENV_TORCHX_PARENT_RUN_ID] = parent_run_id

--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -18,8 +18,6 @@ from torchx.util.types import decode, decode_optional, get_argparse_param_type, 
 
 from .api import AppDef, DeviceMount
 
-ENV_TORCHX_COMPONENT_ARGS = "TORCHX_COMPONENT_ARGS"
-
 
 def _create_args_parser(
     cmpnt_fn: Callable[..., AppDef],
@@ -136,7 +134,6 @@ def materialize_appdef(
     cmpnt_args: List[str],
     cmpnt_defaults: Optional[Dict[str, Any]] = None,
     config: Optional[Dict[str, Any]] = None,
-    component_args_string: Optional[str] = None,
 ) -> AppDef:
     """
     Creates an application by running user defined ``app_fn``.
@@ -190,10 +187,6 @@ def materialize_appdef(
         var_arg = var_arg[1:]
 
     appdef = cmpnt_fn(*function_args, *var_arg, **kwargs)
-
-    if component_args_string:
-        for role in appdef.roles:
-            role.env[ENV_TORCHX_COMPONENT_ARGS] = component_args_string
 
     return appdef
 

--- a/torchx/tracker/api.py
+++ b/torchx/tracker/api.py
@@ -22,7 +22,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 ENV_TORCHX_TRACKERS = "TORCHX_TRACKERS"
 ENV_TORCHX_PARENT_RUN_ID = "TORCHX_PARENT_RUN_ID"
-ENV_TORCHX_JOB_ID = "TORCHX_JOB_ID"
+ENV_TORCHX_JOB_ID = "TTFB_TORCHX_JOB_ID"
 
 
 @dataclass


### PR DESCRIPTION
Summary: remove torchx component args env var to avoid taking too much storage/ hitting limits for env var size

Differential Revision: D56033363


