### PR TITLE
Allow injecting validators for component verification

### DIFF
--- a/torchx/specs/file_linter.py
+++ b/torchx/specs/file_linter.py
@@ -244,11 +244,18 @@ class TorchFunctionVisitor(ast.NodeVisitor):
 
     """
 
-    def __init__(self, component_function_name: str) -> None:
-        self.validators = [
-            TorchxFunctionArgsValidator(),
-            TorchxReturnValidator(),
-        ]
+    def __init__(
+        self,
+        component_function_name: str,
+        validators: Optional[List[TorchxFunctionValidator]],
+    ) -> None:
+        if validators is None:
+            self.validators: List[TorchxFunctionValidator] = [
+                TorchxFunctionArgsValidator(),
+                TorchxReturnValidator(),
+            ]
+        else:
+            self.validators = validators
         self.linter_errors: List[LinterMessage] = []
         self.component_function_name = component_function_name
         self.visited_function = False
@@ -264,7 +271,11 @@ class TorchFunctionVisitor(ast.NodeVisitor):
             self.linter_errors += validator.validate(node)
 
 
-def validate(path: str, component_function: str) -> List[LinterMessage]:
+def validate(
+    path: str,
+    component_function: str,
+    validators: Optional[List[TorchxFunctionValidator]],
+) -> List[LinterMessage]:
     """
     Validates the function to make sure it complies the component standard.
 
@@ -293,7 +304,7 @@ def validate(path: str, component_function: str) -> List[LinterMessage]:
             severity="error",
         )
         return [linter_message]
-    visitor = TorchFunctionVisitor(component_function)
+    visitor = TorchFunctionVisitor(component_function, validators)
     visitor.visit(module)
     linter_errors = visitor.linter_errors
     if not visitor.visited_function:

--- a/torchx/specs/test/file_linter_test.py
+++ b/torchx/specs/test/file_linter_test.py
@@ -121,14 +121,13 @@ class SpecsFileValidatorTest(unittest.TestCase):
         content = "!!foo====bar"
         with patch("torchx.specs.file_linter.read_conf_file") as read_conf_file_mock:
             read_conf_file_mock.return_value = content
-            errors = validate(self._path, "unknown_function")
+            errors = validate(self._path, "unknown_function", None)
             self.assertEqual(1, len(errors))
             self.assertEqual("invalid syntax", errors[0].description)
 
     def test_validate_varargs_kwargs_fn(self) -> None:
         linter_errors = validate(
-            self._path,
-            "_test_invalid_fn_with_varags_and_kwargs",
+            self._path, "_test_invalid_fn_with_varags_and_kwargs", None
         )
         self.assertEqual(1, len(linter_errors))
         self.assertTrue(
@@ -136,7 +135,7 @@ class SpecsFileValidatorTest(unittest.TestCase):
         )
 
     def test_validate_no_return(self) -> None:
-        linter_errors = validate(self._path, "_test_fn_no_return")
+        linter_errors = validate(self._path, "_test_fn_no_return", None)
         self.assertEqual(1, len(linter_errors))
         expected_desc = (
             "Function: _test_fn_no_return missing return annotation or "
@@ -145,7 +144,7 @@ class SpecsFileValidatorTest(unittest.TestCase):
         self.assertEqual(expected_desc, linter_errors[0].description)
 
     def test_validate_incorrect_return(self) -> None:
-        linter_errors = validate(self._path, "_test_fn_return_int")
+        linter_errors = validate(self._path, "_test_fn_return_int", None)
         self.assertEqual(1, len(linter_errors))
         expected_desc = (
             "Function: _test_fn_return_int has incorrect return annotation, "
@@ -153,12 +152,24 @@ class SpecsFileValidatorTest(unittest.TestCase):
         )
         self.assertEqual(expected_desc, linter_errors[0].description)
 
+    def test_no_validators_has_no_validation(self) -> None:
+        linter_errors = validate(self._path, "_test_fn_return_int", [])
+        self.assertEqual(0, len(linter_errors))
+
+        linter_errors = validate(self._path, "_test_fn_no_return", [])
+        self.assertEqual(0, len(linter_errors))
+
+        linter_errors = validate(
+            self._path, "_test_invalid_fn_with_varags_and_kwargs", []
+        )
+        self.assertEqual(0, len(linter_errors))
+
     def test_validate_empty_fn(self) -> None:
-        linter_errors = validate(self._path, "_test_empty_fn")
+        linter_errors = validate(self._path, "_test_empty_fn", None)
         self.assertEqual(0, len(linter_errors))
 
     def test_validate_args_no_type_defs(self) -> None:
-        linter_errors = validate(self._path, "_test_args_no_type_defs")
+        linter_errors = validate(self._path, "_test_args_no_type_defs", None)
         print(linter_errors)
         self.assertEqual(2, len(linter_errors))
         self.assertEqual(
@@ -169,10 +180,7 @@ class SpecsFileValidatorTest(unittest.TestCase):
         )
 
     def test_validate_args_no_type_defs_complex(self) -> None:
-        linter_errors = validate(
-            self._path,
-            "_test_args_dict_list_complex_types",
-        )
+        linter_errors = validate(self._path, "_test_args_dict_list_complex_types", None)
         self.assertEqual(5, len(linter_errors))
         self.assertEqual(
             "Arg arg0 missing type annotation", linter_errors[0].description
@@ -210,7 +218,7 @@ to your component (see: https://pytorch.org/torchx/latest/component_best_practic
         self.assertEqual(" ", param_desc["arg0"])
 
     def test_validate_unknown_function(self) -> None:
-        linter_errors = validate(self._path, "unknown_function")
+        linter_errors = validate(self._path, "unknown_function", None)
         self.assertEqual(1, len(linter_errors))
         self.assertEqual(
             "Function unknown_function not found", linter_errors[0].description

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -106,13 +106,13 @@ _ = torchx.specs.test.finder_test
 
     @patch(_METADATA_EPS, return_value=_ENTRY_POINTS)
     def test_get_invalid_component(self, _: MagicMock) -> None:
-        components = _load_components()
+        components = _load_components(None)
         foobar_component = components["invalid_component"]
         self.assertEqual(1, len(foobar_component.validation_errors))
 
     @patch(_METADATA_EPS, return_value=_ENTRY_POINTS)
     def test_get_entrypoints_components(self, _: MagicMock) -> None:
-        components = _load_components()
+        components = _load_components(None)
         foobar_component = components["_test_component"]
         self.assertEqual(_test_component, foobar_component.fn)
         self.assertEqual("_test_component", foobar_component.fn_name)
@@ -132,7 +132,7 @@ bar = torchx.specs.test.components.c.d
         ),
     )
     def test_load_custom_components(self, _: MagicMock) -> None:
-        components = _load_components()
+        components = _load_components(None)
 
         # the name of the appdefs returned by each component
         # is the expected component name
@@ -155,7 +155,7 @@ _1 = torchx.specs.test.components.c.d
         ),
     )
     def test_load_custom_components_nogroup(self, _: MagicMock) -> None:
-        components = _load_components()
+        components = _load_components(None)
 
         # test component names are hardcoded expecting
         # test.components.* to be grouped under foo.*
@@ -166,16 +166,17 @@ _1 = torchx.specs.test.components.c.d
             self.assertEqual(expected_name, actual_name)
 
     def test_load_builtins(self) -> None:
-        components = _load_components()
+        components = _load_components(None)
 
         # if nothing registered in entrypoints, then builtins should be loaded
         expected = {
-            c.name for c in ModuleComponentsFinder("torchx.components", group="").find()
+            c.name
+            for c in ModuleComponentsFinder("torchx.components", group="").find(None)
         }
         self.assertEqual(components.keys(), expected)
 
     def test_load_builtin_echo(self) -> None:
-        components = _load_components()
+        components = _load_components(None)
         self.assertTrue(len(components) > 1)
         component = components["utils.echo"]
         self.assertEqual("utils.echo", component.name)
@@ -194,7 +195,7 @@ class CustomComponentsFinderTest(unittest.TestCase):
     def test_find_components(self) -> None:
         components = CustomComponentsFinder(
             current_file_path(), "_test_component"
-        ).find()
+        ).find(None)
         self.assertEqual(1, len(components))
         component = components[0]
         self.assertEqual(f"{current_file_path()}:_test_component", component.name)
@@ -205,7 +206,7 @@ class CustomComponentsFinderTest(unittest.TestCase):
     def test_find_components_without_docstring(self) -> None:
         components = CustomComponentsFinder(
             current_file_path(), "_test_component_without_docstring"
-        ).find()
+        ).find(None)
         self.assertEqual(1, len(components))
         component = components[0]
         self.assertEqual(


### PR DESCRIPTION
Summary: So that we can inject logic for verifying pipeline definitions. Currently the verifications are hardcoded to expect appdef

Reviewed By: lgarg26

Differential Revision: D70936713


