### PR TITLE
create minicube integration test

### DIFF
--- a/.github/workflows/kubernetes-minicube-integration-test.yaml
+++ b/.github/workflows/kubernetes-minicube-integration-test.yaml
@@ -1,0 +1,35 @@
+name: Kubernetes Minicube Integration Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  kubernetes-launch:
+    runs-on: "linux.20_04.16x"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          architecture: x64
+      - name: Checkout TorchX
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          set -eux
+          pip install -e .[kubernetes]
+      - name: Start Kubernetes
+        run: |
+          scripts/setup_minikube.sh
+      - name: Run Kubernetes Integration Tests
+        env:
+          INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
+          CONTAINER_REPO: localhost:5000/torchx
+        run: |
+          scripts/minicube_trainer.py

--- a/.github/workflows/kubernetes-minicube-integration-test.yaml
+++ b/.github/workflows/kubernetes-minicube-integration-test.yaml
@@ -29,7 +29,6 @@ jobs:
           scripts/setup_minikube.sh
       - name: Run Kubernetes Integration Tests
         env:
-          INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
           CONTAINER_REPO: localhost:5000/torchx
         run: |
           chmod +x scripts/minicube_trainer.py

--- a/.github/workflows/kubernetes-minicube-integration-test.yaml
+++ b/.github/workflows/kubernetes-minicube-integration-test.yaml
@@ -32,4 +32,5 @@ jobs:
           INTEGRATION_TEST_STORAGE: ${{ secrets.INTEGRATION_TEST_STORAGE }}
           CONTAINER_REPO: localhost:5000/torchx
         run: |
+          chmod +x scripts/minicube_trainer.py
           scripts/minicube_trainer.py

--- a/.github/workflows/kubernetes-minicube-integration-test.yaml
+++ b/.github/workflows/kubernetes-minicube-integration-test.yaml
@@ -1,4 +1,4 @@
-name: Kubernetes Minicube Integration Test
+name: Kubernetes Minikube Integration Test
 
 on:
   push:
@@ -31,5 +31,5 @@ jobs:
         env:
           CONTAINER_REPO: localhost:5000/torchx
         run: |
-          chmod +x scripts/minicube_trainer.py
-          scripts/minicube_trainer.py
+          chmod +x scripts/minikube_trainer.py
+          scripts/minikube_trainer.py

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -65,8 +65,6 @@ def run_job() -> None:
     storage_path = os.getenv("INTEGRATION_TEST_STORAGE", "/tmp/storage")
     root = os.path.join(storage_path, build.id)
     output_path = os.path.join(root, "output")
-
-
     args = ("--output_path", output_path)
     train_app = dist_ddp(
         *("--output_path", output_path),
@@ -84,8 +82,6 @@ def run_job() -> None:
     dryrun_info2 = runner.dryrun(train_app, "kubernetes", cfg=cfg)
     warnings.warn(f"\nAppDef:\n{dumps(asdict(train_app), indent=4)}")
     warnings.warn(f"\nScheduler Request:\n{dryrun_info2}")
-
-
     app_handle = runner.run(train_app, "kubernetes", cfg)
     print(app_handle)
     warnings.warn("AAAA6")

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -14,6 +14,7 @@ Kubernetes integration tests.
 import argparse
 import logging
 import os
+import warnings
 
 from dataclasses import asdict
 from json import dumps
@@ -57,6 +58,7 @@ def build_and_push_image() -> BuildInfo:
 
 
 def run_job(dryrun: bool = False) -> None:
+    warnings.warn("AAAA6")
     log.info(f"\nAAAA")
     register_gpu_resource()
     build = build_and_push_image()

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -81,9 +81,7 @@ def run_job() -> None:
         "queue": "default",
     }
     print("Submitting pods")
-    dryrun_info2 = runner.dryrun(
-        train_app, "kubernetes", cfg=cfg
-    )
+    dryrun_info2 = runner.dryrun(train_app, "kubernetes", cfg=cfg)
     warnings.warn(f"\nAppDef:\n{dumps(asdict(train_app), indent=4)}")
     warnings.warn(f"\nScheduler Request:\n{dryrun_info2}")
 

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -57,14 +57,18 @@ def build_and_push_image() -> BuildInfo:
 
 
 def run_job(dryrun: bool = False) -> None:
+    log.info(f"\nAAAA")
     register_gpu_resource()
     build = build_and_push_image()
+    log.info(f"\nAAAA2")
     image = build.torchx_image
     runner = get_runner("kubeflow-dist-runner")
 
     storage_path = os.getenv("INTEGRATION_TEST_STORAGE", "/tmp/storage")
     root = os.path.join(storage_path, build.id)
     output_path = os.path.join(root, "output")
+
+    log.info(f"\nAAAA3")
 
     args = ("--output_path", output_path)
     train_app = dist_ddp(
@@ -74,6 +78,7 @@ def run_job(dryrun: bool = False) -> None:
         h="GPU_X1",
         j="2x1",
     )
+    log.info(f"\nAAAA4")
     print(f"Starting Trainer with args: {args}")
     cfg = {
         "namespace": "default",

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Kubernetes integration tests.
+"""
+
+import argparse
+import os
+
+from integ_test_utils import (
+    build_images,
+    BuildInfo,
+    getenv_asserts,
+    MissingEnvError,
+    push_images,
+)
+from torchx.components.dist import ddp as dist_ddp
+from torchx.runner import get_runner
+from torchx.specs import _named_resource_factories, AppState, Resource
+from torchx.util.types import none_throws
+
+
+GiB: int = 1024
+
+
+# TODO(aivanou): remove this when partial resources are introduced.
+def register_gpu_resource() -> None:
+    res = Resource(
+        cpu=2,
+        gpu=1,
+        memMB=8 * GiB,
+        capabilities={
+            "node.kubernetes.io/instance-type": "p3.2xlarge",
+        },
+    )
+    print(f"Registering resource: {res}")
+    _named_resource_factories["GPU_X1"] = lambda: res
+
+
+def build_and_push_image() -> BuildInfo:
+    build = build_images()
+    push_images(build, container_repo=getenv_asserts("CONTAINER_REPO"))
+    return build
+
+
+def run_job(dryrun: bool = False) -> None:
+    register_gpu_resource()
+    build = build_and_push_image()
+    image = build.torchx_image
+    runner = get_runner("kubeflow-dist-runner")
+
+    storage_path = os.getenv("INTEGRATION_TEST_STORAGE", "/tmp/storage")
+    root = os.path.join(storage_path, build.id)
+    output_path = os.path.join(root, "output")
+
+    args = ("--output_path", output_path)
+    train_app = dist_ddp(
+        *("--output_path", output_path),
+        image=image,
+        m="torchx.examples.apps.lightning.train",
+        h="GPU_X1",
+        j="2x1",
+    )
+    print(f"Starting Trainer with args: {args}")
+    cfg = {
+        "namespace": "default",
+        "queue": "default",
+    }
+    print("Submitting pods")
+    if dryrun:
+        dryrun_info = runner.dryrun(train_app, "kubernetes", cfg)
+        print(f"Dryrun info: {dryrun_info}")
+    else:
+        dryrun_info2 = runner.dryrun(
+            train_app, "kubernetes", cfg=cfg
+        )
+        log.info(f"\nAppDef:\n{dumps(asdict(train_app), indent=4)}")
+        log.info(f"\nScheduler Request:\n{dryrun_info2}")
+
+
+        app_handle = runner.run(train_app, "kubernetes", cfg)
+        print(app_handle)
+        runner.wait(app_handle)
+        final_status = runner.status(app_handle)
+        print(f"Final status: {final_status}")
+        if none_throws(final_status).state != AppState.SUCCEEDED:
+            raise Exception(f"Dist app failed with status: {final_status}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="kubernetes dist trainer integration test runner"
+    )
+    parser.add_argument(
+        "--dryrun",
+        action="store_true",
+        help="Does not actually submit the app," " just prints the scheduler request",
+    )
+    args = parser.parse_args()
+
+    try:
+        run_job(args.dryrun)
+    except MissingEnvError:
+        print("Skip runnig tests, executed only docker buid step")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -12,7 +12,11 @@ Kubernetes integration tests.
 """
 
 import argparse
+import logging
 import os
+
+from dataclasses import asdict
+from json import dumps
 
 from integ_test_utils import (
     build_images,
@@ -25,6 +29,8 @@ from torchx.components.dist import ddp as dist_ddp
 from torchx.runner import get_runner
 from torchx.specs import _named_resource_factories, AppState, Resource
 from torchx.util.types import none_throws
+
+log: logging.Logger = logging.getLogger(__name__)
 
 
 GiB: int = 1024

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -58,19 +58,18 @@ def build_and_push_image() -> BuildInfo:
 
 
 def run_job(dryrun: bool = False) -> None:
-    warnings.warn("AAAA6")
-    log.info(f"\nAAAA")
+    warnings.warn("AAAA0")
     register_gpu_resource()
     build = build_and_push_image()
-    log.info(f"\nAAAA2")
+    warnings.warn("AAAA1")
     image = build.torchx_image
     runner = get_runner("kubeflow-dist-runner")
-
+    warnings.warn("AAAA2")
     storage_path = os.getenv("INTEGRATION_TEST_STORAGE", "/tmp/storage")
     root = os.path.join(storage_path, build.id)
     output_path = os.path.join(root, "output")
+    warnings.warn("AAAA3")
 
-    log.info(f"\nAAAA3")
 
     args = ("--output_path", output_path)
     train_app = dist_ddp(
@@ -80,13 +79,13 @@ def run_job(dryrun: bool = False) -> None:
         h="GPU_X1",
         j="2x1",
     )
-    log.info(f"\nAAAA4")
     print(f"Starting Trainer with args: {args}")
     cfg = {
         "namespace": "default",
         "queue": "default",
     }
     print("Submitting pods")
+    warnings.warn("AAAA4")
     if dryrun:
         dryrun_info = runner.dryrun(train_app, "kubernetes", cfg)
         print(f"Dryrun info: {dryrun_info}")
@@ -94,8 +93,9 @@ def run_job(dryrun: bool = False) -> None:
         dryrun_info2 = runner.dryrun(
             train_app, "kubernetes", cfg=cfg
         )
-        log.info(f"\nAppDef:\n{dumps(asdict(train_app), indent=4)}")
-        log.info(f"\nScheduler Request:\n{dryrun_info2}")
+        warnings.warn("AAAA5")
+        warnings.warn(f"\nAppDef:\n{dumps(asdict(train_app), indent=4)}")
+        warnings.warn(f"\nScheduler Request:\n{dryrun_info2}")
 
 
         app_handle = runner.run(train_app, "kubernetes", cfg)

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -9,6 +9,8 @@
 
 """
 Kubernetes integration tests.
+git commit -m "mini_v9"
+git push origin minicube2
 """
 
 import argparse
@@ -67,24 +69,28 @@ def run_job() -> None:
     output_path = os.path.join(root, "output")
     args = ("--output_path", output_path)
     train_app = dist_ddp(
-        *("--output_path", output_path),
-        image=image,
-        m="torchx.examples.apps.lightning.train",
-        h="GPU_X1",
-        j="2x1",
+       m="torchx.examples.apps.compute_world_size.main",
+            name="ddp-trainer",
+            image=image,
+            cpu=1,
+            j="2x2",
+            max_retries=3,
+            env={
+                "LOGLEVEL": "INFO",
+            },
     )
-    print(f"Starting Trainer with args: {args}")
     cfg = {
-        "namespace": "default",
+        # "namespace": "default",
+        "namespace": "torchx-dev",
         "queue": "default",
     }
-    print("Submitting pods")
+
     dryrun_info2 = runner.dryrun(train_app, "kubernetes", cfg=cfg)
     warnings.warn(f"\nAppDef:\n{dumps(asdict(train_app), indent=4)}")
     warnings.warn(f"\nScheduler Request:\n{dryrun_info2}")
     app_handle = runner.run(train_app, "kubernetes", cfg)
-    print(app_handle)
-    warnings.warn("AAAA6")
+
+
     runner.wait(app_handle)
     final_status = runner.status(app_handle)
     print(f"Final status: {final_status}")

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -12,6 +12,7 @@ Kubernetes integration tests.
 """
 
 import logging
+
 from integ_test_utils import (
     build_images,
     BuildInfo,
@@ -27,6 +28,7 @@ from torchx.util.types import none_throws
 log: logging.Logger = logging.getLogger(__name__)
 
 GiB: int = 1024
+
 
 def register_gpu_resource() -> None:
     res = Resource(

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -54,22 +54,16 @@ def run_job() -> None:
     build = build_and_push_image()
     image = build.torchx_image
     runner = get_runner()
-    # train_app = dist_ddp(
-    #     m="torchx.examples.apps.compute_world_size.main",
-    #     name="ddp-trainer",
-    #     image=image,
-    #     cpu=1,
-    #     j="2x2",
-    #     max_retries=3,
-    #     env={
-    #         "LOGLEVEL": "INFO",
-    #     },
-    # )
     train_app = dist_ddp(
+        m="torchx.examples.apps.compute_world_size.main",
+        name="ddp-trainer",
         image=image,
-        m="torchx.examples.apps.lightning.train",
-        h="GPU_X1",
-        j="2x1",
+        cpu=1,
+        j="2x2",
+        max_retries=3,
+        env={
+            "LOGLEVEL": "INFO",
+        },
     )
     cfg = {
         "namespace": "torchx-dev",

--- a/scripts/minicube_trainer.py
+++ b/scripts/minicube_trainer.py
@@ -54,16 +54,22 @@ def run_job() -> None:
     build = build_and_push_image()
     image = build.torchx_image
     runner = get_runner()
+    # train_app = dist_ddp(
+    #     m="torchx.examples.apps.compute_world_size.main",
+    #     name="ddp-trainer",
+    #     image=image,
+    #     cpu=1,
+    #     j="2x2",
+    #     max_retries=3,
+    #     env={
+    #         "LOGLEVEL": "INFO",
+    #     },
+    # )
     train_app = dist_ddp(
-        m="torchx.examples.apps.compute_world_size.main",
-        name="ddp-trainer",
         image=image,
-        cpu=1,
-        j="2x2",
-        max_retries=3,
-        env={
-            "LOGLEVEL": "INFO",
-        },
+        m="torchx.examples.apps.lightning.train",
+        h="GPU_X1",
+        j="2x1",
     )
     cfg = {
         "namespace": "torchx-dev",

--- a/scripts/minikube_trainer.py
+++ b/scripts/minikube_trainer.py
@@ -24,7 +24,7 @@ from torchx.components.dist import ddp as dist_ddp
 from torchx.runner import get_runner
 from torchx.specs import _named_resource_factories, AppState, Resource
 from torchx.util.types import none_throws
-from scripts.component_integration_tests import build_and_push_image
+from component_integration_tests import build_and_push_image
 
 log: logging.Logger = logging.getLogger(__name__)
 

--- a/scripts/minikube_trainer.py
+++ b/scripts/minikube_trainer.py
@@ -57,18 +57,21 @@ def run_job() -> None:
         "queue": "default",
     }
     app_handle = runner.run(train_app, "kubernetes", cfg)
+    log.info("Start waiting for app to finish")
     runner.wait(app_handle)
     final_status = runner.status(app_handle)
-    print(f"Final status: {final_status}")
+    log.info(f"Final status: {final_status}")
     if none_throws(final_status).state != AppState.SUCCEEDED:
         raise Exception(f"Dist app failed with status: {final_status}")
+
+
 
 
 def main() -> None:
     try:
         run_job()
     except MissingEnvError:
-        print("Skip runnig tests, executed only docker buid step")
+        print("Skip running tests, executed only docker buid step")
 
 
 if __name__ == "__main__":

--- a/scripts/minikube_trainer.py
+++ b/scripts/minikube_trainer.py
@@ -24,6 +24,7 @@ from torchx.components.dist import ddp as dist_ddp
 from torchx.runner import get_runner
 from torchx.specs import _named_resource_factories, AppState, Resource
 from torchx.util.types import none_throws
+from scripts.component_integration_tests import build_and_push_image
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -35,23 +36,20 @@ def register_gpu_resource() -> None:
         cpu=2,
         gpu=1,
         memMB=8 * GiB,
-        capabilities={
-            "node.kubernetes.io/instance-type": "p3.2xlarge",
-        },
     )
     print(f"Registering resource: {res}")
     _named_resource_factories["GPU_X1"] = lambda: res
 
 
-def build_and_push_image() -> BuildInfo:
-    build = build_images()
-    push_images(build, container_repo=getenv_asserts("CONTAINER_REPO"))
-    return build
+# def build_and_push_image() -> BuildInfo:
+#     build = build_images()
+#     push_images(build, container_repo=getenv_asserts("CONTAINER_REPO"))
+#     return build
 
 
 def run_job() -> None:
     register_gpu_resource()
-    build = build_and_push_image()
+    build = build_and_push_image(container_repo=getenv_asserts("CONTAINER_REPO"))
     image = build.torchx_image
     runner = get_runner()
     train_app = dist_ddp(

--- a/scripts/minikube_trainer.py
+++ b/scripts/minikube_trainer.py
@@ -65,8 +65,6 @@ def run_job() -> None:
         raise Exception(f"Dist app failed with status: {final_status}")
 
 
-
-
 def main() -> None:
     try:
         run_job()

--- a/scripts/minikube_trainer.py
+++ b/scripts/minikube_trainer.py
@@ -11,8 +11,6 @@
 Kubernetes integration tests.
 """
 
-import logging
-
 from component_integration_tests import build_and_push_image
 
 from integ_test_utils import getenv_asserts, MissingEnvError
@@ -20,8 +18,6 @@ from torchx.components.dist import ddp as dist_ddp
 from torchx.runner import get_runner
 from torchx.specs import _named_resource_factories, AppState, Resource
 from torchx.util.types import none_throws
-
-log: logging.Logger = logging.getLogger(__name__)
 
 GiB: int = 1024
 
@@ -57,10 +53,10 @@ def run_job() -> None:
         "queue": "default",
     }
     app_handle = runner.run(train_app, "kubernetes", cfg)
-    log.info("Start waiting for app to finish")
+    print("Start waiting for app to finish")
     runner.wait(app_handle)
     final_status = runner.status(app_handle)
-    log.info(f"Final status: {final_status}")
+    print(f"Final status: {final_status}")
     if none_throws(final_status).state != AppState.SUCCEEDED:
         raise Exception(f"Dist app failed with status: {final_status}")
 

--- a/scripts/minikube_trainer.py
+++ b/scripts/minikube_trainer.py
@@ -15,10 +15,7 @@ import logging
 
 from component_integration_tests import build_and_push_image
 
-from integ_test_utils import (
-    getenv_asserts,
-    MissingEnvError,
-)
+from integ_test_utils import getenv_asserts, MissingEnvError
 from torchx.components.dist import ddp as dist_ddp
 from torchx.runner import get_runner
 from torchx.specs import _named_resource_factories, AppState, Resource

--- a/scripts/minikube_trainer.py
+++ b/scripts/minikube_trainer.py
@@ -13,18 +13,16 @@ Kubernetes integration tests.
 
 import logging
 
+from component_integration_tests import build_and_push_image
+
 from integ_test_utils import (
-    build_images,
-    BuildInfo,
     getenv_asserts,
     MissingEnvError,
-    push_images,
 )
 from torchx.components.dist import ddp as dist_ddp
 from torchx.runner import get_runner
 from torchx.specs import _named_resource_factories, AppState, Resource
 from torchx.util.types import none_throws
-from component_integration_tests import build_and_push_image
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -39,12 +37,6 @@ def register_gpu_resource() -> None:
     )
     print(f"Registering resource: {res}")
     _named_resource_factories["GPU_X1"] = lambda: res
-
-
-# def build_and_push_image() -> BuildInfo:
-#     build = build_images()
-#     push_images(build, container_repo=getenv_asserts("CONTAINER_REPO"))
-#     return build
 
 
 def run_job() -> None:


### PR DESCRIPTION
We decided to migrate the Kubernetes integration test to using Minicube. This will let us avoid the AWS but still have a Kubernetes test on github host. 
The old Kubernetes integration test will be deprecated and deleted later. 
