### PR TITLE
[torchx/dev-requirements] Fix broken unittest in CI 

### DIFF
--- a/.github/workflows/kubernetes-minikube-integration-test.yaml
+++ b/.github/workflows/kubernetes-minikube-integration-test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   kubernetes-launch:
-    runs-on: linux.24_04.16x
+    runs-on: linux.24_04.4x
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Fixes broken unittests in CI by specifying a tighter version requirement for sagemaker.