### PR TITLE
schedulers parameterized

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -363,7 +363,9 @@ class AWSBatchOpts(TypedDict, total=False):
     execution_role_arn: Optional[str]
 
 
-class AWSBatchScheduler(DockerWorkspaceMixin, Scheduler[AWSBatchOpts]):
+class AWSBatchScheduler(
+    DockerWorkspaceMixin, Scheduler[AWSBatchOpts, AppDef, AppDryRunInfo[BatchJob]]
+):
     """
     AWSBatchScheduler is a TorchX scheduling interface to AWS Batch.
 

--- a/torchx/schedulers/aws_sagemaker_scheduler.py
+++ b/torchx/schedulers/aws_sagemaker_scheduler.py
@@ -156,7 +156,10 @@ def _merge_ordered(
     return merged
 
 
-class AWSSageMakerScheduler(DockerWorkspaceMixin, Scheduler[AWSSageMakerOpts]):  # type: ignore[misc]
+class AWSSageMakerScheduler(
+    DockerWorkspaceMixin,
+    Scheduler[AWSSageMakerOpts, AppDef, AppDryRunInfo[AWSSageMakerJob]],
+):
     """
     AWSSageMakerScheduler is a TorchX scheduling interface to AWS SageMaker.
 

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -128,7 +128,9 @@ class DockerOpts(TypedDict, total=False):
     privileged: bool
 
 
-class DockerScheduler(DockerWorkspaceMixin, Scheduler[DockerOpts]):
+class DockerScheduler(
+    DockerWorkspaceMixin, Scheduler[DockerOpts, AppDef, AppDryRunInfo[DockerJob]]
+):
     """
     DockerScheduler is a TorchX scheduling interface to Docker.
 

--- a/torchx/schedulers/gcp_batch_scheduler.py
+++ b/torchx/schedulers/gcp_batch_scheduler.py
@@ -104,7 +104,7 @@ class GCPBatchOpts(TypedDict, total=False):
     location: Optional[str]
 
 
-class GCPBatchScheduler(Scheduler[GCPBatchOpts]):
+class GCPBatchScheduler(Scheduler[GCPBatchOpts, AppDef, AppDryRunInfo[GCPBatchJob]]):
     """
     GCPBatchScheduler is a TorchX scheduling interface to GCP Batch.
 

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -796,7 +796,9 @@ class KubernetesMCADOpts(TypedDict, total=False):
     network: Optional[str]
 
 
-class KubernetesMCADScheduler(DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts]):
+class KubernetesMCADScheduler(
+    DockerWorkspaceMixin, Scheduler[KubernetesMCADOpts, AppDef, AppDryRunInfo]
+):
     """
     KubernetesMCADScheduler is a TorchX scheduling interface to Kubernetes.
 

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -472,7 +472,10 @@ class KubernetesOpts(TypedDict, total=False):
     priority_class: Optional[str]
 
 
-class KubernetesScheduler(DockerWorkspaceMixin, Scheduler[KubernetesOpts]):
+class KubernetesScheduler(
+    DockerWorkspaceMixin,
+    Scheduler[KubernetesOpts, AppDef, AppDryRunInfo[KubernetesJob]],
+):
     """
     KubernetesScheduler is a TorchX scheduling interface to Kubernetes.
 

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -529,7 +529,7 @@ def _register_termination_signals() -> None:
         signal.signal(signal.SIGINT, _terminate_process_handler)
 
 
-class LocalScheduler(Scheduler[LocalOpts]):
+class LocalScheduler(Scheduler[LocalOpts, AppDef, AppDryRunInfo[PopenRequest]]):
     """
     Schedules on localhost. Containers are modeled as processes and
     certain properties of the container that are either not relevant

--- a/torchx/schedulers/lsf_scheduler.py
+++ b/torchx/schedulers/lsf_scheduler.py
@@ -395,7 +395,7 @@ class LsfBsub:
 {self.materialize()}"""
 
 
-class LsfScheduler(Scheduler[LsfOpts]):
+class LsfScheduler(Scheduler[LsfOpts, AppDef, AppDryRunInfo]):
     """
     **Example: hello_world**
 

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -114,7 +114,9 @@ if _has_ray:
         requirements: Optional[str] = None
         actors: List[RayActor] = field(default_factory=list)
 
-    class RayScheduler(TmpDirWorkspaceMixin, Scheduler[RayOpts]):
+    class RayScheduler(
+        TmpDirWorkspaceMixin, Scheduler[RayOpts, AppDef, AppDryRunInfo[RayJob]]
+    ):
         """
         RayScheduler is a TorchX scheduling interface to Ray. The job def
         workers will be launched as Ray actors

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -259,7 +259,9 @@ fi
 {self.materialize()}"""
 
 
-class SlurmScheduler(DirWorkspaceMixin, Scheduler[SlurmOpts]):
+class SlurmScheduler(
+    DirWorkspaceMixin, Scheduler[SlurmOpts, AppDef, AppDryRunInfo[SlurmBatchRequest]]
+):
     """
     SlurmScheduler is a TorchX scheduling interface to slurm. TorchX expects
     that slurm CLI tools are locally installed and job accounting is enabled.

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -35,10 +35,12 @@ from torchx.specs.api import (
 from torchx.workspace.api import WorkspaceMixin
 
 T = TypeVar("T")
+A = TypeVar("A")
+D = TypeVar("D")
 
 
 class SchedulerTest(unittest.TestCase):
-    class MockScheduler(Scheduler[T], WorkspaceMixin[None]):
+    class MockScheduler(Scheduler[T, A, D], WorkspaceMixin[None]):
         def __init__(self, session_name: str) -> None:
             super().__init__("mock", session_name)
 
@@ -151,7 +153,7 @@ class SchedulerTest(unittest.TestCase):
 
     def test_role_preproc_called(self) -> None:
         scheduler_mock = SchedulerTest.MockScheduler("test_session")
-        app_mock = MagicMock()
+        app_mock = AppDef(name="test")
         app_mock.roles = [MagicMock()]
 
         cfg = {"foo": "bar"}
@@ -161,7 +163,7 @@ class SchedulerTest(unittest.TestCase):
 
     def test_validate(self) -> None:
         scheduler_mock = SchedulerTest.MockScheduler("test_session")
-        app_mock = MagicMock()
+        app_mock = AppDef(name="test")
         app_mock.roles = [MagicMock()]
         app_mock.roles[0].resource = NULL_RESOURCE
 

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -157,6 +157,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
     def test_submit_dryrun_job_role_arn(self) -> None:
         cfg = AWSBatchOpts({"queue": "ignored_in_test", "job_role_arn": "fizzbuzz"})
         info = create_scheduler("test").submit_dryrun(_test_app(), cfg)
+        # pyre-ignore[16]
         node_groups = info.request.job_def["nodeProperties"]["nodeRangeProperties"]
         self.assertEqual(1, len(node_groups))
         self.assertEqual(cfg["job_role_arn"], node_groups[0]["container"]["jobRoleArn"])
@@ -166,6 +167,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
             {"queue": "ignored_in_test", "execution_role_arn": "veryexecutive"}
         )
         info = create_scheduler("test").submit_dryrun(_test_app(), cfg)
+        # pyre-ignore[16]
         node_groups = info.request.job_def["nodeProperties"]["nodeRangeProperties"]
         self.assertEqual(1, len(node_groups))
         self.assertEqual(
@@ -175,6 +177,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
     def test_submit_dryrun_privileged(self) -> None:
         cfg = AWSBatchOpts({"queue": "ignored_in_test", "privileged": True})
         info = create_scheduler("test").submit_dryrun(_test_app(), cfg)
+        # pyre-ignore[16]
         node_groups = info.request.job_def["nodeProperties"]["nodeRangeProperties"]
         self.assertEqual(1, len(node_groups))
         self.assertTrue(node_groups[0]["container"]["privileged"])
@@ -184,6 +187,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
         resource = specs.named_resources_aws.aws_p3dn_24xlarge()
         app = _test_app(num_replicas=2, resource=resource)
         info = create_scheduler("test").submit_dryrun(app, cfg)
+        # pyre-ignore[16]
         node_groups = info.request.job_def["nodeProperties"]["nodeRangeProperties"]
         self.assertEqual(1, len(node_groups))
         self.assertEqual(
@@ -196,6 +200,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
         resource = specs.named_resources_aws.aws_p3dn_24xlarge()
         app = _test_app(num_replicas=1, resource=resource)
         info = create_scheduler("test").submit_dryrun(app, cfg)
+        # pyre-ignore[16]
         node_groups = info.request.job_def["nodeProperties"]["nodeRangeProperties"]
         self.assertEqual(1, len(node_groups))
         self.assertTrue("instanceType" not in node_groups[0]["container"])
@@ -205,6 +210,7 @@ class AWSBatchSchedulerTest(unittest.TestCase):
         resource = specs.named_resources_aws.aws_p3dn_24xlarge()
         app = _test_app(num_replicas=2)
         info = create_scheduler("test").submit_dryrun(app, cfg)
+        # pyre-ignore[16]
         node_groups = info.request.job_def["nodeProperties"]["nodeRangeProperties"]
         self.assertEqual(1, len(node_groups))
         self.assertTrue("instanceType" not in node_groups[0]["container"])

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -515,7 +515,7 @@ spec:
             make_unique_ctx.return_value = "app-name-42"
             info = scheduler.submit_dryrun(app, cfg)
 
-        tasks = info.request.resource["spec"]["tasks"]
+        tasks = info.request.resource["spec"]["tasks"]  # pyre-ignore[16]
         container0 = tasks[0]["template"].spec.containers[0]
         self.assertIn("TORCHX_RANK0_HOST", container0.command)
         self.assertIn(


### PR DESCRIPTION
Summary:
Parameterize Scheduler
This not only more precisely expresses it's type (previously was unspecified generic variant of AppDryRunInfo[T] where T was unspecified; not it can be fully specified); This also allows us to inject PipelineDryRunInfo for schedulers that are pipeline schedulers

Differential Revision: D71023681


