### PR TITLE
Ensure duplicate arguments are only checked within their respective argument groups

### DIFF
--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -251,6 +251,32 @@ class CmdRunTest(unittest.TestCase):
             ),
         )
 
+        self.assertEqual(
+            (
+                "fb.python.binary",
+                [
+                    "--img",
+                    "lex_ig_o3_package",
+                    "-m",
+                    "dper_lib.instagram.pyper_v2.teams.stories.train",
+                    "--",
+                    "-m",
+                ],
+            ),
+            _parse_component_name_and_args(
+                [
+                    "fb.python.binary",
+                    "--img",
+                    "lex_ig_o3_package",
+                    "-m",
+                    "dper_lib.instagram.pyper_v2.teams.stories.train",
+                    "--",
+                    "-m",
+                ],
+                sp,
+            ),
+        )
+
         with self.assertRaises(SystemExit):
             _parse_component_name_and_args(["--"], sp)
 
@@ -269,6 +295,11 @@ class CmdRunTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             _parse_component_name_and_args(
                 ["--msg  ", "hello", "--msg     ", "repeate"], sp
+            )
+
+        with self.assertRaises(SystemExit):
+            _parse_component_name_and_args(
+                ["--m", "hello", "--", "--msg", "msg", "--msg", "repeate"], sp
             )
 
     def test_parse_component_name_and_args_with_default(self) -> None:


### PR DESCRIPTION
Summary:
There are valid scenarios where the same argument may appear in different groups, delineated by '--'. E.g.:

```
torchx run \
--scheduler local_penv \
--workspace //fblearner/flow/projects/lex/ig_o3_torchx:workflow \
-cfg build_remote_package=true  \
fb.python.binary \
--img lex_ig_o3_package  \
-m dper_lib.instagram.pyper_v2.teams.stories.train \
-- \
-m
```
("-m" appears twice in 2 different groups)
Right now, this doesn't pass our duplicate argument checks so this diff changed that.

Differential Revision: D57459718


