### PR TITLE
Make TTFB torchx event aware of distributed_ai_stack

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -198,10 +198,14 @@ class Runner:
                 parent_run_id=parent_run_id,
             )
             handle = self.schedule(dryrun_info)
+            app = none_throws(dryrun_info._app)
             ctx._torchx_event.workspace = workspace
             ctx._torchx_event.scheduler = none_throws(dryrun_info._scheduler)
-            ctx._torchx_event.app_image = none_throws(dryrun_info._app).roles[0].image
+            ctx._torchx_event.app_image = app.roles[0].image
             ctx._torchx_event.app_id = parse_app_handle(handle)[2]
+            ctx._torchx_event.distributed_ai_stack = app.metadata.get(
+                "distributed_ai_stack", None
+            )
             return handle
 
     def dryrun_component(
@@ -263,6 +267,9 @@ class Runner:
             ctx._torchx_event.scheduler = none_throws(dryrun_info._scheduler)
             ctx._torchx_event.app_image = none_throws(dryrun_info._app).roles[0].image
             ctx._torchx_event.app_id = parse_app_handle(handle)[2]
+            ctx._torchx_event.distributed_ai_stack = app.metadata.get(
+                "distributed_ai_stack", None
+            )
             return handle
 
     def schedule(self, dryrun_info: AppDryRunInfo) -> AppHandle:

--- a/torchx/runner/events/__init__.py
+++ b/torchx/runner/events/__init__.py
@@ -84,6 +84,7 @@ class log_event:
         scheduler: Optional[str] = None,
         app_id: Optional[str] = None,
         app_image: Optional[str] = None,
+        distributed_ai_stack: Optional[str] = None,
         runcfg: Optional[str] = None,
         workspace: Optional[str] = None,
     ) -> None:
@@ -92,6 +93,7 @@ class log_event:
             scheduler or "",
             app_id,
             app_image=app_image,
+            distributed_ai_stack=distributed_ai_stack,
             runcfg=runcfg,
             workspace=workspace,
         )
@@ -128,6 +130,7 @@ class log_event:
         scheduler: str,
         app_id: Optional[str] = None,
         app_image: Optional[str] = None,
+        distributed_ai_stack: Optional[str] = None,
         runcfg: Optional[str] = None,
         source: SourceType = SourceType.UNKNOWN,
         workspace: Optional[str] = None,
@@ -138,6 +141,7 @@ class log_event:
             api=api,
             app_id=app_id,
             app_image=app_image,
+            distributed_ai_stack=distributed_ai_stack,
             runcfg=runcfg,
             source=source,
             workspace=workspace,

--- a/torchx/runner/events/api.py
+++ b/torchx/runner/events/api.py
@@ -29,6 +29,7 @@ class TorchxEvent:
         scheduler: Scheduler that is used to execute request
         api: Api name
         app_id: Unique id that is set by the underlying scheduler
+        distributed_ai_stack: Distributed AI stack used in the workflow (e.g., PyPer, HPC)
         image: Image/container bundle that is used to execute request.
         runcfg: Run config that was used to schedule app.
         source: Type of source the event is generated.
@@ -41,6 +42,7 @@ class TorchxEvent:
     api: str
     app_id: Optional[str] = None
     app_image: Optional[str] = None
+    distributed_ai_stack: Optional[str] = None
     runcfg: Optional[str] = None
     raw_exception: Optional[str] = None
     source: SourceType = SourceType.UNKNOWN

--- a/torchx/runner/events/test/lib_test.py
+++ b/torchx/runner/events/test/lib_test.py
@@ -29,6 +29,9 @@ class TorchxEventLibTest(unittest.TestCase):
         self.assertEqual(actual_event.api, expected_event.api)
         self.assertEqual(actual_event.app_id, expected_event.app_id)
         self.assertEqual(actual_event.app_image, expected_event.app_image)
+        self.assertEqual(
+            actual_event.distributed_ai_stack, expected_event.distributed_ai_stack
+        )
         self.assertEqual(actual_event.runcfg, expected_event.runcfg)
         self.assertEqual(actual_event.source, expected_event.source)
 
@@ -47,6 +50,7 @@ class TorchxEventLibTest(unittest.TestCase):
             api="test_api",
             app_image="test_app_image",
             workspace="test_workspace",
+            distributed_ai_stack="test_distributed_ai_stack",
         )
         self.assertEqual("test_session", event.session)
         self.assertEqual("test_scheduler", event.scheduler)
@@ -54,6 +58,7 @@ class TorchxEventLibTest(unittest.TestCase):
         self.assertEqual("test_app_image", event.app_image)
         self.assertEqual(SourceType.UNKNOWN, event.source)
         self.assertEqual("test_workspace", event.workspace)
+        self.assertEqual("test_distributed_ai_stack", event.distributed_ai_stack)
 
     def test_event_deser(self) -> None:
         event = TorchxEvent(
@@ -62,6 +67,7 @@ class TorchxEventLibTest(unittest.TestCase):
             api="test_api",
             app_image="test_app_image",
             workspace="test_workspace",
+            distributed_ai_stack="test_distributed_ai_stack",
             source=SourceType.EXTERNAL,
         )
         json_event = event.serialize()
@@ -76,6 +82,7 @@ class LogEventTest(unittest.TestCase):
         self.assertEqual(expected.app_id, actual.app_id)
         self.assertEqual(expected.api, actual.api)
         self.assertEqual(expected.app_image, actual.app_image)
+        self.assertEqual(expected.distributed_ai_stack, actual.distributed_ai_stack)
         self.assertEqual(expected.source, actual.source)
         self.assertEqual(expected.workspace, actual.workspace)
 
@@ -86,6 +93,7 @@ class LogEventTest(unittest.TestCase):
             "local",
             "test_app_id",
             app_image="test_app_image_id",
+            distributed_ai_stack="test_distributed_ai_stack",
             runcfg=cfg,
             workspace="test_workspace",
         )
@@ -95,6 +103,7 @@ class LogEventTest(unittest.TestCase):
             "test_call",
             "test_app_id",
             app_image="test_app_image_id",
+            distributed_ai_stack="test_distributed_ai_stack",
             runcfg=cfg,
             workspace="test_workspace",
         )
@@ -108,6 +117,7 @@ class LogEventTest(unittest.TestCase):
             "local",
             "test_app_id",
             app_image="test_app_image_id",
+            distributed_ai_stack="test_distributed_ai_stack",
             runcfg=cfg,
             workspace="test_workspace",
         ) as ctx:
@@ -119,6 +129,7 @@ class LogEventTest(unittest.TestCase):
             "test_call",
             "test_app_id",
             app_image="test_app_image_id",
+            distributed_ai_stack="test_distributed_ai_stack",
             runcfg=cfg,
             workspace="test_workspace",
             cpu_time_usec=ctx._torchx_event.cpu_time_usec,


### PR DESCRIPTION
Summary: Add an optional field `distributed_ai_stack` into TorchX Event. This is a common and valuable field which is also existing in MAST job metadata, as well as needed for post data processing of AI Instrumentation Framework in order to include pre MAST job submission as part of TTFB measurement.

Differential Revision: D61578121
