### PR TITLE
Run CI actions on ubuntu 24.04 since ubuntu 20.04 is being deprecated on 04/01/2025

### DIFF
--- a/.github/workflows/aws-batch-integration-tests.yaml
+++ b/.github/workflows/aws-batch-integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   awsbatch:
-    runs-on: "linux.20_04.4x"
+    runs-on: linux.24_04.4x
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -12,20 +12,20 @@ jobs:
       matrix:
         include:
           - scheduler: "aws_batch"
-            platform: "linux.20_04.4x"
+            platform: linux.24_04.4x
           - scheduler: "aws_batch"
             container_repo: localhost
             extra_args: "--mock"
-            platform: "linux.20_04.4x"
+            platform: linux.24_04.4x
           - scheduler: "kubernetes"
             container_repo: localhost:5000/torchx
-            platform: "linux.20_04.16x"
+            platform: linux.24_04.4x
           - scheduler: "local_cwd"
-            platform: ubuntu-20.04
+            platform: ubuntu-latest
           - scheduler: "local_docker"
-            platform: "linux.20_04.4x"
+            platform: linux.24_04.4x
           - scheduler: "ray"
-            platform: ubuntu-20.04
+            platform: ubuntu-latest
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     permissions:

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: linux.24_04.4x
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   docbuild:
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -65,7 +65,7 @@ jobs:
           fi
 
   docpush:
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     needs: docbuild
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:

--- a/.github/workflows/gcp-batch-integration-tests.yaml
+++ b/.github/workflows/gcp-batch-integration-tests.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   gcpbatch:
     if: github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-20.04
+    runs-on: linux.24_04.4x
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/kfp-integration-tests.yaml
+++ b/.github/workflows/kfp-integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   kfp-launch:
-    runs-on: linux.20_04.16x
+    runs-on: inux.24_04.16x
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/kubernetes-minikube-integration-test.yaml
+++ b/.github/workflows/kubernetes-minikube-integration-test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   kubernetes-launch:
-    runs-on: "linux.20_04.16x"
+    runs-on: linux.24_04.16x
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   nightly:
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     steps:
       - name: Setup Python 3.10
         uses: actions/setup-python@v2

--- a/.github/workflows/pyre.yaml
+++ b/.github/workflows/pyre.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pyre:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9, "3.10", 3.11, 3.12]
-        platform: ["linux.20_04.4x"]
+        platform: [linux.24_04.4x]
         include:
-          - python-version: 3.9
-            platform: macos-12-xl
+          - python-version: 3.12
+            platform: macos-13-xlarge
       fail-fast: false
     env:
       OS: ${{ matrix.platform }}


### PR DESCRIPTION
Summary:
We've been getting a bunch of warnings in our CI because ubuntu 20.04 is being deprecated in a few days. This change upgrades us to ubuntu 24.04

 {F1976524616}

Differential Revision: D72004581
