### PR TITLE
Add application metadata to the describe API's return value

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -597,7 +597,7 @@ class Runner:
             if not app:
                 desc = scheduler.describe(app_id)
                 if desc:
-                    app = AppDef(name=app_id, roles=desc.roles)
+                    app = AppDef(name=app_id, roles=desc.roles, metadata=desc.metadata)
             return app
 
     def log_lines(

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -440,6 +440,7 @@ class RunnerTest(TestWithTmpDir):
 
     def test_describe(self, _) -> None:
         with self.get_runner() as runner:
+            metadata = {"a": "b", "c": "d"}
             role = Role(
                 name="sleep",
                 image=str(self.tmpdir),
@@ -447,7 +448,7 @@ class RunnerTest(TestWithTmpDir):
                 entrypoint="sleep",
                 args=["60"],
             )
-            app = AppDef("sleeper", roles=[role])
+            app = AppDef("sleeper", roles=[role], metadata=metadata)
 
             app_handle = runner.run(app, scheduler="local_dir", cfg=self.cfg)
             self.assertEqual(app, runner.describe(app_handle))

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -43,7 +43,7 @@ class DescribeAppResponse:
     the status and description of the application as known by the scheduler.
     For some schedulers implementations this response object has necessary
     and sufficient information to recreate an ``AppDef`` object. For these types
-    of schedulers, the user can re-``run()`` the recreted application. Otherwise
+    of schedulers, the user can re-``run()`` the recreated application. Otherwise
     the user can only call non-creating methods (e.g. ``wait()``, ``status()``,
     etc).
 
@@ -61,6 +61,7 @@ class DescribeAppResponse:
     msg: str = NONE
     structured_error_msg: str = NONE
     ui_url: Optional[str] = None
+    metadata: dict[str, str] = field(default_factory=dict)
 
     roles_statuses: List[RoleStatus] = field(default_factory=list)
     roles: List[Role] = field(default_factory=list)


### PR DESCRIPTION
Summary: Today torchx's describe API does not capture the job's metadata from the scheduler. This diff adds a `metadata` field to the describe API so that the schedulers can hydrate the metadata field in their describe APIs.

Differential Revision: D74438626


