### PR TITLE
(torchx/CI) Retiring support for python-3.9

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -10,7 +10,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        python-version: ["3.10", 3.11, 3.12]
         platform: [linux.24_04.4x]
         include:
           - python-version: 3.12

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ def get_nightly_version():
 
 
 if __name__ == "__main__":
-    if sys.version_info < (3, 8):
-        sys.exit("python >= 3.8 required for torchx-sdk")
+    if sys.version_info < (3, 10):
+        sys.exit("python >= 3.10 required for torchx")
 
     name = "torchx"
     NAME_ARG = "--override-name"


### PR DESCRIPTION
Summary:
Retiring official support for python-3.9. Removes python-3.9 unittests.

Should simplify typing.

Differential Revision: D82340571
