### PR TITLE
feat: add aws p5e instance type as named resources

### DIFF
--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -120,6 +120,16 @@ def aws_p5_48xlarge() -> Resource:
     )
 
 
+def aws_p5e_48xlarge() -> Resource:
+    return Resource(
+        cpu=192,
+        gpu=8,
+        memMB=2048 * GiB,
+        capabilities={K8S_ITYPE: "p5e.48xlarge"},
+        devices={EFA_DEVICE: 32},
+    )
+
+
 def aws_p5en_48xlarge() -> Resource:
     return Resource(
         cpu=192,
@@ -419,6 +429,7 @@ NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = {
     "aws_p4d.24xlarge": aws_p4d_24xlarge,
     "aws_p4de.24xlarge": aws_p4de_24xlarge,
     "aws_p5.48xlarge": aws_p5_48xlarge,
+    "aws_p5e.48xlarge": aws_p5e_48xlarge,
     "aws_p5en.48xlarge": aws_p5en_48xlarge,
     "aws_g4dn.xlarge": aws_g4dn_xlarge,
     "aws_g4dn.2xlarge": aws_g4dn_2xlarge,

--- a/torchx/specs/test/named_resources_aws_test.py
+++ b/torchx/specs/test/named_resources_aws_test.py
@@ -44,6 +44,7 @@ from torchx.specs.named_resources_aws import (
     aws_p4d_24xlarge,
     aws_p4de_24xlarge,
     aws_p5_48xlarge,
+    aws_p5e_48xlarge,
     aws_p5en_48xlarge,
     aws_t3_medium,
     aws_trn1_2xlarge,
@@ -95,12 +96,18 @@ class NamedResourcesTest(unittest.TestCase):
 
     def test_aws_p5(self) -> None:
         p5 = aws_p5_48xlarge()
+        p5e = aws_p5e_48xlarge()
         p5en = aws_p5en_48xlarge()
 
         self.assertEqual(192, p5.cpu)
         self.assertEqual(8, p5.gpu)
         self.assertEqual(2048 * GiB, p5.memMB)
         self.assertEqual({EFA_DEVICE: 32}, p5.devices)
+
+        self.assertEqual(192, p5e.cpu)
+        self.assertEqual(8, p5e.gpu)
+        self.assertEqual(2048 * GiB, p5e.memMB)
+        self.assertEqual({EFA_DEVICE: 32}, p5e.devices)
 
         self.assertEqual(192, p5en.cpu)
         self.assertEqual(8, p5en.gpu)


### PR DESCRIPTION
As described in title

Test plan:

```
test_aws_c5_18xlarge (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_c5_18xlarge) ... ok
test_aws_g4dn (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_g4dn) ... ok
test_aws_g5 (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_g5) ... ok
test_aws_g6e (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_g6e) ... ok
test_aws_inf2 (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_inf2) ... ok
test_aws_m5_2xlarge (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_m5_2xlarge) ... ok
test_aws_p3 (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_p3) ... ok
test_aws_p4 (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_p4) ... ok
test_aws_p5 (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_p5) ... ok
test_aws_t3_medium (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_t3_medium) ... ok
test_aws_trn1 (specs.test.named_resources_aws_test.NamedResourcesTest.test_aws_trn1) ... ok
test_capabilities (specs.test.named_resources_aws_test.NamedResourcesTest.test_capabilities) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.002s

OK
Finished running tests!
```
