### PR TITLE
Fix flaky compute_world_size test on devservers and make pyre happy

### DIFF
--- a/torchx/examples/apps/compute_world_size/config/__init__.py
+++ b/torchx/examples/apps/compute_world_size/config/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchx/examples/apps/compute_world_size/module/test/util_test.py
+++ b/torchx/examples/apps/compute_world_size/module/test/util_test.py
@@ -26,8 +26,8 @@ class UtilTest(unittest.TestCase):
                     "rank": 0,
                     "world_size": 1,
                     "master_addr": "localhost",
-                    # ephemeral port range in linux
-                    "master_port": random.randint(32768, 60999),
+                    # specifying 0 as master_port makes TCPStore chose a free random port
+                    "master_port": 0,
                     "backend": "gloo",
                 }
             }


### PR DESCRIPTION
Summary: Fixes tests that are flaky when running locally on devservers. Makes pyre happy for type checking `//torchx/schedulers/fb:ray_scheduler`

Reviewed By: manav-a, hstonec, tonykao8080

Differential Revision: D71576534


