### PR TITLE
decouple torchx native scuba logging and  ttfb

### DIFF
--- a/torchx/util/test/modules_test.py
+++ b/torchx/util/test/modules_test.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import unittest
 
-from torchx.util.modules import load_module
+from torchx.util.modules import import_attr, load_module
 
 
 class ModulesTest(unittest.TestCase):
@@ -21,3 +23,23 @@ class ModulesTest(unittest.TestCase):
         import os
 
         self.assertEqual(result, os.path.join)
+
+    def test_try_import(self) -> None:
+        def _join(_0: str, *_1: str) -> str:
+            return ""  # should never be called
+
+        os_path_join = import_attr("os.path", "join", default=_join)
+        import os
+
+        self.assertEqual(os.path.join, os_path_join)
+
+    def test_try_import_non_existent_module(self) -> None:
+        should_default = import_attr("non.existent", "foo", default="bar")
+        self.assertEqual("bar", should_default)
+
+    def test_try_import_non_existent_attr(self) -> None:
+        def _join(_0: str, *_1: str) -> str:
+            return ""  # should never be called
+
+        with self.assertRaises(AttributeError):
+            import_attr("os.path", "joyin", default=_join)


### PR DESCRIPTION
Summary:
Split out ttfb into its own logging handler and only hook it up to `torchx.runner.events.handler` if the module is included. Also splits out ttfb into its own BUCK target (`//torchx/runner/events/fb:ttfb`)

NOTE: Dependants of //torchx/runner:lib will still get ttfb since I added an manual dep to //torchx/runner/events/fb:ttfb to it. Otherwise users now have to explicitly add a dep to ttfb.

## Motivation
ttfb pulls unwanted deps such as quickflow (see output of `buck cquery "deps(//torchx/runner/events/fb:ttfb)"`). This prevents us from creating `torchx-lite` - a minimal set of torchx APIs (with no scheduler/workspace implementations pulled transitively).

## Other Notes

Removed the unused `//torchx/runner/events:handlers_oss` targets which was confusing autodeps - hence requiring `autodeps-skip` in `//torchx/runner/events:lib`

Differential Revision: D73060221


