### PR TITLE
Export powers_of_two_gpus and halve_mem_down_to at torchx.plugins level (#1274)

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -143,10 +143,10 @@ and decorate them:
 .. code-block:: python
 
    # torchx_plugins/named_resources/my_cluster.py
-   from torchx.plugins import register, WHOLE
+   from torchx.plugins import powers_of_two_gpus, register, WHOLE
    from torchx.specs import Resource
 
-   @register.named_resource(fractionals=register.powers_of_two_gpus)
+   @register.named_resource(fractionals=powers_of_two_gpus)
    def gpu_x(fractional: float = WHOLE) -> Resource:
        return Resource(
            cpu=int(64 * fractional),
@@ -160,8 +160,8 @@ and decorate them:
        return Resource(cpu=32, gpu=0, memMB=131072)
 
 The ``fractionals`` argument auto-generates fractional variants. See
-:py:meth:`~torchx.plugins.register.powers_of_two_gpus` and
-:py:meth:`~torchx.plugins.register.halve_mem_down_to` in :doc:`plugins`.
+:py:func:`~torchx.plugins.powers_of_two_gpus` and
+:py:func:`~torchx.plugins.halve_mem_down_to` in :doc:`plugins`.
 
 **Legacy: entry points** *(deprecated)*
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -19,8 +19,13 @@ Registration
 -------------
 
 .. autoclass:: torchx.plugins.register
-   :members: scheduler, tracker, named_resource,
-             powers_of_two_gpus, halve_mem_down_to
+   :members: scheduler, tracker, named_resource
+
+Fractional Helpers
+-------------------
+
+.. autofunction:: torchx.plugins.powers_of_two_gpus
+.. autofunction:: torchx.plugins.halve_mem_down_to
 
 Constants
 ----------

--- a/torchx/plugins/__init__.py
+++ b/torchx/plugins/__init__.py
@@ -34,6 +34,8 @@ Discover plugins and print a diagnostic report::
 from torchx.plugins._registration import (
     EIGHTH,
     HALF,
+    halve_mem_down_to,
+    powers_of_two_gpus,
     QUARTER,
     register,
     resource_tags,
@@ -52,6 +54,8 @@ __all__ = [
     # _registration.py
     "register",
     "resource_tags",
+    "powers_of_two_gpus",
+    "halve_mem_down_to",
     "WHOLE",
     "HALF",
     "QUARTER",

--- a/torchx/plugins/_registration.py
+++ b/torchx/plugins/_registration.py
@@ -76,6 +76,114 @@ class resource_tags:
     """``True`` when the resource is a fractional slice of a base resource."""
 
 
+def powers_of_two_gpus(resource: Any) -> dict[float, str]:
+    """Return fractional specs for every power-of-two GPU slice of *resource*.
+
+    For example, an 8-GPU resource produces::
+
+        {1.0: "8", 0.5: "4", 0.25: "2", 0.125: "1"}
+
+    When passed as the ``fractionals`` argument of
+    :py:meth:`register.named_resource`, this auto-generates and registers
+    all power-of-two fractional variants (e.g. ``my_gpu_8``, ``my_gpu_4``,
+    …).
+
+    Args:
+        resource: The base (whole-host) resource.  Must have ``gpu > 0``
+            and ``gpu`` must be a power of two.
+
+    Raises:
+        ValueError: if ``resource.gpu`` is zero or not a power of two.
+    """
+
+    def _is_pow2(n: int) -> bool:
+        return (n > 0) and ((n & (n - 1)) == 0)
+
+    gpus = resource.gpu
+    if gpus <= 0:
+        raise ValueError(
+            f"resource must have gpu > 0 to generate power-of-two slices (got {gpus})"
+        )
+    if not _is_pow2(gpus):
+        raise ValueError(
+            f"resource.gpu must be a power of two to generate slices (got {gpus})"
+        )
+
+    fractionals: dict[float, str] = {}
+    fraction = 1.0
+    while (fractional_gpus := int(gpus * fraction)) > 0:
+        fractionals[fraction] = str(fractional_gpus)
+        fraction /= 2
+    return fractionals
+
+
+def halve_mem_down_to(
+    *,
+    minGiB: int,
+) -> Callable[..., dict[float, str]]:
+    """Generate fractional suffixes by halving memory in GiB.
+
+    Returns a callable that produces a geometric series with r=1/2
+    starting from the resource's total memory in GiB down to ``minGiB``.
+    Each entry maps a fractional float to the corresponding memory
+    suffix string.
+
+    Example — 64 GiB host with ``minGiB=8``::
+
+        {1.0: "64", 0.5: "32", 0.25: "16", 0.125: "8"}
+
+    Usage::
+
+        @register.named_resource(fractionals=halve_mem_down_to(minGiB=16))
+        def t1(fractional: float = WHOLE) -> Resource: ...
+
+    Args:
+        minGiB: Stop generating fractionals when memory drops below
+            this threshold in GiB.  Must be >= the odd part of
+            ``memGiB`` (i.e. ``memGiB`` with all factors of 2
+            removed), otherwise halving would produce non-integer
+            GiB values.
+
+    Raises:
+        ValueError: if ``resource.memMB`` is zero, not GiB-aligned,
+            or ``minGiB`` is below the odd part of ``memGiB``.
+    """
+
+    def _odd_part(n: int) -> int:
+        """Return the odd part of *n* (strip all factors of 2)."""
+        while n > 0 and n % 2 == 0:
+            n //= 2
+        return n
+
+    def _factory(resource: Any) -> dict[float, str]:
+        mem_mb = resource.memMB
+        if mem_mb <= 0:
+            raise ValueError(
+                f"resource must have memMB > 0 to generate memory slices (got {mem_mb})"
+            )
+        if mem_mb % 1024 != 0:
+            raise ValueError(
+                f"resource.memMB must be a whole number of GiB (got {mem_mb} MB)"
+            )
+        mem_gib = mem_mb // 1024
+        odd = _odd_part(mem_gib)
+        if minGiB < odd:
+            raise ValueError(
+                f"`minGiB` must be >= the odd part of `memGiB` ({odd}) "
+                f"because halving {mem_gib} GiB below {odd} produces "
+                f"non-integer GiB values (got minGiB={minGiB})"
+            )
+
+        fractionals: dict[float, str] = {}
+        fraction = 1.0
+        while (frac_gib := int(mem_gib * fraction)) >= minGiB:
+            fractionals[fraction] = str(frac_gib)
+            fraction /= 2
+        return fractionals
+
+    return _factory
+
+
 class register:
     """Decorator that tags a function as a TorchX plugin.
 
@@ -105,15 +213,14 @@ class register:
     Fractional resource helpers
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    :py:meth:`powers_of_two_gpus` and :py:meth:`halve_mem_down_to` are
-    available as staticmethods so plugin authors can use them with a
-    single import::
+    :py:func:`powers_of_two_gpus` and :py:func:`halve_mem_down_to` are
+    module-level functions that plugin authors can use directly::
 
-        @register.named_resource(fractionals=register.powers_of_two_gpus)
+        @register.named_resource(fractionals=powers_of_two_gpus)
         def my_gpu(fractional: float = 1.0) -> Resource:
             ...
 
-        @register.named_resource(fractionals=register.halve_mem_down_to(minGiB=16))
+        @register.named_resource(fractionals=halve_mem_down_to(minGiB=16))
         def my_cpu(fractional: float = 1.0) -> Resource:
             ...
 
@@ -166,116 +273,6 @@ class register:
             name=name, aliases=aliases, fractionals=fractionals
         )
 
-    # -- named-resource authoring utilities (staticmethods) ----------------
-
-    @staticmethod
-    def powers_of_two_gpus(resource: Any) -> dict[float, str]:
-        """Return fractional specs for every power-of-two GPU slice of *resource*.
-
-        For example, an 8-GPU resource produces::
-
-            {1.0: "8", 0.5: "4", 0.25: "2", 0.125: "1"}
-
-        When passed as the ``fractionals`` argument of
-        :py:meth:`register.named_resource`, this auto-generates and registers
-        all power-of-two fractional variants (e.g. ``my_gpu_8``, ``my_gpu_4``,
-        …).
-
-        Args:
-            resource: The base (whole-host) resource.  Must have ``gpu > 0``
-                and ``gpu`` must be a power of two.
-
-        Raises:
-            ValueError: if ``resource.gpu`` is zero or not a power of two.
-        """
-
-        def _is_pow2(n: int) -> bool:
-            return (n > 0) and ((n & (n - 1)) == 0)
-
-        gpus = resource.gpu
-        if gpus <= 0:
-            raise ValueError(
-                f"resource must have gpu > 0 to generate power-of-two slices (got {gpus})"
-            )
-        if not _is_pow2(gpus):
-            raise ValueError(
-                f"resource.gpu must be a power of two to generate slices (got {gpus})"
-            )
-
-        fractionals: dict[float, str] = {}
-        fraction = 1.0
-        while (fractional_gpus := int(gpus * fraction)) > 0:
-            fractionals[fraction] = str(fractional_gpus)
-            fraction /= 2
-        return fractionals
-
-    @staticmethod
-    def halve_mem_down_to(
-        *,
-        minGiB: int,
-    ) -> Callable[..., dict[float, str]]:
-        """Generate fractional suffixes by halving memory in GiB.
-
-        Returns a callable that produces a geometric series with r=1/2
-        starting from the resource's total memory in GiB down to ``minGiB``.
-        Each entry maps a fractional float to the corresponding memory
-        suffix string.
-
-        Example — 64 GiB host with ``minGiB=8``::
-
-            {1.0: "64", 0.5: "32", 0.25: "16", 0.125: "8"}
-
-        Usage::
-
-            @register.named_resource(fractionals=register.halve_mem_down_to(minGiB=16))
-            def t1(fractional: float = WHOLE) -> Resource: ...
-
-        Args:
-            minGiB: Stop generating fractionals when memory drops below
-                this threshold in GiB.  Must be >= the odd part of
-                ``memGiB`` (i.e. ``memGiB`` with all factors of 2
-                removed), otherwise halving would produce non-integer
-                GiB values.
-
-        Raises:
-            ValueError: if ``resource.memMB`` is zero, not GiB-aligned,
-                or ``minGiB`` is below the odd part of ``memGiB``.
-        """
-
-        def _odd_part(n: int) -> int:
-            """Return the odd part of *n* (strip all factors of 2)."""
-            while n > 0 and n % 2 == 0:
-                n //= 2
-            return n
-
-        def _factory(resource: Any) -> dict[float, str]:
-            mem_mb = resource.memMB
-            if mem_mb <= 0:
-                raise ValueError(
-                    f"resource must have memMB > 0 to generate memory slices (got {mem_mb})"
-                )
-            if mem_mb % 1024 != 0:
-                raise ValueError(
-                    f"resource.memMB must be a whole number of GiB (got {mem_mb} MB)"
-                )
-            mem_gib = mem_mb // 1024
-            odd = _odd_part(mem_gib)
-            if minGiB < odd:
-                raise ValueError(
-                    f"`minGiB` must be >= the odd part of `memGiB` ({odd}) "
-                    f"because halving {mem_gib} GiB below {odd} produces "
-                    f"non-integer GiB values (got minGiB={minGiB})"
-                )
-
-            fractionals: dict[float, str] = {}
-            fraction = 1.0
-            while (frac_gib := int(mem_gib * fraction)) >= minGiB:
-                fractionals[fraction] = str(frac_gib)
-                fraction /= 2
-            return fractionals
-
-        return _factory
-
 
 class _register_named_resource(register):
     """Specialised :py:class:`register` for named resources.
@@ -301,7 +298,7 @@ class _register_named_resource(register):
       For every ``{fraction: suffix}`` entry, a zero-arg factory named
       ``{base_name}_{suffix}`` is auto-generated and registered.
 
-      For example, an 8-GPU resource with :py:meth:`register.powers_of_two_gpus`
+      For example, an 8-GPU resource with :py:func:`powers_of_two_gpus`
       produces ``my_gpu_8``, ``my_gpu_4``, ``my_gpu_2``, ``my_gpu_1`` —
       each calling ``my_gpu(fractional=<fraction>)``.
 

--- a/torchx/plugins/test/default/torchx_plugins/named_resources/generic.py
+++ b/torchx/plugins/test/default/torchx_plugins/named_resources/generic.py
@@ -9,13 +9,13 @@
 
 """Generic named resources for testing namespace package discovery."""
 
-from torchx.plugins import register, WHOLE
+from torchx.plugins import halve_mem_down_to, powers_of_two_gpus, register, WHOLE
 from torchx.specs.api import Resource
 
 GiB: int = 1024
 
 
-@register.named_resource(aliases=["t4g"], fractionals=register.powers_of_two_gpus)
+@register.named_resource(aliases=["t4g"], fractionals=powers_of_two_gpus)
 def gpu(fractional: float = WHOLE) -> Resource:
     return Resource(
         cpu=int(64 * fractional),
@@ -24,7 +24,7 @@ def gpu(fractional: float = WHOLE) -> Resource:
     )
 
 
-@register.named_resource(fractionals=register.halve_mem_down_to(minGiB=8))
+@register.named_resource(fractionals=halve_mem_down_to(minGiB=8))
 def cpu(fractional: float = WHOLE) -> Resource:
     return Resource(
         cpu=int(16 * fractional),

--- a/torchx/plugins/test/register_test.py
+++ b/torchx/plugins/test/register_test.py
@@ -19,7 +19,12 @@ import types
 import unittest
 from typing import Any
 
-from torchx.plugins._registration import _register_named_resource, register
+from torchx.plugins._registration import (
+    _register_named_resource,
+    halve_mem_down_to,
+    powers_of_two_gpus,
+    register,
+)
 from torchx.plugins._registry import NAMED_RESOURCES_ATTR, PluginType, registry
 from torchx.specs.api import Resource
 
@@ -430,11 +435,11 @@ class NamedResourceRegisterTest(unittest.TestCase):
 
 
 class PowersOfTwoGpusTest(unittest.TestCase):
-    """Unit tests for :meth:`register.powers_of_two_gpus`."""
+    """Unit tests for :meth:`powers_of_two_gpus`."""
 
     def test_8_gpus(self) -> None:
         r = Resource(cpu=64, gpu=8, memMB=1024)
-        result = register.powers_of_two_gpus(r)
+        result = powers_of_two_gpus(r)
         self.assertEqual(
             result,
             {1.0: "8", 0.5: "4", 0.25: "2", 0.125: "1"},
@@ -443,7 +448,7 @@ class PowersOfTwoGpusTest(unittest.TestCase):
 
     def test_2_gpus(self) -> None:
         r = Resource(cpu=16, gpu=2, memMB=512)
-        result = register.powers_of_two_gpus(r)
+        result = powers_of_two_gpus(r)
         self.assertEqual(
             result,
             {1.0: "2", 0.5: "1"},
@@ -452,7 +457,7 @@ class PowersOfTwoGpusTest(unittest.TestCase):
 
     def test_1_gpu(self) -> None:
         r = Resource(cpu=8, gpu=1, memMB=256)
-        result = register.powers_of_two_gpus(r)
+        result = powers_of_two_gpus(r)
         self.assertEqual(
             result,
             {1.0: "1"},
@@ -462,22 +467,40 @@ class PowersOfTwoGpusTest(unittest.TestCase):
     def test_zero_gpus_raises(self) -> None:
         r = Resource(cpu=8, gpu=0, memMB=256)
         with self.assertRaises(ValueError, msg="gpu=0 should raise"):
-            register.powers_of_two_gpus(r)
+            powers_of_two_gpus(r)
 
     def test_non_power_of_two_gpus_raises(self) -> None:
         r = Resource(cpu=8, gpu=6, memMB=256)
         with self.assertRaises(ValueError, msg="gpu=6 should raise"):
-            register.powers_of_two_gpus(r)
+            powers_of_two_gpus(r)
+
+    def test_top_level_importable(self) -> None:
+        """``powers_of_two_gpus`` and ``halve_mem_down_to`` are importable from ``torchx.plugins``."""
+        from torchx.plugins import (
+            halve_mem_down_to as pkg_halve,
+            powers_of_two_gpus as pkg_pot,
+        )
+
+        self.assertIs(
+            pkg_pot,
+            powers_of_two_gpus,
+            "top-level import should be the same function",
+        )
+        self.assertIs(
+            pkg_halve,
+            halve_mem_down_to,
+            "top-level import should be the same function",
+        )
 
 
 class HalvingMemGiBTest(unittest.TestCase):
-    """Unit tests for :meth:`register.halve_mem_down_to`."""
+    """Unit tests for :meth:`halve_mem_down_to`."""
 
     GiB: int = 1024
 
     def test_64_gib_min_1(self) -> None:
         r = Resource(cpu=16, gpu=0, memMB=64 * self.GiB)
-        result = register.halve_mem_down_to(minGiB=1)(r)
+        result = halve_mem_down_to(minGiB=1)(r)
         self.assertEqual(
             result,
             {
@@ -494,7 +517,7 @@ class HalvingMemGiBTest(unittest.TestCase):
 
     def test_64_gib_min_8(self) -> None:
         r = Resource(cpu=16, gpu=0, memMB=64 * self.GiB)
-        factory = register.halve_mem_down_to(minGiB=8)
+        factory = halve_mem_down_to(minGiB=8)
         result = factory(r)
         self.assertEqual(
             result,
@@ -504,7 +527,7 @@ class HalvingMemGiBTest(unittest.TestCase):
 
     def test_256_gib_min_32(self) -> None:
         r = Resource(cpu=24, gpu=0, memMB=256 * self.GiB)
-        factory = register.halve_mem_down_to(minGiB=32)
+        factory = halve_mem_down_to(minGiB=32)
         result = factory(r)
         self.assertEqual(
             result,
@@ -515,7 +538,7 @@ class HalvingMemGiBTest(unittest.TestCase):
     def test_non_power_of_two_mem(self) -> None:
         """96 GiB (= 3 * 2^5) is valid, halves to 3."""
         r = Resource(cpu=16, gpu=0, memMB=96 * self.GiB)
-        factory = register.halve_mem_down_to(minGiB=3)
+        factory = halve_mem_down_to(minGiB=3)
         result = factory(r)
         self.assertEqual(
             result,
@@ -526,16 +549,16 @@ class HalvingMemGiBTest(unittest.TestCase):
     def test_min_below_odd_part_raises(self) -> None:
         """96 GiB has odd part 3; min=2 should raise."""
         r = Resource(cpu=16, gpu=0, memMB=96 * self.GiB)
-        factory = register.halve_mem_down_to(minGiB=2)
+        factory = halve_mem_down_to(minGiB=2)
         with self.assertRaises(ValueError, msg="min < odd part should raise"):
             factory(r)
 
     def test_zero_mem_raises(self) -> None:
         r = Resource(cpu=8, gpu=0, memMB=0)
         with self.assertRaises(ValueError, msg="memMB=0 should raise"):
-            register.halve_mem_down_to(minGiB=1)(r)
+            halve_mem_down_to(minGiB=1)(r)
 
     def test_non_gib_aligned_raises(self) -> None:
         r = Resource(cpu=8, gpu=0, memMB=500)
         with self.assertRaises(ValueError, msg="non-GiB-aligned memMB should raise"):
-            register.halve_mem_down_to(minGiB=1)(r)
+            halve_mem_down_to(minGiB=1)(r)


### PR DESCRIPTION
Summary:

Original motivation: https://www.internalfb.com/diff/D99506286?dst_version_fbid=1307352738124570&transaction_fbid=836074936188650

`powers_of_two_gpus` and `halve_mem_down_to` were staticmethods on the
`register` class.  This moves them to module-level functions in
`_registration.py` and updates all callers (`register.powers_of_two_gpus` →
`powers_of_two_gpus`).  Since all usages are within fbcode/torchx, no
backwards-compat aliases are needed.

Plugin authors can now write:
    from torchx.plugins import powers_of_two_gpus, halve_mem_down_to

Differential Revision: D99601942


