### PR TITLE
add workspace to TorchXEvent for logging

### DIFF
--- a/torchx/runner/events/__init__.py
+++ b/torchx/runner/events/__init__.py
@@ -85,9 +85,15 @@ class log_event:
         app_id: Optional[str] = None,
         app_image: Optional[str] = None,
         runcfg: Optional[str] = None,
+        workspace: Optional[str] = None,
     ) -> None:
         self._torchx_event: TorchxEvent = self._generate_torchx_event(
-            api, scheduler or "", app_id, app_image=app_image, runcfg=runcfg
+            api,
+            scheduler or "",
+            app_id,
+            app_image=app_image,
+            runcfg=runcfg,
+            workspace=workspace,
         )
         self._start_cpu_time_ns = 0
         self._start_wall_time_ns = 0
@@ -124,6 +130,7 @@ class log_event:
         app_image: Optional[str] = None,
         runcfg: Optional[str] = None,
         source: SourceType = SourceType.UNKNOWN,
+        workspace: Optional[str] = None,
     ) -> TorchxEvent:
         return TorchxEvent(
             session=app_id or "",
@@ -133,4 +140,5 @@ class log_event:
             app_image=app_image,
             runcfg=runcfg,
             source=source,
+            workspace=workspace,
         )

--- a/torchx/runner/events/api.py
+++ b/torchx/runner/events/api.py
@@ -47,6 +47,7 @@ class TorchxEvent:
     cpu_time_usec: Optional[int] = None
     wall_time_usec: Optional[int] = None
     start_epoch_time_usec: Optional[int] = None
+    workspace: Optional[str] = None
 
     def __str__(self) -> str:
         return self.serialize()

--- a/torchx/runner/events/test/lib_test.py
+++ b/torchx/runner/events/test/lib_test.py
@@ -46,12 +46,14 @@ class TorchxEventLibTest(unittest.TestCase):
             scheduler="test_scheduler",
             api="test_api",
             app_image="test_app_image",
+            workspace="test_workspace",
         )
         self.assertEqual("test_session", event.session)
         self.assertEqual("test_scheduler", event.scheduler)
         self.assertEqual("test_api", event.api)
         self.assertEqual("test_app_image", event.app_image)
         self.assertEqual(SourceType.UNKNOWN, event.source)
+        self.assertEqual("test_workspace", event.workspace)
 
     def test_event_deser(self) -> None:
         event = TorchxEvent(
@@ -59,6 +61,7 @@ class TorchxEventLibTest(unittest.TestCase):
             scheduler="test_scheduler",
             api="test_api",
             app_image="test_app_image",
+            workspace="test_workspace",
             source=SourceType.EXTERNAL,
         )
         json_event = event.serialize()
@@ -74,6 +77,7 @@ class LogEventTest(unittest.TestCase):
         self.assertEqual(expected.api, actual.api)
         self.assertEqual(expected.app_image, actual.app_image)
         self.assertEqual(expected.source, actual.source)
+        self.assertEqual(expected.workspace, actual.workspace)
 
     def test_create_context(self, _) -> None:
         cfg = json.dumps({"test_key": "test_value"})
@@ -83,6 +87,7 @@ class LogEventTest(unittest.TestCase):
             "test_app_id",
             app_image="test_app_image_id",
             runcfg=cfg,
+            workspace="test_workspace",
         )
         expected_torchx_event = TorchxEvent(
             "test_app_id",
@@ -91,7 +96,9 @@ class LogEventTest(unittest.TestCase):
             "test_app_id",
             app_image="test_app_image_id",
             runcfg=cfg,
+            workspace="test_workspace",
         )
+
         self.assert_torchx_event(expected_torchx_event, context._torchx_event)
 
     def test_record_event(self, record_mock: MagicMock) -> None:
@@ -102,6 +109,7 @@ class LogEventTest(unittest.TestCase):
             "test_app_id",
             app_image="test_app_image_id",
             runcfg=cfg,
+            workspace="test_workspace",
         ) as ctx:
             pass
 
@@ -112,6 +120,7 @@ class LogEventTest(unittest.TestCase):
             "test_app_id",
             app_image="test_app_image_id",
             runcfg=cfg,
+            workspace="test_workspace",
             cpu_time_usec=ctx._torchx_event.cpu_time_usec,
             wall_time_usec=ctx._torchx_event.wall_time_usec,
         )


### PR DESCRIPTION
Summary:
add the workspace to the TorchXEvent type, so eventually it can be stored to the tsm logger.

this will let us track how different workspaces/ no workspace affects build and scheduler

Differential Revision: D56324618


