### PR TITLE
Strip lines when log-tailing

### DIFF
--- a/torchx/util/log_tee_helpers.py
+++ b/torchx/util/log_tee_helpers.py
@@ -102,7 +102,7 @@ def _print_log_lines_for_role_replica(
                 color_begin = ""
                 color_end = ""
             prefix = f"{color_begin}{which_role}/{which_replica}{color_end} "
-            print(_prefix_line(prefix, line), file=dst, end="", flush=True)
+            print(_prefix_line(prefix, line.strip()), file=dst, end="\n", flush=True)
     except Exception as e:
         exceptions.put(e)
         raise


### PR DESCRIPTION
Summary:
For some reason, certain jobs have logs that end in \n\n, making unreadable whitespace

This diff explicitly strips lines before prefixing them, and then manually adds back exactly one "\n"

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: haonans

Differential Revision: D66191123


