### PR TITLE
Fix issue handling function with decorator

### DIFF
--- a/torchx/specs/finder.py
+++ b/torchx/specs/finder.py
@@ -287,7 +287,9 @@ class CustomComponentsFinder(ComponentsFinder):
         my_component defined in some_file.py, imported in other_file.py
         and the component is invoked as other_file.py:my_component
         """
-        path_to_function_decl = inspect.getabsfile(function)
+        # Unwrap decorated functions to get the original function
+        unwrapped_function = inspect.unwrap(function)
+        path_to_function_decl = inspect.getabsfile(unwrapped_function)
         if path_to_function_decl is None or not os.path.isfile(path_to_function_decl):
             return self._filepath
         return path_to_function_decl


### PR DESCRIPTION
Summary:
Add support to handle function with decorators that hit validation errors.

**Root cause:** If the function contains decorators, the getabsfile will return the decorator function filepath.

**Fix**: Add an unwrap before we getabsfile, this could lead to right filepath.

Differential Revision: D82132556


