### PR TITLE
update pyre version

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -18,5 +18,6 @@
     "stubs"
   ],
   "strict": true,
-  "version": "0.0.101732536891"
+  "enable_strict_any_check": true,
+  "version": "0.0.101749035478"
 }


### PR DESCRIPTION
Summary:
Updating to a new version of pyre since the one we used has been removed from pip (too old).
Recently it seems pyre configs have changed and we need a special argument to enable strict "no Any type" checks.

Differential Revision: D75996666


