### PR TITLE
Fix issue with torchx status failing when return error is string instead of json

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -13,6 +13,7 @@ import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
+from json import JSONDecodeError
 from string import Template
 from typing import (
     Any,
@@ -554,7 +555,10 @@ class AppStatus:
 
     def _format_replica_status(self, replica_status: ReplicaStatus) -> str:
         if replica_status.structured_error_msg != NONE:
-            error_data = json.loads(replica_status.structured_error_msg)
+            try:
+                error_data = json.loads(replica_status.structured_error_msg)
+            except JSONDecodeError:
+                return replica_status.structured_error_msg
             error_message = self._format_error_message(
                 msg=error_data["message"]["message"], header="    error_msg: "
             )


### PR DESCRIPTION
Summary: torchx status assumes the return value is json but there are cases where the  return value is a string. This returns the raw data if the data isn't json

Differential Revision: D56338530


