### PR TITLE
Allow empty session name for APIs that take it

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -1115,14 +1115,31 @@ class UnknownAppException(Exception):
 
 def parse_app_handle(app_handle: AppHandle) -> ParsedAppHandle:
     """
-    parses the app handle into ```(scheduler_backend, session_name, and app_id)```
+    Parses the app handle into ```(scheduler_backend, session_name, and app_id)```.
+
+    Example:
+
+    .. doctest::
+
+     assert parse_app_handle("k8s://default/foo_bar") == ("k8s", "default", "foo_bar")
+     assert parse_app_handle("k8s:///foo_bar") == ("k8s", "", "foo_bar")
+
+    Args:
+        app_handle: a URI of the form ``{scheduler}://{session_name}/{app_id}``,
+            where the ``session_name`` is optional. In this case the app handle is
+            of the form ``{scheduler}:///{app_id}`` (notice the triple slashes).
+
+    Returns: A ``Tuple`` of three elements, ``(scheduler, session_name, app_id)``
+        parsed from the app_handle URI str. If the session name is not present then
+        an empty string is returned in its place in the tuple.
+
     """
 
     # parse it manually b/c currently torchx does not
     # define allowed characters nor length for session name and app_id
     import re
 
-    pattern = r"(?P<scheduler_backend>.+)://(?P<session_name>.+)/(?P<app_id>.+)"
+    pattern = r"(?P<scheduler_backend>.+)://(?P<session_name>.*)/(?P<app_id>.+)"
     match = re.match(pattern, app_handle)
     if not match:
         raise MalformedAppHandleException(app_handle)

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -377,6 +377,15 @@ class AppHandleTest(unittest.TestCase):
                 with self.assertRaises(MalformedAppHandleException):
                     parse_app_handle(handle)
 
+    def test_parse_app_handle_empty_session_name(self) -> None:
+        # missing session name is not OK but an empty one is
+        app_handle = "local:///my_application_id"
+        handle = parse_app_handle(app_handle)
+
+        self.assertEqual(handle.app_id, "my_application_id")
+        self.assertEqual("local", handle.scheduler_backend)
+        self.assertEqual("", handle.session_name)
+
     def test_parse(self) -> None:
         (scheduler_backend, session_name, app_id) = parse_app_handle(
             "local://my_session/my_app_id_1234"


### PR DESCRIPTION
Summary:
Makes the session name returning and accepting APIs symmetric by allowing empty session names.

Today `torchx.runner.Runner()` takes an empty string as `session_name` and returns an `app_handle` with an empty session name (e.g. `local:///app-id`) when the `run()` or `schedule()` methods are called (see the newly added unittest in `torchx/runner/test/api_test.py#test_empty_session_id()`)

However runner APIs that accept `app_handle` (e.g. `runner.cancel()`) will error when the session name is empty.  This makes the APIs non-symmetric since the `app_handle` returned by `run/schedule` APIs cannot be used.

This PR fixes this.

Differential Revision: D73799333


