### PR TITLE
add in_cluster option for KubernetesScheduler

### DIFF
--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -446,6 +446,7 @@ class KubernetesOpts(TypedDict, total=False):
     image_repo: Optional[str]
     service_account: Optional[str]
     priority_class: Optional[str]
+    in_cluster: Optional[bool]
 
 
 class KubernetesScheduler(DockerWorkspaceMixin, Scheduler[KubernetesOpts]):
@@ -553,10 +554,16 @@ class KubernetesScheduler(DockerWorkspaceMixin, Scheduler[KubernetesOpts]):
         c = self._client
         if c is None:
             configuration = client.Configuration()
-            try:
-                config.load_kube_config(client_configuration=configuration)
-            except config.ConfigException as e:
-                warnings.warn(f"failed to load kube config: {e}")
+            if self._in_cluster:
+                try:
+                    config.load_incluster_config(client_configuration=configuration)
+                except config.ConfigException as e:
+                    warnings.warn(f"failed to load incluster config: {e}")
+            else:   
+                try:
+                    config.load_kube_config(client_configuration=configuration)
+                except config.ConfigException as e:
+                    warnings.warn(f"failed to load kube config: {e}")
 
             c = self._client = client.ApiClient(configuration)
 
@@ -586,6 +593,12 @@ class KubernetesScheduler(DockerWorkspaceMixin, Scheduler[KubernetesOpts]):
         cfg = dryrun_info._cfg
         assert cfg is not None, f"{dryrun_info} missing cfg"
         namespace = cfg.get("namespace") or "default"
+        
+        in_cluster = cfg.get("in_cluster") or False
+        if not isinstance(in_cluster, bool):
+            raise TypeError(f"config value 'in_cluster' must be a bool, got {in_cluster}")
+
+        self._in_cluster = in_cluster
 
         images_to_push = dryrun_info.request.images_to_push
         self.push_images(images_to_push)
@@ -674,6 +687,11 @@ class KubernetesScheduler(DockerWorkspaceMixin, Scheduler[KubernetesOpts]):
             "priority_class",
             type_=str,
             help="The name of the PriorityClass to set on the job specs",
+        )
+        opts.add(
+            "in_cluster",
+            type_=bool,
+            help="Type of run to use local cluster if KUBECONFIG not provided"
         )
         return opts
 


### PR DESCRIPTION
<!-- Change Summary -->

Add in_cluster opts to run KubernetesScheduler on pods without ~/.kube/config file where $KUBECONFIG env is "" .

I have problem with my Airflow DAG, after that I implemented my solution to run KubernetesScheduler with volcano without KUBECONFIG

[2024-05-28, 20:13:35 UTC] {warnings.py:110} WARNING - /home/airflow/.local/lib/python3.12/site-packages/torchx/schedulers/kubernetes_scheduler.py:557: UserWarning: failed to load kube config: Invalid kube-config file. No configuration found.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Run on my airflow configuration with cfg

```python
    app_handle = runner.run(component_spec, scheduler="kubernetes", cfg={
        "queue": "queue",
        "in_cluster": True
    })
   ```
