### PR TITLE
(torchx/workspace) Add API for caching workspace build artifacts between roles

### DIFF
--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -131,7 +131,7 @@ class Scheduler(abc.ABC, Generic[T, A, D]):
         self,
         app: A,
         cfg: T,
-        workspace: Optional[Union[Workspace, str]] = None,
+        workspace: str | Workspace | None = None,
     ) -> str:
         """
         Submits the application to be run by the scheduler.
@@ -145,7 +145,12 @@ class Scheduler(abc.ABC, Generic[T, A, D]):
         resolved_cfg = self.run_opts().resolve(cfg)
         if workspace:
             assert isinstance(self, WorkspaceMixin)
-            self.build_workspace_and_update_role2(app.roles[0], workspace, resolved_cfg)
+
+            if isinstance(workspace, str):
+                workspace = Workspace.from_str(workspace)
+
+            app.roles[0].workspace = workspace
+            self.build_workspaces(app.roles, resolved_cfg)
 
         # pyre-fixme: submit_dryrun takes Generic type for resolved_cfg
         dryrun_info = self.submit_dryrun(app, resolved_cfg)

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -46,6 +46,7 @@ from torchx.specs.api import (
     TORCHX_HOME,
     Workspace,
 )
+from torchx.test.fixtures import TestWithTmpDir
 
 
 class TorchXHomeTest(unittest.TestCase):
@@ -75,7 +76,7 @@ class TorchXHomeTest(unittest.TestCase):
                 self.assertTrue(conda_pack_out.is_dir())
 
 
-class WorkspaceTest(unittest.TestCase):
+class WorkspaceTest(TestWithTmpDir):
 
     def test_bool(self) -> None:
         self.assertFalse(Workspace(projects={}))
@@ -148,6 +149,28 @@ class WorkspaceTest(unittest.TestCase):
 """
             ).projects,
         )
+
+    def test_merge(self) -> None:
+        self.touch("workspace/myproj/README.md")
+        self.touch("workspace/myproj/bin/cli")
+
+        self.touch("workspace/torch/setup.py")
+        self.touch("workspace/torch/torch/__init__.py")
+
+        w = Workspace(
+            projects={
+                str(self.tmpdir / "workspace/myproj"): "",
+                str(self.tmpdir / "workspace/torch"): "torch",
+            }
+        )
+
+        outdir = self.tmpdir / "out"
+        w.merge_into(outdir)
+
+        self.assertTrue((outdir / "README.md").is_file())
+        self.assertTrue((outdir / "bin/cli").is_file())
+        self.assertTrue((outdir / "torch/setup.py").is_file())
+        self.assertTrue((outdir / "torch/torch/__init__.py").is_file())
 
 
 class AppDryRunInfoTest(unittest.TestCase):

--- a/torchx/test/fixtures.py
+++ b/torchx/test/fixtures.py
@@ -76,6 +76,14 @@ class TestWithTmpDir(unittest.TestCase):
         f.touch()
         return f
 
+    def mkdir(self, dirpath: str) -> Path:
+        """
+        Creates a directory in the test's tmpdir and returns the ``Path`` to the created directory
+        """
+        d = self.tmpdir / dirpath
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
     def write(self, filepath: str, content: Iterable[str]) -> Path:
         """
         Creates a file given the filepath (can be a file name or a relative path) in the test's tmpdir
@@ -135,6 +143,109 @@ class TestWithTmpDir(unittest.TestCase):
 
         with open(self.tmpdir / filepath, "r") as fin:
             return fin.readlines()
+
+    def assertDirIsEmpty(self, directory: str | Path) -> None:
+        """
+        Asserts that the given directory exists but is empty.
+        If ``dir`` is a relative path, it is assumed to be relative to this test's ``tmpdir``.
+        """
+        directory = Path(directory)
+        d = directory if directory.is_absolute() else self.tmpdir / directory
+        self.assertTrue(d.is_dir(), f"{d} is not a directory")
+        self.assertEqual(0, len(list(d.iterdir())), f"{d} is not empty")
+
+    def assertDirTree(self, root: str | Path, tree: dict[str, object]) -> None:
+        """
+        Asserts that the given ``root`` has the directory structure as specified by ``tree``.
+        If ``root`` is a relative path, it is assumed to be relative to this test's ``tmpdir``
+
+        Usage:
+
+        .. code-block:: python
+            self.assertDirTree(
+                "out",
+                {
+                    "setup.py": "",
+                    "torchx": {
+                        "__init__.py": "",
+                        "version.py": "0.8.0dev0",
+                        "specs": {
+                            "__init__.py": "",
+                            "api.py": "",
+                        },
+                    },
+                },
+            )
+        """
+        root = Path(root)
+        d = root if root.is_absolute() else self.tmpdir / root
+        self.assertTrue(d.is_dir(), f"{d} is not a directory")
+
+        def _assert_tree(current_dir: Path, subtree: dict[str, object]) -> None:
+            # Check that the directory contains exactly the keys in subtree
+            actual_entries = {p.name for p in current_dir.iterdir()}
+            expected_entries = set(subtree.keys())
+            self.assertSetEqual(
+                expected_entries,
+                actual_entries,
+                f"contents of the dir `{current_dir}` do not match the expected",
+            )
+            for name, value in subtree.items():
+                path = current_dir / name
+                if isinstance(value, dict):
+                    self.assertTrue(path.is_dir(), f"{path} is not a directory")
+                    _assert_tree(path, value)
+                else:
+                    self.assertTrue(path.is_file(), f"{path} is not a file")
+                    if value != "":
+                        with open(path, "r") as f:
+                            content = f.read().strip()
+                        self.assertEqual(
+                            content,
+                            value,
+                            f"file {path} content {content!r} does not match expected {value!r}",
+                        )
+
+        _assert_tree(d, tree)
+
+    def create_dir_tree(self, root: str, tree: dict[str, object]) -> Path:
+        """
+        Creates the directory structure as specified by ``tree`` under ``self.tmpdir / root``
+
+        Usage:
+
+        .. code-block:: python
+            self.createDirTree(
+                "out",
+                {
+                    "README.md": "foobar",
+                    "torchx": {
+                        "__init__.py": "",
+                        "version.py": "0.8.0dev0",
+                        "specs": {
+                            "__init__.py": "",
+                            "api.py": "",
+                        },
+                    },
+                },
+            )
+        """
+        d = self.tmpdir / root
+        d.mkdir(parents=True, exist_ok=True)
+
+        def _create_tree(current_dir: Path, subtree: dict[str, object]) -> None:
+            for name, value in subtree.items():
+                path = current_dir / name
+                if isinstance(value, dict):
+                    path.mkdir(parents=True, exist_ok=True)
+                    _create_tree(path, value)
+                else:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    with open(path, "w") as f:
+                        f.write(str(value))
+
+        _create_tree(d, tree)
+        return d
 
 
 Ret = TypeVar("Ret")

--- a/torchx/workspace/test/api_test.py
+++ b/torchx/workspace/test/api_test.py
@@ -11,117 +11,195 @@ import shutil
 from pathlib import Path
 from typing import Mapping
 
-from torchx.specs import CfgVal, Role
+from torchx.specs import CfgVal, Role, Workspace
 from torchx.test.fixtures import TestWithTmpDir
 
-from torchx.workspace.api import Workspace, WorkspaceMixin
+from torchx.workspace.api import WorkspaceMixin
+from typing_extensions import override
+
+IGNORED = "__IGNORED__"
 
 
-class TestWorkspace(WorkspaceMixin[None]):
+class NonCachingWorkspace(WorkspaceMixin[None]):
     def __init__(self, tmpdir: Path) -> None:
         self.tmpdir = tmpdir
+        self.version_counter: dict[str, int] = {}
 
+    def _build_new_workspace_image(self, role: Role) -> str:
+        version = self.version_counter.setdefault(role.image, 0)
+        ephemeral_image = f"{role.image}:{version}"
+        self.version_counter[role.image] += 1
+
+        return ephemeral_image
+
+    @override
     def build_workspace_and_update_role(
         self, role: Role, workspace: str, cfg: Mapping[str, CfgVal]
     ) -> None:
-        role.image = "bar"
-        role.metadata["workspace"] = workspace
-
-        if not workspace.startswith("//"):
-            # to validate the merged workspace dir copy its content to the tmpdir
-            shutil.copytree(workspace, self.tmpdir)
+        role.image = self._build_new_workspace_image(role)
+        # copy the given workspace dir for assertions
+        shutil.copytree(workspace, self.tmpdir / role.image)
 
 
-class WorkspaceTest(TestWithTmpDir):
+class NonCachingWorkspaceTest(TestWithTmpDir):
+    """Tests workspaces with `build_workspace_and_update_role` implemented"""
 
-    def build_workspace_and_update_role(
-        self, role: Role, workspace: str, cfg: Mapping[str, CfgVal]
-    ) -> None:
-        role.image = "bar"
-        role.metadata["workspace"] = workspace
-
-        if not workspace.startswith("//"):
-            # to validate the merged workspace dir copy its content to the tmpdir
-            shutil.copytree(workspace, self.tmpdir)
-
-    def test_build_and_update_role2_str_workspace(self) -> None:
-        proj = self.tmpdir / "github" / "torch"
-        proj.mkdir(parents=True)
-        (proj / "torch.py").touch()
-
-        role = Role(name="__IGNORED__", image="foo")
-        out = self.tmpdir / "workspace-merged"
-        TestWorkspace(out).build_workspace_and_update_role2(
-            role,
-            str(proj),
-            cfg={},
+    def test_build_workspaces(self) -> None:
+        workspace_dir = self.create_dir_tree(
+            "workspace",
+            {
+                "proj_a": {
+                    "a.py": "project a",
+                },
+                "proj_b": {
+                    "b.py": "project b",
+                },
+            },
         )
-
-        # make sure build_workspace_and_update_role has been called
-        # by checking that the image is updated from "foo" to "bar"
-        self.assertEqual(role.image, "bar")
-        self.assertTrue((out / "torch.py").exists())
-
-    def test_build_and_update_role2_unmapped_single_project_workspace(self) -> None:
-        proj = self.tmpdir / "github" / "torch"
-        proj.mkdir(parents=True)
-        (proj / "torch.py").touch()
-
-        role = Role(name="__IGNORED__", image="foo")
-        out = self.tmpdir / "workspace-merged"
-        TestWorkspace(out).build_workspace_and_update_role2(
-            role,
-            Workspace(projects={str(proj): ""}),
-            cfg={},
-        )
-
-        self.assertEqual(role.image, "bar")
-        self.assertTrue((out / "torch.py").exists())
-
-    def test_build_and_update_role2_unmapped_single_project_workspace_buck(
-        self,
-    ) -> None:
-        buck_target = "//foo/bar:main"
-
-        role = Role(name="__IGNORED__", image="foo")
-        out = self.tmpdir / "workspace-merged"
-        TestWorkspace(out).build_workspace_and_update_role2(
-            role,
-            Workspace(projects={buck_target: ""}),
-            cfg={},
-        )
-        self.assertEqual(role.image, "bar")
-        self.assertEqual(role.metadata["workspace"], buck_target)
-
-    def test_build_and_update_role2_multi_project_workspace(self) -> None:
-        proj1 = self.tmpdir / "github" / "torch"
-        proj1.mkdir(parents=True)
-        (proj1 / "torch.py").touch()
-
-        proj2 = self.tmpdir / "github" / "verl"
-        proj2.mkdir(parents=True)
-        (proj2 / "verl.py").touch()
-
-        file1 = self.tmpdir / ".torchxconfig"
-        file1.touch()
-
-        role = Role(name="__IGNORED__", image="foo")
         workspace = Workspace(
             projects={
-                str(proj1): "",
-                str(proj2): "verl",
-                str(file1): "verl/.torchxconfig",
+                str(workspace_dir / "proj_a"): "",
+                str(workspace_dir / "proj_b"): "b",
             }
         )
+        roles = [
+            Role(name=IGNORED, image="foo", workspace=None),
+            Role(name=IGNORED, image="bar", workspace=workspace),
+            Role(name=IGNORED, image="bar", workspace=workspace),
+            Role(name=IGNORED, image="baz", workspace=workspace),
+        ]
 
-        out = self.tmpdir / "workspace-merged"
-        TestWorkspace(out).build_workspace_and_update_role2(
-            role,
-            workspace,
-            cfg={},
+        outdir = self.tmpdir / "out"
+        NonCachingWorkspace(outdir).build_workspaces(roles, cfg={})
+
+        # check the updated images for each role
+        self.assertListEqual(
+            [
+                Role(name=IGNORED, image="foo", workspace=None),
+                Role(name=IGNORED, image="bar:0", workspace=workspace),
+                Role(name=IGNORED, image="bar:1", workspace=workspace),
+                Role(name=IGNORED, image="baz:0", workspace=workspace),
+            ],
+            roles,
         )
 
-        self.assertEqual(role.image, "bar")
-        self.assertTrue((out / "torch.py").exists())
-        self.assertTrue((out / "verl" / "verl.py").exists())
-        self.assertTrue((out / "verl" / ".torchxconfig").exists())
+        merged_workspace = {
+            "a.py": "project a",
+            "b": {
+                "b.py": "project b",
+            },
+        }
+        self.assertDirTree(
+            outdir,
+            {
+                "bar:0": merged_workspace,
+                "bar:1": merged_workspace,
+                "baz:0": merged_workspace,
+            },
+        )
+
+
+class CachingWorkspace(WorkspaceMixin[None]):
+    def __init__(self, tmpdir: Path) -> None:
+        self.tmpdir = tmpdir
+        self.version_counter: dict[str, int] = {}
+
+    def _build_new_workspace_image(self, role: Role) -> str:
+        version = self.version_counter.setdefault(role.image, 0)
+        ephemeral_image = f"{role.image}:{version}"
+        self.version_counter[role.image] += 1
+
+        workspace = role.workspace
+        assert workspace is not None
+
+        workspace.merge_into(self.tmpdir / ephemeral_image)
+        return ephemeral_image
+
+    @override
+    def caching_build_workspace_and_update_role(
+        self,
+        role: Role,
+        cfg: Mapping[str, CfgVal],
+        build_cache: dict[object, object],
+    ) -> None:
+        image = role.image
+        workspace = role.workspace
+
+        cache_key = (image, workspace)
+        if (ephemeral_image := build_cache.get(cache_key)) is None:
+            # cache miss, build new image
+            role.image = self._build_new_workspace_image(role)
+            build_cache[cache_key] = role.image
+        else:
+            assert isinstance(ephemeral_image, str)
+            role.image = ephemeral_image
+
+
+class CachingWorkspaceTest(TestWithTmpDir):
+    """Tests workspaces with `caching_build_workspace_and_update_role` implemented"""
+
+    def test_build_workspaces(self) -> None:
+        workspace_dir = self.create_dir_tree(
+            "workspace",
+            {
+                "proj_a": {
+                    "a.py": "project a",
+                },
+                "proj_b": {
+                    "b.py": "project b",
+                },
+                "proj_c": {
+                    "c.py": "project c",
+                },
+            },
+        )
+        workspace1 = Workspace(
+            projects={
+                str(workspace_dir / "proj_a"): "",
+                str(workspace_dir / "proj_b"): "b",
+            }
+        )
+        workspace2 = Workspace(projects={str(workspace_dir / "proj_c"): "c"})
+
+        roles = [
+            Role(name=IGNORED, image="foo", workspace=None),
+            Role(name=IGNORED, image="bar", workspace=workspace1),
+            Role(name=IGNORED, image="bar", workspace=workspace1),  # cache hit
+            Role(name=IGNORED, image="baz", workspace=workspace1),
+            Role(name=IGNORED, image="baz", workspace=workspace2),  # cache miss
+        ]
+
+        outdir = self.tmpdir / "out"
+        CachingWorkspace(outdir).build_workspaces(roles, cfg={})
+
+        # check the updated images for each role
+        self.assertListEqual(
+            [
+                Role(name=IGNORED, image="foo", workspace=None),
+                Role(name=IGNORED, image="bar:0", workspace=workspace1),
+                Role(name=IGNORED, image="bar:0", workspace=workspace1),  # cache hit
+                Role(name=IGNORED, image="baz:0", workspace=workspace1),
+                Role(name=IGNORED, image="baz:1", workspace=workspace2),  # cache miss
+            ],
+            roles,
+        )
+
+        merged_workspace1 = {
+            "a.py": "project a",
+            "b": {
+                "b.py": "project b",
+            },
+        }
+        merged_workspace2 = {
+            "c": {
+                "c.py": "project c",
+            },
+        }
+        self.assertDirTree(
+            outdir,
+            {
+                "bar:0": merged_workspace1,
+                "baz:0": merged_workspace1,
+                "baz:1": merged_workspace2,
+            },
+        )


### PR DESCRIPTION
Summary:
Since we now allow each `Role` to specify its own workspace through the `Role.workspace` attribute, there are cases where all the roles have the same workspace and base image. In this case, we don't have to re-build the workspace image for each role since the ephemerals will all have the same content!

This diff introduces the `caching_build_workspace_and_update_role()` method to the `WorkspaceMixIn`. This is the preferred method (over `build_workspace_and_update_role()`) that subclasses of `WorkspaceMixIn` should implement.

Until we can completely deprecate `build_workspace_and_update_role()`, we bridge the two by having the default implementation of `caching_build_workspace_and_update_role()` call `build_workspace_and_update_role()`.

To support `caching_build_workspace_and_update_role()`, this diff also does the following:

1. Renames `build_workspace_and_udpate_role2()` to `caching_build_workspace_and_update_role()`.

2. Iterating over the roles and building the workspace for each role is now pushed into the `WorkspaceMixIn.build_workspace_and_update_roles()` instead of it being in the runner.

3. Pushes the logic of merging of multi-directory workspace into a single tmp dir to the `Workspace` class's `merge_into()` method.

Reviewed By: AbishekS

Differential Revision: D84466900


