### PR TITLE
fix: adjust aws_c5.18xlarge memory size

### DIFF
--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -132,7 +132,8 @@ def aws_m5_2xlarge() -> Resource:
 
 def aws_c5_18xlarge() -> Resource:
     return Resource(
-        cpu=72, gpu=0, memMB=144 * GiB, capabilities={K8S_ITYPE: "c5.18xlarge"}
+        # using lower memory size than the spec since MEM_TAX is not enough for adjustment
+        cpu=72, gpu=0, memMB=142 * GiB, capabilities={K8S_ITYPE: "c5.18xlarge"}
     )
 
 


### PR DESCRIPTION
`MEM_TAX` is not enough to adjust memory size for the actual memory we get:
```
              total        used        free      shared  buff/cache   available
Mem:      144113336     1443996   140375536         812     2293804   141697752
Swap:             0           0           0
```

Test plan:
* Submitted a training job using `142 * GiB`