### PR TITLE
slurm: support clusters without sacct

### DIFF
--- a/torchx/cli/cmd_list.py
+++ b/torchx/cli/cmd_list.py
@@ -21,6 +21,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 HANDLE_HEADER = "APP HANDLE"
 STATUS_HEADER = "APP STATUS"
+NAME_HEADER = "APP NAME"
 
 
 class CmdList(SubCommand):
@@ -39,5 +40,7 @@ class CmdList(SubCommand):
     def run(self, args: argparse.Namespace) -> None:
         with get_runner() as runner:
             apps = runner.list(args.scheduler)
-            apps_data = [[app.app_handle, str(app.state)] for app in apps]
-            print(tabulate(apps_data, headers=[HANDLE_HEADER, STATUS_HEADER]))
+            apps_data = [[app.app_handle, app.name, str(app.state)] for app in apps]
+            print(
+                tabulate(apps_data, headers=[HANDLE_HEADER, NAME_HEADER, STATUS_HEADER])
+            )

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -86,6 +86,7 @@ class ListAppResponse:
     app_id: str
     state: AppState
     app_handle: str = "<NOT_SET>"
+    name: str = ""
 
     # Implementing __hash__() makes ListAppResponse hashable which makes
     # it easier to check if a ListAppResponse object exists in a list of


### PR DESCRIPTION
<!-- Change Summary -->

Many bare-bones slurm clusters aren't configured with accounting enabled (sacct) as it requires an external SQL database. This makes torchx slurm scheduler list/describe/status methods fallback to squeue which will show currently running jobs.

It also shows the job name in `torchx list` as slurm job_ids are just numbers

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

```
pytest torchx/schedulers/test/slurm_scheduler_test.py
```

```
(pytorch-3.12) ubuntu@slurm-head-node-0:~/tristanr/runner$ torchx status slurm://torchx/163
Slurm accounting storage is disabled
AppStatus:
    State: RUNNING
    Num Restarts: -1
    Roles: 
 *train[0]:RUNNING
    Msg: RUNNING
    Structured Error Msg: <NONE>
    UI URL: None
    
(pytorch-3.12) ubuntu@slurm-head-node-0:~/tristanr/runner$ torchx list -s slurm
Slurm accounting storage is disabled
APP HANDLE          APP NAME    APP STATUS
------------------  ----------  ------------
slurm://torchx/163  train-0     RUNNING
```
