### PR TITLE
(EZ)(torchx/CI) remove airflow install from docbuild action

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -85,12 +85,6 @@ jobs:
           set -eux
           sudo apt-get install -y pandoc
           pip install -r docs/requirements.txt
-      - name: Start Airflow
-        run: |
-          # start airflow in background
-          airflow standalone &
-          # wait 5 seconds for airflow to start
-          sleep 5
       - name: Build
         run: |
           set -ex

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,3 @@ jupytext
 ipython_genutils
 # https://github.com/jupyter/nbconvert/issues/1736
 jinja2>=3.1.4
-apache-airflow==2.10.5


### PR DESCRIPTION
Summary:
We retired support for airflow in https://github.com/meta-pytorch/torchx/pull/1119 but still installing and starting airflow in the doc build - used to need it to build and test airflow notebook examples.

This diff removes the unnecessary airflow install in docbuild.

Reviewed By: ishachirimar

Differential Revision: D84634762
