### PR TITLE
Improve _get_path_to_function_decl to handle function wrapper with class

### DIFF
--- a/torchx/specs/test/components/f/__init__.py
+++ b/torchx/specs/test/components/f/__init__.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import functools
+
+from torchx import specs
+
+from .g import Cls
+
+
+@functools.wraps(Cls)
+def comp_f(**kwargs) -> specs.AppDef:  # pyre-ignore[2]
+    return Cls(**kwargs).build()

--- a/torchx/specs/test/components/f/g.py
+++ b/torchx/specs/test/components/f/g.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from dataclasses import dataclass
+
+import torchx
+from torchx import specs
+
+from .h import fake_decorator
+
+
+@dataclass
+class Args:
+    name: str
+
+
+@dataclass
+class Cls(Args):
+    def build(self) -> specs.AppDef:
+        return specs.AppDef(
+            name=self.name,
+            roles=[
+                specs.Role(
+                    name=self.name,
+                    image=torchx.IMAGE,
+                    entrypoint="echo",
+                    args=["hello world"],
+                )
+            ],
+        )
+
+
+@fake_decorator
+def comp_g() -> specs.AppDef:
+    return specs.AppDef(
+        name="g",
+        roles=[
+            specs.Role(
+                name="g",
+                image=torchx.IMAGE,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+        ],
+    )

--- a/torchx/specs/test/components/f/h.py
+++ b/torchx/specs/test/components/f/h.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import functools
+from typing import Any, Callable
+
+
+def fake_decorator(  # pyre-ignore[3]
+    func: Callable[..., Any],  # pyre-ignore[2]
+) -> Callable[..., Any]:
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Callable[..., Any]:  # pyre-ignore[3]
+        # Fake decorator: just calls the original function
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -30,6 +30,8 @@ from torchx.specs.finder import (
     ModuleComponentsFinder,
 )
 from torchx.specs.test.components.a import comp_a
+from torchx.specs.test.components.f import comp_f
+from torchx.specs.test.components.f.g import comp_g
 from torchx.util.test.entrypoints_test import EntryPoint_from_text
 from torchx.util.types import none_throws
 
@@ -241,6 +243,14 @@ to your component (see: https://pytorch.org/torchx/latest/component_best_practic
 
     def test_get_component_imported_from_other_file(self) -> None:
         component = get_component(f"{current_file_path()}:comp_a")
+        self.assertListEqual([], component.validation_errors)
+
+    def test_get_component_from_dataclass(self) -> None:
+        component = get_component(f"{current_file_path()}:comp_f")
+        self.assertListEqual([], component.validation_errors)
+
+    def test_get_component_from_decorator(self) -> None:
+        component = get_component(f"{current_file_path()}:comp_g")
         self.assertListEqual([], component.validation_errors)
 
 


### PR DESCRIPTION
Summary:
We added file decorator support in https://github.com/pytorch/torchx/pull/1111

**Problem:** This will fail when the function wrapper with dataclass object
**Fix:** Determine if decorators found in function before unwrap.

Add two test cases to cover:
* comp_f  using dataclass in g.py => should return __init__.py
* comp_g using decorator in h.py => should return g.py

Differential Revision: D82346696


