### PR TITLE
torchx - fix RaySchedulerTest unit test failure

### DIFF
--- a/torchx/schedulers/test/ray_scheduler_test.py
+++ b/torchx/schedulers/test/ray_scheduler_test.py
@@ -197,7 +197,9 @@ if has_ray():
             with self._assert_log_message(
                 "WARNING", "The Ray scheduler does not support port mapping."
             ):
-                self._scheduler._validate(self._app_def, scheduler="ray")
+                self._scheduler._validate(
+                    self._app_def, scheduler="ray", cfg=self._run_cfg
+                )
 
         def test_submit_dryrun_raises_error_if_cluster_config_file_is_not_str(
             self,


### PR DESCRIPTION
Summary: fix unit test failure on ray_scheduler_test due to missing required cfg arg on _validate()

Differential Revision: D67140440


