### PR TITLE
Create minicube integration test

### DIFF
--- a/.github/workflows/kubernetes-minicube-integration-test.yaml
+++ b/.github/workflows/kubernetes-minicube-integration-test.yaml
@@ -1,0 +1,35 @@
+name: Kubernetes Minicube Integration Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  kubernetes-launch:
+    runs-on: "linux.20_04.16x"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          architecture: x64
+      - name: Checkout TorchX
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          set -eux
+          pip install -e .[kubernetes]
+      - name: Start Kubernetes
+        run: |
+          scripts/setup_minikube.sh
+      - name: Run Kubernetes Integration Tests
+        env:
+          INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
+          CONTAINER_REPO: localhost:5000/torchx
+        run: |
+          scripts/kube_dist_trainer.py


### PR DESCRIPTION
Context:
We are going to migrate the Kubernetes Dist Train Integration Test to minicube.
The benefits are: 1. We will no longer need AWS resources in order to run the test. This saves us AWS expense. 2. Because the test will be running on github host instead of AWS hosts, it is much easier to set up config, debug and maintain the test. AWS knowledge is not needed.

Test plan:

The test pass.
