### PR TITLE
Add torchx session id as Environment variable

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -39,6 +39,7 @@ from torchx.tracker.api import (
     ENV_TORCHX_TRACKERS,
     tracker_config_env_var_name,
 )
+from torchx.util.session import get_session_id_or_create_new, TORCHX_INTERNAL_SESSION_ID
 
 from torchx.util.types import none_throws
 from torchx.workspace.api import PkgInfo, WorkspaceBuilder, WorkspaceMixin
@@ -390,6 +391,7 @@ class Runner:
             role.env[ENV_TORCHX_JOB_ID] = make_app_handle(
                 scheduler, self._name, macros.app_id
             )
+            role.env[TORCHX_INTERNAL_SESSION_ID] = get_session_id_or_create_new()
 
             if parent_run_id:
                 role.env[ENV_TORCHX_PARENT_RUN_ID] = parent_run_id


### PR DESCRIPTION
Summary:
This diff passes the torchx_session_id as an environment variable.

In penv_python, I will fetch this id and log it into logging table.
With the session id, it is possible to join the logging table of penv_python with the logging table of torchx.

Differential Revision: D66387522


