### PR TITLE
sync torchx .pyre_configuration.internal with external config and upgrade

### DIFF
--- a/torchx/examples/apps/tracker/main.py
+++ b/torchx/examples/apps/tracker/main.py
@@ -99,6 +99,8 @@ def test(
         for data, target in test_loader:
             data, target = data.to(device), target.to(device)
             output = model(data)
+            # pyre-fixme[58]: `+` is not supported for operand types `int` and
+            #  `Union[bool, float, int]`.
             test_loss += F.nll_loss(
                 output, target, reduction="sum"
             ).item()  # sum up batch loss

--- a/torchx/pipelines/kfp/adapter.py
+++ b/torchx/pipelines/kfp/adapter.py
@@ -50,7 +50,9 @@ def component_spec_from_app(app: api.AppDef) -> Tuple[str, api.Role]:
 
     role = app.roles[0]
     assert (
-        role.num_replicas == 1
+        role.num_replicas
+        == 1
+        # pyre-fixme[16]: `AppDef` has no attribute `num_replicas`.
     ), f"KFP adapter only supports one replica, got {app.num_replicas}"
 
     command = [role.entrypoint, *role.args]

--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -809,6 +809,8 @@ class AWSBatchScheduler(DockerWorkspaceMixin, Scheduler[AWSBatchOpts]):
                     startFromHead=True,
                     **args,
                 )
+            # pyre-fixme[66]: Exception handler type annotation `unknown` must
+            #  extend BaseException.
             except self._log_client.exceptions.ResourceNotFoundException:
                 return []  # noqa: B901
             if response["nextForwardToken"] == next_token:


### PR DESCRIPTION
Summary: It looks like the internal and pyre configuration versions have gone out of date with D66501165. I'm updating the internal pyre version to match the external version of `0.0.101732536891` and performing a pyre upgrade to add/remove fixmes.

Differential Revision: D66964639


