### PR TITLE
[torchx/lintrunner] Propagate pyre cmd errors in pyre_linter.py

### DIFF
--- a/tools/linter/adapters/pyre_linter.py
+++ b/tools/linter/adapters/pyre_linter.py
@@ -48,6 +48,7 @@ def run_pyre() -> List[PyreResult]:
         ["pyre", "--output=json", "incremental"],
         capture_output=True,
     )
+    proc.check_returncode()  # throws CalledProcessError if cmd failed
     return json.loads(proc.stdout)
 
 


### PR DESCRIPTION
The PYRE check for `lintrunner` doesn't check the return code of running `subprocess.run(["pyre", "--output=json", "incremental"])` therefore will try to parse the content of the command's console output as json even if the command fails. 

This results in the propagated error message being non-descriptive.

## Before
Before the change `pyre --output=json incremental` failing would result in:

```
$ lintrunner
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.


>>> General linter failure:

  Advice (pyre) command-failed
    Failed due to JSONDecodeError:
    Expecting value: line 1 column 1 (char 0)
```

## After
After this fix, we get the proper root cause

```
$ lintrunner

>>> General linter failure:

  Advice (pyre) command-failed
    Failed due to CalledProcessError:
    Command '['pyre', '--output=json', 'incremental']' returned non-zero exit
    status 2.
```
