### PR TITLE
Create //torchx/specs:lib_core

### DIFF
--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -13,7 +13,7 @@ used by components to define the apps which can then be launched via a TorchX
 scheduler or pipeline adapter.
 """
 import difflib
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Mapping, Optional
 
 from torchx.specs.api import (
     ALL,
@@ -48,11 +48,16 @@ from torchx.specs.api import (
 )
 from torchx.specs.builders import make_app_handle, materialize_appdef, parse_mounts
 
-from torchx.specs.named_resources_aws import NAMED_RESOURCES as AWS_NAMED_RESOURCES
-from torchx.specs.named_resources_generic import (
-    NAMED_RESOURCES as GENERIC_NAMED_RESOURCES,
-)
 from torchx.util.entrypoints import load_group
+
+from torchx.util.modules import import_attr
+
+AWS_NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = import_attr(
+    "torchx.specs.named_resources_aws", "NAMED_RESOURCES", default={}
+)
+GENERIC_NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = import_attr(
+    "torchx.specs.named_resources_generic", "NAMED_RESOURCES", default={}
+)
 
 GiB: int = 1024
 

--- a/torchx/specs/finder.py
+++ b/torchx/specs/finder.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, Dict, Generator, List, Optional, Union
 
-from torchx.specs import AppDef
 from torchx.specs.file_linter import get_fn_docstring, TorchxFunctionValidator, validate
 from torchx.util import entrypoints
 from torchx.util.io import read_conf_file


### PR DESCRIPTION
Summary:
IMPORTANT:  If you believe you are broken by this diff due to autodeps/codemod having removed a dep to 
`//torchx/specs:api` in favor of `//torchx/specs:lib_core` then try adding a manual (`# manual`) dep to `//torchx/specs/fb:api_extended` to fix forward.  

**Example:** 
```
python_library|binary(  
  name = "my-lib-or-bin",
  srcs = [...],
  deps = [
    "//torchx/specs:lib_core", # <-- added by autodeps codemod
    "//torchx/specs/fb:api_extended", # manual <-- manually add api_extended
    ...
  ]
)
```

Milestone 1.1 of torchx-lite (see [doc](https://fburl.com/gdoc/4wxcoaoa) for details)

Creates `//torchx/specs:lib_core` with only the source files of `torchx.specs` module and a minimal set of dependencies for a proper closure of this module.

For BC, we keep `//torchx/specs:lib` and `//torchx/specs:api` as is by adding the existing bundled deps as `manual` so that autodeps doesn't remove them on future codemods.

Switches over to `//torchx/specs:lib_core` for TorchX internal targets (e.g. within `//torchx/...`).

Differential Revision: D73195094


