### PR TITLE
[torchx][ci] Pin pip-25.0.1 since pip-25.1 breaks editable installs of torchx[dev]

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -28,6 +28,14 @@ jobs:
           architecture: x64
       - name: Checkout TorchX
         uses: actions/checkout@v2
+      - name: Pin pip-25.0.1
+        run: |
+          set -eux
+          # required since pip-25.1 breaks a few old deps in dev-requirements.txt
+          # (upgrading those will take some time)
+          # see: https://pip.pypa.io/en/stable/news/#v25-1
+          python -m pip install pip==25.0.1
+          pip --version
       - name: Install dependencies
         run: |
           set -eux

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,6 @@ kubernetes==25.3.0
 flake8==3.9.0
 fsspec==2024.3.1
 s3fs==2024.3.1
-google-api-core
 google-cloud-batch==0.17.14
 google-cloud-logging==3.10.0
 google-cloud-runtimeconfig==0.34.0


### PR DESCRIPTION
Solves python unittests failing with:
```
ERROR: Exception:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 105, in _run_wrapper
    status = _inner_run()
  File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 96, in _inner_run
    return self.run(options, args)
  File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 68, in wrapper
    return func(self, options, args)
  File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_internal/commands/install.py", line 421, in run
    reqs_to_build = [
  File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_internal/commands/install.py", line 424, in <listcomp>
    if should_build_for_install_command(r)
  File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_internal/wheel_builder.py", line 65, in should_build_for_install_command
    return _should_build(req)
  File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_internal/wheel_builder.py", line 53, in _should_build
    assert req.source_dir
AssertionError
```
see: https://github.com/pytorch/torchx/actions/runs/14781211083/job/41500352685?pr=1057
