### PR TITLE
Fix up targets for devices.py and specs folder

### DIFF
--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -15,13 +15,7 @@ scheduler or pipeline adapter.
 import difflib
 from typing import Callable, Dict, Optional
 
-from torchx.specs.named_resources_aws import NAMED_RESOURCES as AWS_NAMED_RESOURCES
-from torchx.specs.named_resources_generic import (
-    NAMED_RESOURCES as GENERIC_NAMED_RESOURCES,
-)
-from torchx.util.entrypoints import load_group
-
-from .api import (  # noqa: F401 F403
+from torchx.specs.api import (
     ALL,
     AppDef,
     AppDryRunInfo,
@@ -52,7 +46,13 @@ from .api import (  # noqa: F401 F403
     UnknownSchedulerException,
     VolumeMount,
 )
-from .builders import make_app_handle, materialize_appdef, parse_mounts  # noqa
+from torchx.specs.builders import make_app_handle, materialize_appdef, parse_mounts
+
+from torchx.specs.named_resources_aws import NAMED_RESOURCES as AWS_NAMED_RESOURCES
+from torchx.specs.named_resources_generic import (
+    NAMED_RESOURCES as GENERIC_NAMED_RESOURCES,
+)
+from torchx.util.entrypoints import load_group
 
 GiB: int = 1024
 
@@ -183,3 +183,42 @@ def get_named_resources(res: str) -> Resource:
 
     """
     return named_resources[res]
+
+
+__all__ = [
+    "AppDef",
+    "AppDryRunInfo",
+    "AppHandle",
+    "AppState",
+    "AppStatus",
+    "BindMount",
+    "CfgVal",
+    "DeviceMount",
+    "get_type_name",
+    "is_terminal",
+    "macros",
+    "MISSING",
+    "NONE",
+    "NULL_RESOURCE",
+    "parse_app_handle",
+    "ReplicaState",
+    "ReplicaStatus",
+    "Resource",
+    "RetryPolicy",
+    "Role",
+    "RoleStatus",
+    "runopt",
+    "runopts",
+    "UnknownAppException",
+    "UnknownSchedulerException",
+    "InvalidRunConfigException",
+    "MalformedAppHandleException",
+    "VolumeMount",
+    "resource",
+    "get_named_resources",
+    "named_resources",
+    "make_app_handle",
+    "materialize_appdef",
+    "parse_mounts",
+    "ALL",
+]


### PR DESCRIPTION
Summary: This diff fixes up the buck targets so that the OSS tests can actually run internally and not cause the CI/CD pipelines to break.

Differential Revision: D59403775
