### PR TITLE
Fix for issue with multiple -- in command line

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -86,7 +86,11 @@ def _parse_component_name_and_args(
             component_args = args[1:]
 
     # Error if there are repeated command line arguments
-    all_options = [x for x in component_args if x.startswith("-")]
+    all_options = [
+        x
+        for x in component_args
+        if x.startswith("-") and x.strip() != "-" and x.strip() != "--"
+    ]
     arg_count = Counter(all_options)
     duplicates = [arg for arg, count in arg_count.items() if count > 1]
     if len(duplicates) > 0:

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -230,6 +230,27 @@ class CmdRunTest(unittest.TestCase):
             _parse_component_name_and_args(["utils.echo", "--msg", "hello"], sp),
         )
 
+        self.assertEqual(
+            ("utils.echo", ["--msg", "hello", "--", "--"]),
+            _parse_component_name_and_args(
+                ["utils.echo", "--msg", "hello", "--", "--"], sp
+            ),
+        )
+
+        self.assertEqual(
+            ("utils.echo", ["--msg", "hello", "-", "-"]),
+            _parse_component_name_and_args(
+                ["utils.echo", "--msg", "hello", "-", "-"], sp
+            ),
+        )
+
+        self.assertEqual(
+            ("utils.echo", ["--msg", "hello", "-  ", "-  "]),
+            _parse_component_name_and_args(
+                ["utils.echo", "--msg", "hello", "-  ", "-  "], sp
+            ),
+        )
+
         with self.assertRaises(SystemExit):
             _parse_component_name_and_args(["--"], sp)
 
@@ -244,6 +265,11 @@ class CmdRunTest(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             _parse_component_name_and_args(["--msg", "hello", "--msg", "repeate"], sp)
+
+        with self.assertRaises(SystemExit):
+            _parse_component_name_and_args(
+                ["--msg  ", "hello", "--msg     ", "repeate"], sp
+            )
 
     def test_parse_component_name_and_args_with_default(self) -> None:
         sp = argparse.ArgumentParser(prog="test")


### PR DESCRIPTION
Summary: Repeated args in the command line were removed to avoid errors but a condition with repeated -- caused a breakage

Differential Revision: D56317273


