### PR TITLE
Add missing workspace docs

### DIFF
--- a/docs/source/_static/css/torchx.css
+++ b/docs/source/_static/css/torchx.css
@@ -37,7 +37,7 @@ article.pytorch-article .py dt span.pre {
 .output_area.stderr.docutils.container {
   background-color: #fed !important;
 }
-.note .admonition-title > p {
+.note .admonition-title > p, .warning .admonition-title > p {
   margin: 0 !important;
   font: inherit;
   color: inherit;


### PR DESCRIPTION
Summary:
Ultimately we want to remove all the docs under https://www.internalfb.com/intern/wiki/TorchX_internal/TorchX and consolidate it all in the staticdocs wiki.

This diff moves the info from https://www.internalfb.com/intern/wiki/TorchX_internal/TorchX/How_Patching_Works/ into the patching wiki page, and also does some nice formatting.

Note: I mostly ignored the stuff under the deprecated custom patch section, if anyone knows more about this, please let me know if there's anything in there that should be moved over and/or if any of the stuff in this wiki is wrong.

Reviewed By: ishachirimar

Differential Revision: D63643254


