### PR TITLE
build: Unpin urllib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ docker
 filelock
 fsspec>=2023.10.0
 # To resolve confliciting dependencies for urllib3: https://github.com/pytorch/torchx/actions/runs/3484190429/jobs/5828784263#step:4:552
-urllib3<1.27,>=1.21.1
+urllib3>=1.21.1
 tabulate


### PR DESCRIPTION
This pin makes it difficult to integrate downstream libraries into other projects

<!-- Change Summary -->

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
