### PR TITLE
Fixup Optional runopt cfg values handling during cfg_from_json_repr deserialization

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -948,7 +948,12 @@ class runopts:
         for key, val in cfg_dict.items():
             runopt_ = self.get(key)
             if runopt_:
-                if runopt_.opt_type == List[str]:
+                # Optional runopt cfg values default their value to None,
+                # but use `_type` to specify their type when provided.
+                # Make sure not to treat None's as lists/dictionaries
+                if val is None:
+                    cfg[key] = val
+                elif runopt_.opt_type == List[str]:
                     cfg[key] = [str(v) for v in val]
                 elif runopt_.opt_type == Dict[str, str]:
                     cfg[key] = {str(k): str(v) for k, v in val.items()}

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -555,6 +555,7 @@ class RunConfigTest(unittest.TestCase):
         opts.add("disable", type_=bool, default=True, help="")
         opts.add("complex_list", type_=List[str], default=[], help="")
         opts.add("complex_dict", type_=Dict[str, str], default={}, help="")
+        opts.add("default_none", type_=List[str], help="")
 
         self.assertDictEqual(
             {
@@ -565,6 +566,7 @@ class RunConfigTest(unittest.TestCase):
                 "disable": False,
                 "complex_list": ["v1", "v2", "v3"],
                 "complex_dict": {"k1": "v1", "k2": "v2"},
+                "default_none": None,
             },
             opts.resolve(
                 opts.cfg_from_json_repr(
@@ -575,7 +577,8 @@ class RunConfigTest(unittest.TestCase):
                         "enable": true,
                         "disable": false,
                         "complex_list": ["v1", "v2", "v3"],
-                        "complex_dict": {"k1": "v1", "k2": "v2"}
+                        "complex_dict": {"k1": "v1", "k2": "v2"},
+                        "default_none": null
                     }"""
                 )
             ),


### PR DESCRIPTION
Summary: Handle default to None types in runopts for derserialization API

Differential Revision: D68445341


