### PR TITLE
Fix local docker invalid container name created by trimming

### DIFF
--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -221,13 +221,15 @@ class DockerSchedulerTest(unittest.TestCase):
         for role in app.roles:
             role.name = "ethology_explore_magic_calliope_divisive_whirl_dealt_lotus_oncology_facet_deerskin_blum_elective_spill_trammel_trainer"
         with patch("torchx.schedulers.docker_scheduler.make_unique") as make_unique_ctx:
-            make_unique_ctx.return_value = "ethology_explore_magic_calliope_divisive_whirl_dealt_lotus_oncology_facet_deerskin_blum_elective_spill_trammel_12345"
+            make_unique_ctx.return_value = "ethology_explore_magic_calliope_divisive_whirl_dealt_lotus_oncology_facet_deerskin__.-_elective_spill_trammel_1234"
             info = self.scheduler.submit_dryrun(app, DockerOpts())
         for container in info.request.containers:
             assert "name" in container.kwargs
             name = container.kwargs["name"]
             assert isinstance(name, str)
             assert len(name) < 65
+            # Assert match container name rules https://github.com/moby/moby/blob/master/daemon/names/names.go#L6
+            self.assertRegex(name, r"[a-zA-Z0-9][a-zA-Z0-9_.-]")
 
 
 if has_docker():


### PR DESCRIPTION
Change:
- Fix local docker invalid container name created by trimming.
    - Sample app name: `123.-_app-id123456`
    - Error: `docker.errors.APIError: 400 Client Error for http+docker://localhost/v1.41/containers/create?name=.-_app-id123456-b2hcqzf4bxkjhd-role-name-0: Bad Request ("Invalid container name (.-_app-id123456-b2hcqzf4bxkjhd-role-name-0), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed")`
- Remove invalid prefixes (https://github.com/moby/moby/blob/master/daemon/names/names.go#L6).

Test plan:
`pytest torchx/schedulers/test/docker_scheduler_test.py` => 16 passed in 33.68s
