### PR TITLE
torchx runner: only add config files that can be accessed.

### DIFF
--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -489,7 +489,7 @@ def find_configs(dirs: Optional[Iterable[str]] = None) -> List[str]:
             dirs = DEFAULT_CONFIG_DIRS
         for d in dirs:
             configfile = Path(d) / CONFIG_FILE
-            if configfile.exists():
+            if os.access(configfile, os.R_OK):
                 config_files.append(str(configfile))
     return config_files
 


### PR DESCRIPTION
Summary:
This is a bit of a weird one, but maybe it's worth addressing.

We had an issue where we ran into a 'PermissionError' exception when trying to launch the runner since we didn't have permissions to access the home directory (weird setup, I know).

We had a valid config file in Path.cwd(), but DEFAULT_CONFIG_DIRS tries to look at Path.home() first and the .exists() call will throw an exception if it doesn't have permission to read the file.

This fix would replace the .exists() call with os.access() which will just return False if the path doesn't exist and/or is unreadable.

The os.access() call as well as the os.R_OK constant should work on windows/mac and linux, but I only tested on mac and linux so far.

Differential Revision: D59290870
