### PR TITLE
Fix pydantic incompatiblity causing test failures

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,7 +22,7 @@ pytest
 pytest-cov
 pytorch-lightning==2.3.1
 tensorboard==2.14.0
-sagemaker>=2.149.0
+sagemaker==2.224.4
 torch-model-archiver>=0.4.2
 torch==2.2.1
 torchmetrics==0.10.3


### PR DESCRIPTION
<!-- Change Summary -->
Seeing a failure because of an incompatibility between pydantic and sagemaker causing the error `ERROR torchx/schedulers/test/aws_sagemaker_scheduler_test.py - NameError: Field name "json" shadows a BaseModel attribute; use a different field name with "alias='json'".` eg. https://github.com/pytorch/torchx/actions/runs/12147832511/job/33874943758

This diff pins the sagemaker version to avoid this

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
Ran `pytest torchx/schedulers/test/aws_sagemaker_scheduler_test.py`, also CI tests pass (docs and pyre errors are pre-existing)
