### PR TITLE
(torchx/workspace) Support multi-project/directory workspace

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -36,6 +36,7 @@ from torchx.specs.finder import (
 )
 from torchx.util.log_tee_helpers import tee_logs
 from torchx.util.types import none_throws
+from torchx.workspace import Workspace
 
 
 MISSING_COMPONENT_ERROR_MSG = (
@@ -92,7 +93,7 @@ def torchx_run_args_from_json(json_data: Dict[str, Any]) -> TorchXRunArgs:
 
     torchx_args = TorchXRunArgs(**filtered_json_data)
     if torchx_args.workspace == "":
-        torchx_args.workspace = f"file://{Path.cwd()}"
+        torchx_args.workspace = f"{Path.cwd()}"
     return torchx_args
 
 
@@ -250,7 +251,7 @@ class CmdRun(SubCommand):
         subparser.add_argument(
             "--workspace",
             "--buck-target",
-            default=f"file://{Path.cwd()}",
+            default=f"{Path.cwd()}",
             action=torchxconfig_run,
             help="local workspace to build/patch (buck-target of main binary if using buck)",
         )
@@ -289,12 +290,14 @@ class CmdRun(SubCommand):
             else args.component_args
         )
         try:
+            workspace = Workspace.from_str(args.workspace) if args.workspace else None
+
             if args.dryrun:
                 dryrun_info = runner.dryrun_component(
                     args.component_name,
                     component_args,
                     args.scheduler,
-                    workspace=args.workspace,
+                    workspace=workspace,
                     cfg=args.scheduler_cfg,
                     parent_run_id=args.parent_run_id,
                 )

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -401,7 +401,7 @@ component = custom.echo
 
     def test_verify_no_extra_args_stdin_with_value_args(self) -> None:
         """Test that arguments with values conflict with stdin."""
-        args = self.parser.parse_args(["--stdin", "--workspace", "file:///custom/path"])
+        args = self.parser.parse_args(["--stdin", "--workspace", "/custom/path"])
         with self.assertRaises(SystemExit):
             self.cmd_run.verify_no_extra_args(args)
 
@@ -499,7 +499,7 @@ class TorchXRunArgsTest(unittest.TestCase):
         self.assertEqual(result.dryrun, False)
         self.assertEqual(result.wait, False)
         self.assertEqual(result.log, False)
-        self.assertEqual(result.workspace, f"file://{Path.cwd()}")
+        self.assertEqual(result.workspace, f"{Path.cwd()}")
         self.assertEqual(result.parent_run_id, None)
         self.assertEqual(result.tee_logs, False)
         self.assertEqual(result.component_args, {})
@@ -515,7 +515,7 @@ class TorchXRunArgsTest(unittest.TestCase):
             "dryrun": True,
             "wait": True,
             "log": True,
-            "workspace": "file:///custom/path",
+            "workspace": "/custom/path",
             "parent_run_id": "parent123",
             "tee_logs": True,
         }
@@ -529,7 +529,7 @@ class TorchXRunArgsTest(unittest.TestCase):
         self.assertEqual(result2.dryrun, True)
         self.assertEqual(result2.wait, True)
         self.assertEqual(result2.log, True)
-        self.assertEqual(result2.workspace, "file:///custom/path")
+        self.assertEqual(result2.workspace, "/custom/path")
         self.assertEqual(result2.parent_run_id, "parent123")
         self.assertEqual(result2.tee_logs, True)
 
@@ -626,7 +626,7 @@ class TorchXRunArgsTest(unittest.TestCase):
         args.dryrun = True
         args.wait = False
         args.log = True
-        args.workspace = "file:///custom/workspace"
+        args.workspace = "/custom/workspace"
         args.parent_run_id = "parent_123"
         args.tee_logs = False
 
@@ -654,7 +654,7 @@ class TorchXRunArgsTest(unittest.TestCase):
         self.assertEqual(result.dryrun, True)
         self.assertEqual(result.wait, False)
         self.assertEqual(result.log, True)
-        self.assertEqual(result.workspace, "file:///custom/workspace")
+        self.assertEqual(result.workspace, "/custom/workspace")
         self.assertEqual(result.parent_run_id, "parent_123")
         self.assertEqual(result.tee_logs, False)
         self.assertEqual(result.component_args, {})

--- a/torchx/runner/events/api.py
+++ b/torchx/runner/events/api.py
@@ -29,7 +29,7 @@ class TorchxEvent:
         scheduler: Scheduler that is used to execute request
         api: Api name
         app_id: Unique id that is set by the underlying scheduler
-        image: Image/container bundle that is used to execute request.
+        app_image: Image/container bundle that is used to execute request.
         app_metadata: metadata to the app (treatment of metadata is scheduler dependent)
         runcfg: Run config that was used to schedule app.
         source: Type of source the event is generated.

--- a/torchx/workspace/__init__.py
+++ b/torchx/workspace/__init__.py
@@ -22,4 +22,4 @@ Example workspace paths:
     * ``memory://foo-bar/`` an in-memory workspace for notebook/programmatic usage
 """
 
-from torchx.workspace.api import walk_workspace, WorkspaceMixin  # noqa: F401
+from torchx.workspace.api import walk_workspace, Workspace, WorkspaceMixin  # noqa: F401

--- a/torchx/workspace/api.py
+++ b/torchx/workspace/api.py
@@ -9,9 +9,22 @@
 import abc
 import fnmatch
 import posixpath
+import shutil
+import tempfile
 import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, Iterable, Mapping, Tuple, TYPE_CHECKING, TypeVar
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Iterable,
+    Mapping,
+    Tuple,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
 
 from torchx.specs import AppDef, CfgVal, Role, runopts
 
@@ -75,6 +88,71 @@ class WorkspaceBuilder(Generic[PackageType, WorkspaceConfigType]):
         pass
 
 
+@dataclass
+class Workspace:
+    """
+    Specifies a local "workspace" (a set of directories). Workspaces are ad-hoc built
+    into an (usually ephemeral) image. This effectively mirrors the local code changes
+    at job submission time.
+
+    For example:
+
+      1. ``projects={"~/github/torch": "torch"}`` copies ``~/github/torch/**`` into ``$REMOTE_WORKSPACE_ROOT/torch/**``
+      2. ``projects={"~/github/torch": ""}`` copies ``~/github/torch/**`` into ``$REMOTE_WORKSPACE_ROOT/**``
+
+    The exact location of ``$REMOTE_WORKSPACE_ROOT`` is implementation dependent and varies between
+    different implementations of :py:class:`~torchx.workspace.api.WorkspaceMixin`.
+    Check the scheduler documentation for details on which workspace it supports.
+
+    Note: ``projects`` maps the location of the local project to a sub-directory in the remote workspace root directory.
+    Typically the local project location is a directory path (e.g. ``/home/foo/github/torch``).
+
+
+    Attributes:
+        projects: mapping of local project to the sub-dir in the remote workspace dir.
+    """
+
+    projects: dict[str, str]
+
+    def is_unmapped_single_project(self) -> bool:
+        """
+        Returns ``True`` if this workspace only has 1 project
+        and its target mapping is an empty string.
+        """
+        return len(self.projects) == 1 and not next(iter(self.projects.values()))
+
+    @staticmethod
+    def from_str(workspace: str) -> "Workspace":
+        import yaml
+
+        projects = yaml.safe_load(workspace)
+        if isinstance(projects, str):  # single project workspace
+            projects = {projects: ""}
+        else:  # multi-project workspace
+            # Replace None mappings with "" (empty string)
+            projects = {k: ("" if v is None else v) for k, v in projects.items()}
+
+        return Workspace(projects)
+
+    def __str__(self) -> str:
+        """
+        Returns a string representation of the Workspace by concatenating
+        the project mappings using ';' as a delimiter and ':' between key and value.
+        If the single-project workspace with no target mapping, then simply
+        returns the src (local project dir)
+
+        NOTE: meant to be used for logging purposes not serde.
+          Therefore not symmetric with :py:func:`Workspace.from_str`.
+
+        """
+        if self.is_unmapped_single_project():
+            return next(iter(self.projects))
+        else:
+            return ";".join(
+                k if not v else f"{k}:{v}" for k, v in self.projects.items()
+            )
+
+
 class WorkspaceMixin(abc.ABC, Generic[T]):
     """
     Note: (Prototype) this interface may change without notice!
@@ -100,9 +178,50 @@ class WorkspaceMixin(abc.ABC, Generic[T]):
         """
         return runopts()
 
+    def build_workspace_and_update_role2(
+        self,
+        role: Role,
+        workspace: Union[Workspace, str],
+        cfg: Mapping[str, CfgVal],
+    ) -> None:
+        """
+        Same as :py:meth:`build_workspace_and_update_role` but operates
+        on :py:class:`Workspace` (supports multi-project workspaces)
+        as well as ``str`` (for backwards compatibility).
+
+        If ``workspace`` is a ``str`` this method simply calls
+        :py:meth:`build_workspace_and_update_role`.
+
+        If ``workspace`` is :py:class:`Workspace` then the default
+        impl copies all the projects into a tmp directory and passes the tmp dir to
+        :py:meth:`build_workspace_and_update_role`
+
+        Subclasses can override this method to customize multi-project
+        workspace building logic.
+        """
+        if isinstance(workspace, Workspace):
+            if not workspace.is_unmapped_single_project():
+                with tempfile.TemporaryDirectory(suffix="torchx_workspace_") as outdir:
+                    for src, dst in workspace.projects.items():
+                        dst_path = Path(outdir) / dst
+                        if Path(src).is_file():
+                            shutil.copy2(src, dst_path)
+                        else:  # src is dir
+                            shutil.copytree(src, dst_path, dirs_exist_ok=True)
+
+                    self.build_workspace_and_update_role(role, outdir, cfg)
+                    return
+            else:  # single project workspace with no target mapping (treat like a str workspace)
+                workspace = str(workspace)
+
+        self.build_workspace_and_update_role(role, workspace, cfg)
+
     @abc.abstractmethod
     def build_workspace_and_update_role(
-        self, role: Role, workspace: str, cfg: Mapping[str, CfgVal]
+        self,
+        role: Role,
+        workspace: str,
+        cfg: Mapping[str, CfgVal],
     ) -> None:
         """
         Builds the specified ``workspace`` with respect to ``img``

--- a/torchx/workspace/test/api_test.py
+++ b/torchx/workspace/test/api_test.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import shutil
+
+from pathlib import Path
+from typing import Mapping
+
+from torchx.specs import CfgVal, Role
+from torchx.test.fixtures import TestWithTmpDir
+
+from torchx.workspace.api import Workspace, WorkspaceMixin
+
+
+class TestWorkspace(WorkspaceMixin[None]):
+    def __init__(self, tmpdir: Path) -> None:
+        self.tmpdir = tmpdir
+
+    def build_workspace_and_update_role(
+        self, role: Role, workspace: str, cfg: Mapping[str, CfgVal]
+    ) -> None:
+        role.image = "bar"
+        role.metadata["workspace"] = workspace
+
+        if not workspace.startswith("//"):
+            # to validate the merged workspace dir copy its content to the tmpdir
+            shutil.copytree(workspace, self.tmpdir)
+
+
+class WorkspaceTest(TestWithTmpDir):
+
+    def test_to_string_single_project_workspace(self) -> None:
+        self.assertEqual(
+            "/home/foo/bar",
+            str(Workspace(projects={"/home/foo/bar": ""})),
+        )
+
+    def test_to_string_multi_project_workspace(self) -> None:
+        workspace = Workspace(
+            projects={
+                "/home/foo/workspace/myproj": "",
+                "/home/foo/github/torch": "torch",
+            }
+        )
+
+        self.assertEqual(
+            "/home/foo/workspace/myproj;/home/foo/github/torch:torch",
+            str(workspace),
+        )
+
+    def test_is_unmapped_single_project_workspace(self) -> None:
+        self.assertTrue(
+            Workspace(projects={"/home/foo/bar": ""}).is_unmapped_single_project()
+        )
+
+        self.assertFalse(
+            Workspace(projects={"/home/foo/bar": "baz"}).is_unmapped_single_project()
+        )
+
+        self.assertFalse(
+            Workspace(
+                projects={"/home/foo/bar": "", "/home/foo/torch": ""}
+            ).is_unmapped_single_project()
+        )
+
+        self.assertFalse(
+            Workspace(
+                projects={"/home/foo/bar": "", "/home/foo/torch": "pytorch"}
+            ).is_unmapped_single_project()
+        )
+
+    def test_from_str_single_project(self) -> None:
+        self.assertDictEqual(
+            {"/home/foo/bar": ""},
+            Workspace.from_str("/home/foo/bar").projects,
+        )
+
+        self.assertDictEqual(
+            {"/home/foo/bar": "baz"},
+            Workspace.from_str("/home/foo/bar: baz").projects,
+        )
+
+    def test_from_str_multi_project(self) -> None:
+        self.assertDictEqual(
+            {
+                "/home/foo/bar": "",
+                "/home/foo/third-party/verl": "verl",
+            },
+            Workspace.from_str(
+                """#
+/home/foo/bar:
+/home/foo/third-party/verl: verl
+"""
+            ).projects,
+        )
+
+    def test_build_and_update_role2_str_workspace(self) -> None:
+        proj = self.tmpdir / "github" / "torch"
+        proj.mkdir(parents=True)
+        (proj / "torch.py").touch()
+
+        role = Role(name="__IGNORED__", image="foo")
+        out = self.tmpdir / "workspace-merged"
+        TestWorkspace(out).build_workspace_and_update_role2(
+            role,
+            str(proj),
+            cfg={},
+        )
+
+        # make sure build_workspace_and_update_role has been called
+        # by checking that the image is updated from "foo" to "bar"
+        self.assertEqual(role.image, "bar")
+        self.assertTrue((out / "torch.py").exists())
+
+    def test_build_and_update_role2_unmapped_single_project_workspace(self) -> None:
+        proj = self.tmpdir / "github" / "torch"
+        proj.mkdir(parents=True)
+        (proj / "torch.py").touch()
+
+        role = Role(name="__IGNORED__", image="foo")
+        out = self.tmpdir / "workspace-merged"
+        TestWorkspace(out).build_workspace_and_update_role2(
+            role,
+            Workspace(projects={str(proj): ""}),
+            cfg={},
+        )
+
+        self.assertEqual(role.image, "bar")
+        self.assertTrue((out / "torch.py").exists())
+
+    def test_build_and_update_role2_unmapped_single_project_workspace_buck(
+        self,
+    ) -> None:
+        buck_target = "//foo/bar:main"
+
+        role = Role(name="__IGNORED__", image="foo")
+        out = self.tmpdir / "workspace-merged"
+        TestWorkspace(out).build_workspace_and_update_role2(
+            role,
+            Workspace(projects={buck_target: ""}),
+            cfg={},
+        )
+        self.assertEqual(role.image, "bar")
+        self.assertEqual(role.metadata["workspace"], buck_target)
+
+    def test_build_and_update_role2_multi_project_workspace(self) -> None:
+        proj1 = self.tmpdir / "github" / "torch"
+        proj1.mkdir(parents=True)
+        (proj1 / "torch.py").touch()
+
+        proj2 = self.tmpdir / "github" / "verl"
+        proj2.mkdir(parents=True)
+        (proj2 / "verl.py").touch()
+
+        file1 = self.tmpdir / ".torchxconfig"
+        file1.touch()
+
+        role = Role(name="__IGNORED__", image="foo")
+        workspace = Workspace(
+            projects={
+                str(proj1): "",
+                str(proj2): "verl",
+                str(file1): "verl/.torchxconfig",
+            }
+        )
+
+        out = self.tmpdir / "workspace-merged"
+        TestWorkspace(out).build_workspace_and_update_role2(
+            role,
+            workspace,
+            cfg={},
+        )
+
+        self.assertEqual(role.image, "bar")
+        self.assertTrue((out / "torch.py").exists())
+        self.assertTrue((out / "verl" / "verl.py").exists())
+        self.assertTrue((out / "verl" / ".torchxconfig").exists())


### PR DESCRIPTION
Summary:
Usage:

In your `.torchxconfig` file specify multi-project workspace as follows:

```
[cli:run]
workspace = 
  /home/$USER/github/myproj: 
  /home/$USER/github/verl: verl
  /home/$USER/.torchxconfig: verl/.torchxconfig
```

Then the workspace is built as:

1. `/home/$USER/github/myproj/**` -> `$REMOTE_ROOT/**`
1. `/home/$USER/github/verl/**` -> `$REMOTE_ROOT/verl/**`
1. `/home/$USER/.torchxconfig` -> `$REMOTE_ROOT/verl/.torchxconfig`

Notes:

1. The mappings are basically like BUCK `python_library`'s `resoruce` attribute. Mapping to an empty string, or simply leaving the target blank (as we did for `myproj` in the example above) copies the contents of the src dir directly into the remote workspace root

1. Files can be specified as src. The target of a file can be a directory, and if so, the file will be copied into the directory. For example:

```
[cli:run]
workspace = 
  /home/$USER/github/verl: verl
  /home/$USER/.torchxconfig: verl
```

copies `.torchxconfig` into `$REMOTE_ROOT/verl/.torchxconfig`. However if we switching the order of the projects won't work:

```
[cli:run]
workspace = 
  /home/$USER/.torchxconfig: verl
  /home/$USER/github/verl: verl
```

This would copy `.torchxconfig` to the file called `verl` in  `$REMOTE_ROOT/verl`, then `github/verl` would fail to copy.

Differential Revision: D82169554


