### PR TITLE
(torchx/CI) update docker repo to ghcr.io/meta-pytorch/torchx

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -32,8 +32,8 @@ jobs:
         run: |
           set -eux
           torchx/runtime/container/build.sh
-          docker tag torchx "ghcr.io/pytorch/torchx:$VERSION"
+          docker tag torchx "ghcr.io/meta-pytorch/torchx:$VERSION"
       - name: Push containers
         run: |
           set -eux
-          docker push "ghcr.io/pytorch/torchx:$VERSION"
+          docker push "ghcr.io/meta-pytorch/torchx:$VERSION"


### PR DESCRIPTION
Summary: Updating container registry to point to meta-pytorch after the repo migration from pytorch/torchx to meta-pytorch/torchx

Reviewed By: AbishekS

Differential Revision: D83688082
