### PR TITLE
(torchx/specs) Add TORCHX_HOME function that returns the dot-torchx directory

### DIFF
--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -41,6 +41,7 @@ from torchx.specs.api import (
     RoleStatus,
     runopt,
     runopts,
+    TORCHX_HOME,
     UnknownAppException,
     UnknownSchedulerException,
     VolumeMount,
@@ -52,6 +53,7 @@ from torchx.util.entrypoints import load_group
 from torchx.util.modules import import_attr
 
 GiB: int = 1024
+
 
 ResourceFactory = Callable[[], Resource]
 

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -11,6 +11,8 @@ import copy
 import inspect
 import json
 import logging as logger
+import os
+import pathlib
 import re
 import typing
 from dataclasses import asdict, dataclass, field
@@ -64,6 +66,32 @@ _EMBEDDED_ERROR_MESSAGE_RE: Pattern[str] = re.compile(r"(?P<msg>.+)\nException.*
 
 YELLOW_BOLD = "\033[1;33m"
 RESET = "\033[0m"
+
+
+def TORCHX_HOME(*subdir_paths: str) -> pathlib.Path:
+    """
+    Path to the "dot-directory" for torchx.
+    Defaults to `~/.torchx` and is overridable via the `TORCHX_HOME` environment variable.
+
+    Usage:
+
+    .. doc-test::
+
+        from pathlib import Path
+        from torchx.specs import TORCHX_HOME
+
+        assert TORCHX_HOME() == Path.home() / ".torchx"
+        assert TORCHX_HOME("conda-pack-out") ==  Path.home() / ".torchx" / "conda-pack-out"
+    ```
+    """
+
+    default_dir = str(pathlib.Path.home() / ".torchx")
+    torchx_home = pathlib.Path(os.getenv("TORCHX_HOME", default_dir))
+
+    torchx_home = torchx_home / os.path.sep.join(subdir_paths)
+    torchx_home.mkdir(parents=True, exist_ok=True)
+
+    return torchx_home
 
 
 # ========================================


### PR DESCRIPTION
Summary:
Adds a `TORCHX_HOME()` function to `torchx.specs.api` (re-exported from `torchx/specs/__init__.py` for ease of import) that returns the directory path to a `~/.torchx` (aka dot-directory) for torchx.

This directory is to be used by torchx to store temporary output such as workspace builds.

Usage:

```
from torchx.specs import TORCHX_HOME

outdir = TORCHX_HOME("out")
```

Reviewed By: hstonec

Differential Revision: D83575373


