### PR TITLE
(6/n - non-xlformers conda-on-mast mvp)(torchx/runner) Create //torchx/runner:lib_core with no plugin bundling

### DIFF
--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -470,20 +470,17 @@ image = foobar_custom
         sfile = StringIO()
         dump(sfile)
 
-        scheduler_factories = {
-            **get_scheduler_factories(),
-            **(
-                get_scheduler_factories(
-                    group="torchx.schedulers.orchestrator", skip_defaults=True
-                )
-                or {}
-            ),
-        }
+        scheduler_factories = get_scheduler_factories()
 
         for sched_name, sched in scheduler_factories.items():
             sfile.seek(0)  # reset the file pos
             cfg = {}
-            load(scheduler=sched_name, f=sfile, cfg=cfg)
+            try:
+                load(scheduler=sched_name, f=sfile, cfg=cfg)
+            except ModuleNotFoundError:
+                # just test the ones that have been installed
+                continue
+
             for opt_name, _ in sched("test").run_opts():
                 self.assertTrue(
                     opt_name in cfg,


### PR DESCRIPTION
Summary:
See details in [torchx-lite](https://docs.google.com/document/d/1Y_DzoRMAKhqbzE2LQDb7k3H5R-4PnkYdA9R4YLLFLk4/edit?tab=t.0#heading=h.unqedx38434n) doc.

Creates a pure core library target for `torchx.runner` called `//torchx/runner:lib_core`.

Similar to D77394064 which creates `//torchx/schedulers:lib_core`

NOTE: I added a `autodeps_redirect` to `//torchx/runner:lib` from `:lib_core`. I've noticed that autodeps honors this in some cases but not in others (read IMPORTANT note below if you are finding that autodeps is removing `:lib` in favor of `:lib_core`)

IMPORTANT: If you wind up here because autodeps is removing `//torchx/runner:lib` in favor of `//torchx/runner:lib_core`, you have two options (see below). OPTION 2 is preferred since you'll only pull in what you need (not the entire universe of plugins).
 
OPTION 1. Add `# manual` tag to the existing `//torchx/runner:lib` 
```
... 
  deps = [
   "//torchx/runner:lib_core", # <-- autodeps will still add this (which is OK)
    "//torchx/runner:lib", # manual
    ...
  ]
...
```

OPTION 2:
Accept the swap to `//torchx/runner:lib_core` and add any  plugins that you need with `# manual`

```
... 
  deps = [
   "//torchx/runner:lib_core",
    "//torchx/schedulers/fb:mast_scheduler", # manual (mast scheduler plugin)
    ...
  ]
...
```

Reviewed By: highker

Differential Revision: D77400710


