### PR TITLE
Fix broken doc-push

### DIFF
--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -54,8 +54,12 @@ else
     redirects=(latest main)
 fi
 
-echo "Installing torchx from $repo_root..."
+echo "Installing TorchX and Doc dependencies from $repo_root..."
 cd "$repo_root" || exit
+
+# First install doc requirements, then install torchx
+# so that torchx's pinned requirements are honored
+pip install -r docs/requirements.txt
 pip uninstall -y torchx
 pip install -r dev-requirements.txt
 python setup.py install
@@ -66,7 +70,7 @@ echo "Building torchx-$torchx_ver docs..."
 docs_dir=$repo_root/docs
 build_dir=$docs_dir/build
 cd "$docs_dir" || exit
-pip install -r requirements.txt
+
 make clean html
 echo "Doc build complete"
 


### PR DESCRIPTION
Summary:
I fixed doc-build in https://github.com/pytorch/torchx/pull/1033 by:

1. pinning `protobuf-3.20.x` in torchx's `dev-requirements.txt` since `apache-airflow` (defined in `docs/requirements.txt`) was upgrading to `protobuf>=5.x` which is incompatible with `kfp-1.8.x`.
2. installing `doc/requirements.txt` FIRST, then installing `torchx` so that the pinned version of `protobuf` is honored.

The above fixes `doc-build` but not `doc-push` because `doc-push` runs `scripts/doc-push.sh` which needed the same change as #2.

Differential Revision: D72059926


