### PR TITLE
Support JSON input to torchx run

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -25,6 +25,7 @@ from typing import (
     Type,
     TYPE_CHECKING,
     TypeVar,
+    Union,
 )
 
 from torchx.runner.events import log_event
@@ -167,7 +168,7 @@ class Runner:
     def run_component(
         self,
         component: str,
-        component_args: List[str],
+        component_args: Union[list[str], dict[str, Any]],
         scheduler: str,
         cfg: Optional[Mapping[str, CfgVal]] = None,
         workspace: Optional[str] = None,
@@ -226,7 +227,7 @@ class Runner:
     def dryrun_component(
         self,
         component: str,
-        component_args: List[str],
+        component_args: Union[list[str], dict[str, Any]],
         scheduler: str,
         cfg: Optional[Mapping[str, CfgVal]] = None,
         workspace: Optional[str] = None,
@@ -237,10 +238,13 @@ class Runner:
         component, but just returns what "would" have run.
         """
         component_def = get_component(component)
+        args_from_cli = component_args if isinstance(component_args, list) else []
+        args_from_json = component_args if isinstance(component_args, dict) else {}
         app = materialize_appdef(
             component_def.fn,
-            component_args,
+            args_from_cli,
             self._component_defaults.get(component, None),
+            args_from_json,
         )
         return self.dryrun(
             app,

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -225,5 +225,8 @@ __all__ = [
     "make_app_handle",
     "materialize_appdef",
     "parse_mounts",
+    "torchx_run_args_from_argparse",
+    "torchx_run_args_from_json",
+    "TorchXRunArgs",
     "ALL",
 ]

--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -213,7 +213,11 @@ def component_args_from_str(
         arg_value = getattr(parsed_args, param_name)
         parameter_type = parameter.annotation
         parameter_type = decode_optional(parameter_type)
-        arg_value = decode(arg_value, parameter_type)
+        if (
+            parameter_type != arg_value.__class__
+            and parameter.kind != inspect.Parameter.VAR_POSITIONAL
+        ):
+            arg_value = decode(arg_value, parameter_type)
         if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
             var_args = arg_value
         elif parameter.kind == inspect.Parameter.KEYWORD_ONLY:


### PR DESCRIPTION
Summary:
add support for piping a json into torchx run command, like

`JSON | torchx run`

where the JSON contains the args for torchx run (while maintaining the functionality of the regular CLI)

This can be done with either a JSON directly in the terminal or `cat json_file.json`. 

Next steps:
- add a json schema to improve authoring experience for this new config format 
- more robust validation 
- accept varargs for component args/ test this case

Reviewed By: daniel-ohayon

Differential Revision: D80731827


