### PR TITLE
(torchx/specs) component fn python-3.10 compatibility. Support BinOp for optional types and builtin container types.

### DIFF
--- a/docs/source/specs.rst
+++ b/docs/source/specs.rst
@@ -90,17 +90,17 @@ Component Linter
 .. autoclass:: LinterMessage
    :members:
 
-.. autoclass:: TorchFunctionVisitor
+.. autoclass:: ComponentFnVisitor
    :members:
 
 .. autoclass:: TorchXArgumentHelpFormatter
    :members:
 
-.. autoclass:: TorchxFunctionArgsValidator
+.. autoclass:: ArgTypeValidator
    :members:
 
-.. autoclass:: TorchxFunctionValidator
+.. autoclass:: ComponentFunctionValidator
    :members:
 
-.. autoclass:: TorchxReturnValidator
+.. autoclass:: ReturnTypeValidator
    :members:


### PR DESCRIPTION
Summary:
For python-3.10, support type annotations in component fn arguments using builtin `dict`, `list`, `tuple` types and `|` for Optional types.

Allows component fn to be typed as:

```
def foo(env: dict[str, str] | None):
   pass
```

versus

```
from typing import Dict, Optional

def foo(env: Optional[Dict[str, str]]):
  pass
```

Reviewed By: highker

Differential Revision: D81826386
