### PR TITLE
[torchx][CI] Run k8s integration test on linux.24_04.4x since the *.1…

### DIFF
--- a/.github/workflows/kubernetes-minikube-integration-test.yaml
+++ b/.github/workflows/kubernetes-minikube-integration-test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   kubernetes-launch:
-    runs-on: linux.24_04.16x
+    runs-on: linux.24_04.4x
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
k8s integ tests are failing because `linux.24_04.16x` takes too long to acquire. Switch over to a smaller instance (`linux.24_04.4x`).