### PR TITLE
Use component full name in error message

### DIFF
--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -26,8 +26,11 @@ def _create_args_parser(
 ) -> argparse.ArgumentParser:
     parameters = inspect.signature(cmpnt_fn).parameters
     function_desc, args_desc = get_fn_docstring(cmpnt_fn)
+    component_full_name = f"{cmpnt_fn.__module__}.{cmpnt_fn.__name__}".removeprefix(
+        "torchx.components."
+    )
     script_parser = argparse.ArgumentParser(
-        prog=f"torchx run <run args...> {cmpnt_fn.__name__} ",
+        prog=f"torchx run <run args...> {component_full_name} ",
         description=function_desc,
         formatter_class=TorchXArgumentHelpFormatter,
         # enables components to have "h" as a parameter


### PR DESCRIPTION
Summary: Component's name may include module prefix, e.g. `fb.python.binary`. However, we only add the function name, i.e. `binary` in the current error message which is not very clear. This diff constructs the full name and uses it in the error message.

Differential Revision: D56955597


