### PR TITLE
Sync pyre strict comments to match internal copy

### DIFF
--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 """
 
 This contains the TorchX Kubernetes_MCAD scheduler which can be used to run TorchX

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import base64
 import importlib
 import sys


### PR DESCRIPTION
The internal version of torchx has pyre-strict comments. The external version does not.
This diff adds the corresponding comments to re-sync the two repos, using the internal version as a the source of truth.

Test plan:
(Comments - no changes to behaviour, except for pyre)
