### PR TITLE
feat: add quoting support to to_dict (#1052) (#1053)

### DIFF
--- a/torchx/util/test/types_test.py
+++ b/torchx/util/test/types_test.py
@@ -197,6 +197,11 @@ class TypesTest(unittest.TestCase):
             to_dict("key1=value1,,foo=bar"),
         )
 
+        self.assertDictEqual(
+            {"FOO": "value with = and , and ;"},
+            to_dict('FOO="value with = and , and ;"'),
+        )
+
     def test_to_dict_malformed_literal(self) -> None:
         for malformed in ["FOO", "FOO,", "FOO;", "FOO=", "FOO=;BAR=v1"]:
             with self.subTest(malformed=malformed):


### PR DESCRIPTION
Summary:
See https://github.com/pytorch/torchx/issues/1052


Test Plan:
[x] all existing test cases pass

[x] add new test case

[x] test locally:

Given:
```
[component:dist.ddp]
script=test.py
env=
	NCCL_IB_HCA='=mlx5_0:1,mlx5_1:1';
```

Observe:
```
test/0 [7]:environ({...'NCCL_IB_HCA': '=mlx5_0:1,mlx5_1:1', ...})
```

Differential Revision: D74185528

Pulled By: andywag


