### PR TITLE
Fix for issue with APF packaging with multiple roles

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -398,7 +398,7 @@ class Role:
             else:
                 result = ov[attrname]()
             setattr(self, attrname, result)
-            del ov[attrname]
+            ov[attrname] = lambda: result
         return super().__getattribute__(attrname)
 
     def pre_proc(


### PR DESCRIPTION
Summary: There is an issue with the async logic when there are multiple jobs/roles associated with single package. This fix solves this by allowing the future to be used by more than one arm of the package.

Reviewed By: ishachirimar, chouxi

Differential Revision: D69279705
