### PR TITLE
(torchx/runner)(dead code elimination) Remove `build_standalone_workspace` from runner API

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -164,18 +164,6 @@ class Runner:
         for scheduler in self._scheduler_instances.values():
             scheduler.close()
 
-    def build_standalone_workspace(
-        self,
-        workspace_builder: WorkspaceBuilder[S, T],
-        sync: bool = True,
-    ) -> PkgInfo[S]:
-        """
-        Build a standalone workspace for the given role.
-        This method is used to build a workspace for a role independent of the scheduler and
-        also enables asynchronous workspace building using the Role overrides.
-        """
-        return workspace_builder.build_workspace(sync)
-
     def run_component(
         self,
         component: str,


### PR DESCRIPTION
Summary: This instance method has no self references and can be removed to simplify `Runner`

Differential Revision: D81277272


