### PR TITLE
(torchx/workspace) Add deprecation warning to PkgInfo, WorkspaceBuilder, FbpkgWorkspace

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -54,7 +54,7 @@ from torchx.tracker.api import (
 from torchx.util.session import get_session_id_or_create_new, TORCHX_INTERNAL_SESSION_ID
 
 from torchx.util.types import none_throws
-from torchx.workspace.api import PkgInfo, WorkspaceBuilder, WorkspaceMixin
+from torchx.workspace.api import WorkspaceMixin
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/torchx/workspace/api.py
+++ b/torchx/workspace/api.py
@@ -9,6 +9,7 @@
 import abc
 import fnmatch
 import posixpath
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, Iterable, Mapping, Tuple, TYPE_CHECKING, TypeVar
 
@@ -35,10 +36,32 @@ class PkgInfo(Generic[PackageType]):
     lazy_overrides: Dict[str, Any]
     metadata: PackageType
 
+    def __post_init__(self) -> None:
+        msg = (
+            f"{self.__class__.__name__} is deprecated and will be removed in the future."
+            " Consider forking this class if your project depends on it."
+        )
+        warnings.warn(
+            msg,
+            FutureWarning,
+            stacklevel=2,
+        )
+
 
 @dataclass
 class WorkspaceBuilder(Generic[PackageType, WorkspaceConfigType]):
     cfg: WorkspaceConfigType
+
+    def __post_init__(self) -> None:
+        msg = (
+            f"{self.__class__.__name__} is deprecated and will be removed in the future."
+            " Consider forking this class if your project depends on it."
+        )
+        warnings.warn(
+            msg,
+            FutureWarning,
+            stacklevel=2,
+        )
 
     @abc.abstractmethod
     def build_workspace(self, sync: bool = True) -> PkgInfo[PackageType]:


### PR DESCRIPTION
Summary: These classes are not used by torchx anywhere. Add deprecation warning so that we can remove them in the next release.

Differential Revision: D82245264


