### PR TITLE
[torchx][CI] Run slurm integration test on linux.24_04.4x

### DIFF
--- a/.github/workflows/slurm-local-integration-tests.yaml
+++ b/.github/workflows/slurm-local-integration-tests.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   slurm:
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
linux.20_04 is deprecated (see: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)

I missed updating slurm integ test in https://github.com/pytorch/torchx/pull/1032.