### PR TITLE
Add missing troubleshooting docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,6 +60,7 @@ Documentation
       fb/cogwheel.rst
       fb/named_resources.rst
       fb/tracker.md
+      fb/troubleshooting.md
 
 
 Works With


### PR DESCRIPTION
Summary:
Ultimately we want to remove all the docs under https://www.internalfb.com/intern/wiki/TorchX_internal/TorchX and consolidate it all in the staticdocs wiki.
This diff moves the info from https://www.internalfb.com/intern/wiki/TorchX_internal/TorchX/Troubleshooting/ into a new Meta troubleshooting wiki page

Reviewed By: ishachirimar

Differential Revision: D63643251


