### PR TITLE
feat: add TORCHX_IMAGE to env vars for Docker-based schedulers (#1128)

### DIFF
--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -92,6 +92,8 @@ ENV_TORCHX_ROLE_IDX = "TORCHX_ROLE_IDX"
 
 ENV_TORCHX_ROLE_NAME = "TORCHX_ROLE_NAME"
 
+ENV_TORCHX_IMAGE = "TORCHX_IMAGE"
+
 DEFAULT_ROLE_NAME = "node"
 
 TAG_TORCHX_VER = "torchx.pytorch.org/version"
@@ -506,6 +508,7 @@ class AWSBatchScheduler(
             role = values.apply(role)
             role.env[ENV_TORCHX_ROLE_IDX] = str(role_idx)
             role.env[ENV_TORCHX_ROLE_NAME] = str(role.name)
+            role.env[ENV_TORCHX_IMAGE] = role.image
 
             nodes.append(
                 _role_to_node_properties(

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -84,6 +84,8 @@ LABEL_APP_ID: str = "torchx.pytorch.org/app-id"
 LABEL_ROLE_NAME: str = "torchx.pytorch.org/role-name"
 LABEL_REPLICA_ID: str = "torchx.pytorch.org/replica-id"
 
+ENV_TORCHX_IMAGE: str = "TORCHX_IMAGE"
+
 NETWORK = "torchx"
 
 
@@ -279,6 +281,7 @@ class DockerScheduler(
 
                 # configure distributed host envs
                 env["TORCHX_RANK0_HOST"] = rank0_name
+                env[ENV_TORCHX_IMAGE] = replica_role.image
 
                 c = DockerContainer(
                     image=replica_role.image,

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -399,6 +399,7 @@ def app_to_resource(
             replica_role = values.apply(role)
             if role_idx == 0 and replica_id == 0:
                 replica_role.env["TORCHX_RANK0_HOST"] = "localhost"
+            replica_role.env["TORCHX_IMAGE"] = replica_role.image
 
             pod = role_to_pod(name, replica_role, service_account)
             pod.metadata.labels.update(

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -22,6 +22,7 @@ from torchx.schedulers.aws_batch_scheduler import (
     AWSBatchOpts,
     AWSBatchScheduler,
     create_scheduler,
+    ENV_TORCHX_IMAGE,
     ENV_TORCHX_ROLE_NAME,
     resource_from_resource_requirements,
     resource_requirements_from_resource,
@@ -252,6 +253,10 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                                     {"name": "FOO", "value": "bar"},
                                     {"name": "TORCHX_ROLE_IDX", "value": "0"},
                                     {"name": "TORCHX_ROLE_NAME", "value": "trainer"},
+                                    {
+                                        "name": "TORCHX_IMAGE",
+                                        "value": "pytorch/torchx:latest",
+                                    },
                                 ],
                                 "privileged": False,
                                 "resourceRequirements": [
@@ -456,7 +461,11 @@ class AWSBatchSchedulerTest(unittest.TestCase):
                                             {
                                                 "name": ENV_TORCHX_ROLE_NAME,
                                                 "value": "echo",
-                                            }
+                                            },
+                                            {
+                                                "name": ENV_TORCHX_IMAGE,
+                                                "value": "pytorch/torchx:latest",
+                                            },
                                         ],
                                     },
                                 }

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -100,6 +100,7 @@ class DockerSchedulerTest(unittest.TestCase):
                         "environment": {
                             "FOO": "bar",
                             "TORCHX_RANK0_HOST": "app_name_42-trainer-0",
+                            "TORCHX_IMAGE": "pytorch/torchx:latest",
                         },
                         "labels": {
                             "torchx.pytorch.org/app-id": "app_name_42",
@@ -190,6 +191,7 @@ class DockerSchedulerTest(unittest.TestCase):
                 "FOO_1": "f1",
                 "BAR_1": "b1",
                 "TORCHX_RANK0_HOST": "app_name_42-trainer-0",
+                "TORCHX_IMAGE": "pytorch/torchx:latest",
             },
         )
 
@@ -205,6 +207,7 @@ class DockerSchedulerTest(unittest.TestCase):
                 "FOO": "bar",
                 "FOO_1": "BAR_1",
                 "TORCHX_RANK0_HOST": "app_name_42-trainer-0",
+                "TORCHX_IMAGE": "pytorch/torchx:latest",
             },
         )
 

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -320,6 +320,8 @@ spec:
                 fieldPath: bar
           - name: TORCHX_RANK0_HOST
             value: localhost
+          - name: TORCHX_IMAGE
+            value: pytorch/torchx:latest
           image: pytorch/torchx:latest
           name: trainerfoo-0
           ports:
@@ -520,6 +522,9 @@ spec:
         self.assertIn("TORCHX_RANK0_HOST", container0.command)
         self.assertIn(
             V1EnvVar(name="TORCHX_RANK0_HOST", value="localhost"), container0.env
+        )
+        self.assertIn(
+            V1EnvVar(name="TORCHX_IMAGE", value="pytorch/torchx:latest"), container0.env
         )
         container1 = tasks[1]["template"].spec.containers[0]
         self.assertIn("VC_TRAINERFOO_0_HOSTS", container1.command)


### PR DESCRIPTION
Adding `TORCHX_IMAGE` to environment variables so that we give a chance to the payload to record the value beyond the retention restrictions of the scheduler so as to facilitate reproducibility.

Test plan:
[x] updated unit tests

[x] `local_docker --workspace ""` -> no image built or pushed -> we expect to see the base image in `TORCHX_IMAGE` env vars

`torchx run -s local_docker --workspace "" utils.sh --image alpine:latest -- env`

```
torchx 2025-09-25 11:32:59 INFO     Pulling container image: alpine:latest (this may take a while)
...
sh/0 TORCHX_IMAGE=alpine:latest
...
```

[x] `local_docker` -> image built locally, but not pushed -> we expect to see local image SHA in `TORCHX_IMAGE` env vars

`torchx run -s local_docker utils.sh --image alpine:latest -- env`

```
...
torchx 2025-09-25 11:32:45 INFO     Built new image `sha256:7ab1cd30c98bd9ebea5760b86fdb9984ced914aace098589ccc986bb8dd1b508` based on original image `alpine:latest` and changes in workspace `/private/tmp/torchx-test` for role[0]=sh.
...
sh/0 TORCHX_IMAGE=sha256:7ab1cd30c98bd9ebea5760b86fdb9984ced914aace098589ccc986bb8dd1b508
...
```

[x] `aws_batch --image_repo` -> image built locally, tagged and pushed to image repo -> we expect to see image tag in `TORCHX_IMAGE` env vars

`torchx run -s aws_batch --scheduler_args 'queue=<queue-name>,priority=<priority>,image_repo=<image-repo>,share_id=<share-id>' utils.sh -h g5.4xlarge --image alpine:latest`

```
...
torchx 2025-09-25 11:37:02 INFO     pushing image <image-repo>:7ab1cd30c98bd9ebea5760b86fdb9984ced914aace098589ccc986bb8dd1b508...
...
```

Observe in Batch Job details:

```
TORCHX_IMAGE
<image-repo>:7ab1cd30c98bd9ebea5760b86fdb9984ced914aace098589ccc986bb8dd1b508
```