### PR TITLE
Fix docs build by freezing apache airflow version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,5 @@ jupytext
 ipython_genutils
 # https://github.com/jupyter/nbconvert/issues/1736
 jinja2>=3.1.4
-apache-airflow
+apache-airflow==2.6.3  # newer versions require incompatible protobuf version
+protobuf==3.20.3  # kfp requires protobuf < 4.0.0


### PR DESCRIPTION
<!-- Change Summary -->

apache-airflow v2.10.3 bumped a dependency that broke kfp protobuf stuff in docs, this freezes the version to stick to a compatible version

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Docs-related CI passes (other failures are pre-existing)
