### PR TITLE
Add ntasks for older slurm versions.

### DIFF
--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -210,6 +210,7 @@ class SlurmReplicaRequest:
                     sbatch_opts.setdefault("gpus-per-node", str(resource.gpu))
                 else:
                     sbatch_opts.setdefault("gpus-per-task", str(resource.gpu))
+                    sbatch_opts.setdefault("ntasks", "1")
 
         srun_opts = {
             "output": f"slurm-{macros.app_id}-{name}.out",

--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -128,6 +128,7 @@ class SlurmSchedulerTest(unittest.TestCase):
                 "--cpus-per-task=2",
                 "--mem=10",
                 "--gpus-per-task=3",
+                "--ntasks=1",
             ],
         )
         self.assertEqual(
@@ -163,6 +164,7 @@ class SlurmSchedulerTest(unittest.TestCase):
                 "--ntasks-per-node=1",
                 "--cpus-per-task=2",
                 "--gpus-per-task=3",
+                "--ntasks=1",
             ],
         )
 


### PR DESCRIPTION
Without this flag, on slurm 23.11.10 we get this error:

```
sbatch: error: Failed to validate job spec. --gpus-per-task or --tres-per-task used without either --gpus or -n/--ntasks is not allowed.
sbatch: error: Invalid generic resource (gres) specification
```

Test plan:

Manually tested with slurm 23.11.10 and made sure the job was launched