### PR TITLE
feat: add aws_c5_18xlarge

### DIFF
--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -130,6 +130,12 @@ def aws_m5_2xlarge() -> Resource:
     )
 
 
+def aws_c5_18xlarge() -> Resource:
+    return Resource(
+        cpu=72, gpu=0, memMB=144 * GiB, capabilities={K8S_ITYPE: "c5.18xlarge"}
+    )
+
+
 def aws_g4dn_xlarge() -> Resource:
     return Resource(
         cpu=4, gpu=1, memMB=16 * GiB, capabilities={K8S_ITYPE: "g4dn.xlarge"}
@@ -351,6 +357,7 @@ def aws_trn1_32xlarge() -> Resource:
 NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = {
     "aws_t3.medium": aws_t3_medium,
     "aws_m5.2xlarge": aws_m5_2xlarge,
+    "aws_c5.18xlarge": aws_c5_18xlarge,
     "aws_p3.2xlarge": aws_p3_2xlarge,
     "aws_p3.8xlarge": aws_p3_8xlarge,
     "aws_p3.16xlarge": aws_p3_16xlarge,

--- a/torchx/specs/test/named_resources_aws_test.py
+++ b/torchx/specs/test/named_resources_aws_test.py
@@ -8,6 +8,7 @@
 import unittest
 
 from torchx.specs.named_resources_aws import (
+    aws_c5_18xlarge,
     aws_g4dn_12xlarge,
     aws_g4dn_16xlarge,
     aws_g4dn_2xlarge,
@@ -236,6 +237,12 @@ class NamedResourcesTest(unittest.TestCase):
         self.assertEqual(8, resource.cpu)
         self.assertEqual(0, resource.gpu)
         self.assertEqual(32 * GiB, resource.memMB)
+
+    def test_aws_c5_18xlarge(self) -> None:
+        resource = aws_c5_18xlarge()
+        self.assertEqual(72, resource.cpu)
+        self.assertEqual(0, resource.gpu)
+        self.assertEqual(144 * GiB, resource.memMB)
 
     def test_aws_t3_medium(self) -> None:
         resource = aws_t3_medium()


### PR DESCRIPTION
Adding a GPU-less AWS instance type for compute-intensive workloads, e.g. dataset pre-processing and inference.

https://aws.amazon.com/ec2/instance-types/c5

Adding only one of the high end specs, but can add others if needed.

Test plan:
```
================================================================== test session starts ==================================================================
platform darwin -- Python 3.12.4, pytest-7.4.4, pluggy-1.0.0
<REDACTED>
plugins: cov-5.0.0, anyio-3.7.1, typeguard-2.13.3, timeout-2.3.1, xdist-3.6.1
collected 11 items

torchx/specs/test/named_resources_aws_test.py::NamedResourcesTest::test_aws_c5_18xlarge PASSED                                                    [  9%]
...

================================================================== 11 passed in 0.07s ===================================================================
```