### PR TITLE
specs: add ROLE restart policy

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -241,11 +241,14 @@ class RetryPolicy(str, Enum):
                 is not violated using extra hosts as spares. It does not really support
                 elasticity and just uses the delta between num_replicas and min_replicas
                 as spares (EXPERIMENTAL).
+    4. ROLE: Restarts the role when any error occurs in that role. This does not
+             restart the whole job.
     """
 
     REPLICA = "REPLICA"
     APPLICATION = "APPLICATION"
     HOT_SPARE = "HOT_SPARE"
+    ROLE = "ROLE"
 
 
 class MountType(str, Enum):

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -266,6 +266,17 @@ class RoleBuilderTest(unittest.TestCase):
         self.assertEqual(5, trainer.max_retries)
         self.assertEqual(RetryPolicy.REPLICA, trainer.retry_policy)
 
+    def test_retry_policies(self) -> None:
+        self.assertCountEqual(
+            set(RetryPolicy),  # pyre-ignore[6]: Enum isn't iterable
+            {
+                RetryPolicy.APPLICATION,
+                RetryPolicy.REPLICA,
+                RetryPolicy.ROLE,
+                RetryPolicy.HOT_SPARE,
+            },
+        )
+
 
 class AppHandleTest(unittest.TestCase):
     def test_parse_malformed_app_handles(self) -> None:


### PR DESCRIPTION
<!-- Change Summary -->

This allows restarting a single role when the scheduler supports specific role restarts. Not all schedulers support this and this PR doesn't add support for it in any of the existing open source schedulers.

Volcano doesn't support multiple roles and thus we can't support role level restart with the very limited action policy https://pkg.go.dev/volcano.sh/apis@v1.9.0/pkg/apis/bus/v1alpha1#Action

This follows the pattern in https://github.com/pytorch/torchx/pull/922. Role is sufficiently generic so is a valid fit for OSS specs.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pytest torchx/specs/test/api_test.py
```