### PR TITLE
(torchx/local_scheduler) Use os.kill instead of os.killpg when sending SIGTERM to the replica pid. Add runner.wait() for torchx.runner.test.api_test#test_empty_session_id to gracefully wait for the replicas to finish running

### DIFF
--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -153,6 +153,7 @@ class RunnerTest(TestWithTmpDir):
             )
 
             app_handle = runner.run(app, "local", self.cfg)
+            runner.wait(app_handle, wait_interval=0.1)
 
             scheduler, session_name, app_id = parse_app_handle(app_handle)
             self.assertEqual(scheduler, "local")

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -311,7 +311,7 @@ class _LocalReplica:
         """
         # safe to call terminate on a process that already died
         try:
-            os.killpg(self.proc.pid, signal.SIGTERM)
+            os.kill(self.proc.pid, signal.SIGTERM)
         except ProcessLookupError as e:
             log.debug(f"Process {self.proc.pid} already got terminated")
 


### PR DESCRIPTION
Summary:
Fixes macos unittest failures: https://github.com/pytorch/torchx/actions/runs/14844253481/job/41674243877

When looking into the test failure I noticed two things:

1. `local_scheduler` was trying to SIGTERM the process group by passing the replica's pid:  `os.killpg(replica.pid, signal.SIGTERM)` . Changed to call `os.kill`. (note that `os.killpg` is not available on iOS which is why the test was failing).

2. The `torchx.runner.test.api_test.test_empty_session_id()` test case doesn't wait for the `echo` test command to finish hence there was a race condition where in certain cases the runner's `__exit__()` SIGTERMs the replica pids but since the `local_scheduler` was (wronfully) using `os.killpg` not `os.kill` it threw an uncaught error in iOS.

Differential Revision: D74197282


