### PR TITLE
(torchx/local_scheduler) go back to using os.killpg in local_scheduler

### DIFF
--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -311,7 +311,7 @@ class _LocalReplica:
         """
         # safe to call terminate on a process that already died
         try:
-            os.kill(self.proc.pid, signal.SIGTERM)
+            os.killpg(self.proc.pid, signal.SIGTERM)
         except ProcessLookupError as e:
             log.debug(f"Process {self.proc.pid} already got terminated")
 


### PR DESCRIPTION
Summary: Reverting the os.killpg -> os.kill part of https://github.com/pytorch/torchx/pull/1062.

Reviewed By: d4l3k

Differential Revision: D74205288


