### PR TITLE
support AppStatus json output format

### DIFF
--- a/torchx/cli/cmd_status.py
+++ b/torchx/cli/cmd_status.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import argparse
+import json
 import logging
 import sys
 from typing import List, Optional
@@ -46,6 +47,11 @@ class CmdStatus(SubCommand):
         subparser.add_argument(
             "--roles", type=str, default="", help="comma separated roles to filter"
         )
+        subparser.add_argument(
+            "--json",
+            action="store_true",
+            help="output the status in JSON format",
+        )
 
     def run(self, args: argparse.Namespace) -> None:
         app_handle = args.app_handle
@@ -54,7 +60,10 @@ class CmdStatus(SubCommand):
         app_status = runner.status(app_handle)
         filter_roles = parse_list_arg(args.roles)
         if app_status:
-            print(app_status.format(filter_roles))
+            if args.json:
+                print(json.dumps(app_status.to_json(filter_roles)))
+            else:
+                print(app_status.format(filter_roles))
         else:
             logger.error(
                 f"AppDef: {app_id},"

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -176,6 +176,42 @@ Traceback (most recent call last):
         # Split and compare to aviod AssertionError.
         self.assertEqual(expected_message.split(), actual_message.split())
 
+    def test_app_status_in_json(self) -> None:
+        app_status = self._get_test_app_status()
+        result = app_status.to_json()
+        error_msg = '{"message":{"message":"error","errorCode":-1,"extraInfo":{"timestamp":1293182}}}'
+        self.assertDictEqual(
+            result,
+            {
+                "state": "RUNNING",
+                "num_restarts": 0,
+                "roles": [
+                    {
+                        "role": "worker",
+                        "replicas": [
+                            {
+                                "id": 0,
+                                "state": 5,
+                                "role": "worker",
+                                "hostname": "localhost",
+                                "structured_error_msg": error_msg,
+                            },
+                            {
+                                "id": 1,
+                                "state": 3,
+                                "role": "worker",
+                                "hostname": "localhost",
+                                "structured_error_msg": "<NONE>",
+                            },
+                        ],
+                    }
+                ],
+                "msg": "",
+                "structured_error_msg": "<NONE>",
+                "url": None,
+            },
+        )
+
 
 class ResourceTest(unittest.TestCase):
     def test_copy_resource(self) -> None:


### PR DESCRIPTION
Summary:
Enable json output format to show AppStatus

What added:
1. Add `--json` subcommand for `status`, default is False
2. Parse both AppStatus and RoleStatus to dictionary format
3. json.dump dictionary in output
4. Add unit test

Differential Revision: D73180040


