### PR TITLE
fix: add utility capability for local_docker (#906)

### DIFF
--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -314,7 +314,7 @@ class DockerScheduler(DockerWorkspaceMixin, Scheduler[DockerOpts]):
                     c.kwargs["device_requests"] = [
                         DeviceRequest(
                             count=resource.gpu,
-                            capabilities=[["compute"]],
+                            capabilities=[["compute", "utility"]],
                         )
                     ]
                 req.containers.append(c)

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -91,7 +91,7 @@ class DockerSchedulerTest(unittest.TestCase):
                         "device_requests": [
                             DeviceRequest(
                                 count=4,
-                                capabilities=[["compute"]],
+                                capabilities=[["compute", "utility"]],
                             )
                         ],
                         "devices": [


### PR DESCRIPTION
nvidia Docker images require adding libraries like `libnvidia-ml` that are part of `utility` capability.

TorchX currently only adds `compute` [here](https://github.com/pytorch/torchx/blob/eb7e3d87b10842f2f257b623f5a7ee084630f9f8/torchx/schedulers/docker_scheduler.py#L317).

Add `utility` next to `compute`. Similar fixes [here](https://github.com/portainer/portainer/blob/8a81d95253c1f1946f0ee5bc85db557cc66e602e/app/react/docker/containers/CreateView/ResourcesTab/GpuFieldset/toViewModel.ts#L10) and [here](https://github.com/arvados/arvados/blob/b0079c916db05e728cca119333e6dd6a1afd8a83/lib/crunchrun/docker.go#L172)

**NOTE**: [nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime) has been superseded by [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit).

Test plan:
☑ updated unit test

☑  verified works with `compute,utility`

☑ verfiied works with default device capabilities too
