### PR TITLE
mount neuron devices for local_docker/aws_batch scheduler

### DIFF
--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -361,7 +361,10 @@ class AWSBatchSchedulerTest(unittest.TestCase):
             image="",
             mounts=[],
             resource=specs.Resource(
-                cpu=1, memMB=1000, gpu=0, devices={"vpc.amazonaws.com/efa": 2}
+                cpu=1,
+                memMB=1000,
+                gpu=0,
+                devices={"vpc.amazonaws.com/efa": 2, "aws.amazon.com/neurondevice": 1},
             ),
         )
         props = _role_to_node_properties(role, 0)
@@ -377,6 +380,11 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                 {
                     "hostPath": "/dev/infiniband/uverbs1",
                     "containerPath": "/dev/infiniband/uverbs1",
+                    "permissions": ["READ", "WRITE", "MKNOD"],
+                },
+                {
+                    "hostPath": "/dev/neuron0",
+                    "containerPath": "/dev/neuron0",
                     "permissions": ["READ", "WRITE", "MKNOD"],
                 },
             ],

--- a/torchx/schedulers/test/devices_test.py
+++ b/torchx/schedulers/test/devices_test.py
@@ -16,7 +16,7 @@ from torchx.specs.api import DeviceMount
 
 class DevicesTest(unittest.TestCase):
     def test_get_efa(self) -> None:
-        devices = {"vpc.amazonaws.com/efa": 2}
+        devices = {"vpc.amazonaws.com/efa": 2, "aws.amazon.com/neurondevice": 1}
         self.assertEqual(
             get_device_mounts(devices),
             [
@@ -28,6 +28,7 @@ class DevicesTest(unittest.TestCase):
                     src_path="/dev/infiniband/uverbs1",
                     dst_path="/dev/infiniband/uverbs1",
                 ),
+                DeviceMount(src_path="/dev/neuron0", dst_path="/dev/neuron0"),
             ],
         )
 

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -161,12 +161,19 @@ class DockerSchedulerTest(unittest.TestCase):
     def test_resource_devices(self) -> None:
         app = _test_app()
         app.roles[0].mounts = []
-        app.roles[0].resource.devices = {"vpc.amazonaws.com/efa": 1}
+        app.roles[0].resource.devices = {
+            "vpc.amazonaws.com/efa": 1,
+            "aws.amazon.com/neurondevice": 2,
+        }
 
         info = self.scheduler.submit_dryrun(app, cfg={})
         self.assertEqual(
             info.request.containers[0].kwargs["devices"],
-            ["/dev/infiniband/uverbs0:/dev/infiniband/uverbs0:rwm"],
+            [
+                "/dev/infiniband/uverbs0:/dev/infiniband/uverbs0:rwm",
+                "/dev/neuron0:/dev/neuron0:rwm",
+                "/dev/neuron1:/dev/neuron1:rwm",
+            ],
         )
 
     @patch("os.environ", {"FOO_1": "f1", "BAR_1": "b1", "FOOBAR_1": "fb1"})

--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -37,6 +37,7 @@ from typing import Callable, Mapping
 from torchx.specs.api import Resource
 
 EFA_DEVICE = "vpc.amazonaws.com/efa"
+NEURON_DEVICE = "aws.amazon.com/neurondevice"
 
 # ecs and ec2 have memtax and currently AWS Batch uses hard memory limits
 # so we have to account for mem tax when registering these resources for AWS
@@ -255,7 +256,11 @@ def aws_g5_48xlarge() -> Resource:
 
 def aws_trn1_2xlarge() -> Resource:
     return Resource(
-        cpu=8, gpu=0, memMB=32 * GiB, capabilities={K8S_ITYPE: "trn1.2xlarge"}
+        cpu=8,
+        gpu=0,
+        memMB=32 * GiB,
+        capabilities={K8S_ITYPE: "trn1.2xlarge"},
+        devices={NEURON_DEVICE: 1},
     )
 
 
@@ -265,7 +270,7 @@ def aws_trn1_32xlarge() -> Resource:
         gpu=0,
         memMB=512 * GiB,
         capabilities={K8S_ITYPE: "trn1.32xlarge"},
-        devices={EFA_DEVICE: 8},
+        devices={EFA_DEVICE: 8, NEURON_DEVICE: 16},
     )
 
 

--- a/torchx/specs/test/named_resources_aws_test.py
+++ b/torchx/specs/test/named_resources_aws_test.py
@@ -38,6 +38,7 @@ from torchx.specs.named_resources_aws import (
     GiB,
     K8S_ITYPE,
     NAMED_RESOURCES,
+    NEURON_DEVICE,
 )
 
 
@@ -170,11 +171,13 @@ class NamedResourcesTest(unittest.TestCase):
         self.assertEqual(8, trn1_2.cpu)
         self.assertEqual(0, trn1_2.gpu)
         self.assertEqual(32 * GiB, trn1_2.memMB)
+        self.assertEqual({NEURON_DEVICE: 1}, trn1_2.devices)
 
         trn1_32 = aws_trn1_32xlarge()
         self.assertEqual(trn1_32.cpu, trn1_2.cpu * 16)
         self.assertEqual(trn1_32.gpu, trn1_2.gpu)
         self.assertEqual(trn1_32.memMB, trn1_2.memMB * 16)
+        self.assertEqual({EFA_DEVICE: 8, NEURON_DEVICE: 16}, trn1_32.devices)
 
     def test_aws_m5_2xlarge(self) -> None:
         resource = aws_m5_2xlarge()


### PR DESCRIPTION
<!-- Change Summary -->
Add neuron device mount for aws trn instances. Mount these for local_docker scheduler

Docker native way to expose neuron devices to containers: 
https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/tutorials/build-run-neuron-container.html#container-devices

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
updated unit tests
```
663 passed, 104 warnings in 224.46s (0:03:44)
```

with dist.ddp component 

`torchx run -s local_docker --dryrun dist.ddp -h aws_trn1.32xlarge -j 1`

```
=== SCHEDULER REQUEST ===
- !!python/object:torchx.schedulers.docker_scheduler.DockerContainer
  command:
  - bash
  - -c
  - torchrun --rdzv_backend c10d --rdzv_endpoint localhost:0 --rdzv_id 'abc-fm1vcp71mkn0dc'
    --nnodes 1 --nproc_per_node 1 --tee 3 --role '' -m abc
  image: sha256:e7e0cef667c97bae5bdee516d246459fad63f0651f6735d12075f4775e18893e
  kwargs:
    devices:
    - /dev/infiniband/uverbs0:/dev/infiniband/uverbs0:rwm
    - /dev/infiniband/uverbs1:/dev/infiniband/uverbs1:rwm
    - /dev/infiniband/uverbs2:/dev/infiniband/uverbs2:rwm
    - /dev/infiniband/uverbs3:/dev/infiniband/uverbs3:rwm
    - /dev/infiniband/uverbs4:/dev/infiniband/uverbs4:rwm
    - /dev/infiniband/uverbs5:/dev/infiniband/uverbs5:rwm
    - /dev/infiniband/uverbs6:/dev/infiniband/uverbs6:rwm
    - /dev/infiniband/uverbs7:/dev/infiniband/uverbs7:rwm
    - /dev/neuron0:/dev/neuron0:rwm
    - /dev/neuron1:/dev/neuron1:rwm
    - /dev/neuron2:/dev/neuron2:rwm
    - /dev/neuron3:/dev/neuron3:rwm
    - /dev/neuron4:/dev/neuron4:rwm
    - /dev/neuron5:/dev/neuron5:rwm
    - /dev/neuron6:/dev/neuron6:rwm
    - /dev/neuron7:/dev/neuron7:rwm
    - /dev/neuron8:/dev/neuron8:rwm
    - /dev/neuron9:/dev/neuron9:rwm
    - /dev/neuron10:/dev/neuron10:rwm
    - /dev/neuron11:/dev/neuron11:rwm
    - /dev/neuron12:/dev/neuron12:rwm
    - /dev/neuron13:/dev/neuron13:rwm
    - /dev/neuron14:/dev/neuron14:rwm
    - /dev/neuron15:/dev/neuron15:rwm
    environment:
      LOGLEVEL: WARNING
      TORCHX_JOB_ID: local_docker://torchx/abc-fm1vcp71mkn0dc
      TORCHX_RANK0_HOST: abc-fm1vcp71mkn0dc-abc-0
      TORCHX_TRACKING_EXPERIMENT_NAME: default-experiment
    hostname: abc-fm1vcp71mkn0dc-abc-0
    labels:
      torchx.pytorch.org/app-id: abc-fm1vcp71mkn0dc
      torchx.pytorch.org/replica-id: '0'
      torchx.pytorch.org/role-name: abc
      torchx.pytorch.org/version: 0.7.0dev0
    mem_limit: 503296m
    mounts: []
    name: abc-fm1vcp71mkn0dc-abc-0
    nano_cpus: 128000000000
    network: torchx
    privileged: false
    shm_size: 503296m

```

