### PR TITLE
Revert "Update api.py (#899)"

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -187,7 +187,6 @@ class Runner:
                 parent_run_id=parent_run_id,
             )
             handle = self.schedule(dryrun_info)
-            ctx._torchx_event.workspace = workspace
             ctx._torchx_event.scheduler = none_throws(dryrun_info._scheduler)
             ctx._torchx_event.app_image = none_throws(dryrun_info._app).roles[0].image
             ctx._torchx_event.app_id = parse_app_handle(handle)[2]


### PR DESCRIPTION
This reverts commit eb7e3d87b10842f2f257b623f5a7ee084630f9f8.

Reverts https://github.com/pytorch/torchx/pull/899 which breaks python unittests (see HUD: https://hud.pytorch.org/hud/pytorch/torchx/main)

Test plan:

CI
