### PR TITLE
(docs-scout/staleness)[torchx][docs] Fix 7 stale references across components, advanced, and tracker docs

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -286,7 +286,13 @@ suggestion of close matches.
 Registering Custom Components
 -------------------------------
 
-Register custom components as CLI builtins:
+Register custom components as CLI builtins.
+
+.. note::
+
+   Components still use entry-point registration. The ``@register`` decorator
+   migration is pending for components (tracked for a future release). Use
+   entry points as shown below.
 
 .. code-block:: shell-session
 
@@ -719,7 +725,7 @@ the bottom.
 .. seealso::
 
    :doc:`plugins`
-      Plugin API reference (``@register``, ``find()``, ``PluginRegistry``).
+      Plugin API reference (``@register``, ``registry()``, ``PluginRegistry``).
 
    :doc:`cli`
       CLI module API reference.

--- a/docs/source/component_best_practices.rst
+++ b/docs/source/component_best_practices.rst
@@ -101,7 +101,7 @@ Composing Components
 Start from base component definitions rather than building ``AppDef`` from
 scratch:
 
-* :py:mod:`torchx.components.base` for simple single node components.
+* :doc:`custom_components` for simple single-node components.
 * :py:func:`torchx.components.dist.ddp` for distributed components.
 
 You can also merge roles from multiple components to run sidecars alongside

--- a/docs/source/custom_components.rst
+++ b/docs/source/custom_components.rst
@@ -140,7 +140,8 @@ Or push and launch on a :doc:`Kubernetes <schedulers/kubernetes>` cluster:
       Best practices for entrypoints, simplicity, named resources, and testing.
 
    :doc:`advanced`
-      Registering custom components as CLI builtins via entry points.
+      Registering custom components as CLI builtins (via entry points;
+      ``@register`` migration pending for components).
 
    :doc:`components/overview`
       Browse the builtin component library.

--- a/torchx/components/__init__.py
+++ b/torchx/components/__init__.py
@@ -87,7 +87,7 @@ the :py:func:`torchx.components.dist.ddp` builtin.
             specs.Role(
                 name="trainer",
                 image=image,
-                resource=specs.named_resources[host],
+                resource=specs.resource(h=host),
                 num_replicas=nnodes,
                 entrypoint="python",
                 args=[


### PR DESCRIPTION
Summary:
Fix 7 accuracy issues found during docs-scout rotation audit of components/advanced section.

**component_best_practices.rst (item 1, HIGH):**
- Replace reference to non-existent `torchx.components.base` module (no `__init__.py`)
  with link to `custom_components` guide for simple single-node components

**components/__init__.py (item 2, HIGH):**
- Update doctest example from deprecated `specs.named_resources[host]` dict-access
  to current `specs.resource(h=host)` API

**advanced.rst (items 3 + 5, MEDIUM/LOW):**
- Add note that `register` migration is pending for components (other plugin types
  already migrated)
- Fix seealso reference from non-existent `find()` to `registry()` (actual export)

**fb/distributed.rst (item 4, MEDIUM):**
- Fix example from `-s mast` to `-s hpc` (preferred scheduler per quickstart.rst)

**fb/tracker_usage.rst (item 6, LOW):**
- Update "MAST/MSL" to "MSL" (forward-looking, MAST deprecated)

**custom_components.rst (item 7, LOW):**
- Add note that `register` migration is pending for components in seealso

Differential Revision: D96451468


