### PR TITLE
Fix #1267: [torchx/schedulers] Add support for `kueue_scheduler`

### DIFF
--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -1933,3 +1933,25 @@ class KubernetesSchedulerNoImportTest(unittest.TestCase):
 
         with self.assertRaises(ModuleNotFoundError):
             scheduler.submit_dryrun(app, cfg)
+
+
+class KueueSchedulerTest(unittest.TestCase):
+    def test_factory_returns_kueue_scheduler(self) -> None:
+        from torchx_plugins.schedulers.kueue import kueue_scheduler, KueueScheduler
+
+        sched = kueue_scheduler(session_name="test")
+        self.assertIsInstance(sched, KueueScheduler)
+        self.assertEqual(sched.session_name, "test")
+
+    def test_queue_label_added_to_metadata(self) -> None:
+        from torchx_plugins.schedulers.kueue import KUEUE_QUEUE_LABEL, KueueScheduler
+
+        resource: dict[str, object] = {"metadata": {"name": "my-job"}, "spec": {}}
+        mock_dryrun = MagicMock()
+        mock_dryrun.request.resource = resource
+        cfg = Opts(queue="my-kueue-queue")
+        with patch.object(KubernetesScheduler, "_submit_dryrun", return_value=mock_dryrun):
+            result = KueueScheduler(session_name="test")._submit_dryrun(MagicMock(), cfg)
+        labels = resource["metadata"]["labels"]  # type: ignore[index]
+        self.assertEqual(labels[KUEUE_QUEUE_LABEL], "my-kueue-queue")  # type: ignore[index]
+        self.assertIs(result, mock_dryrun)

--- a/torchx_plugins/schedulers/kueue.py
+++ b/torchx_plugins/schedulers/kueue.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Kueue scheduler plugin — wraps KubernetesScheduler with Kueue queue labels."""
+
+from torchx.plugins import register
+from torchx.schedulers.kubernetes_scheduler import KubernetesJob, KubernetesScheduler, Opts
+from torchx.specs.api import AppDef, AppDryRunInfo
+
+KUEUE_QUEUE_LABEL: str = "kueue.x-k8s.io/queue-name"
+
+
+class KueueScheduler(KubernetesScheduler):
+    """KubernetesScheduler variant that stamps ``kueue.x-k8s.io/queue-name`` labels."""
+
+    def _submit_dryrun(self, app: AppDef, cfg: Opts) -> AppDryRunInfo[KubernetesJob]:
+        dryrun_info = super()._submit_dryrun(app, cfg)
+        queue = cfg.get("queue") or "default"
+        assert isinstance(queue, str), "queue must be a str"
+        dryrun_info.request.resource["metadata"].setdefault("labels", {})[KUEUE_QUEUE_LABEL] = queue
+        return dryrun_info
+
+
+@register.scheduler(name="kueue")
+def kueue_scheduler(session_name: str, **kwargs: object) -> KueueScheduler:
+    """Create a :class:`KueueScheduler`."""
+    return KueueScheduler(session_name=session_name)


### PR DESCRIPTION
Closes #1267

Adds `KueueScheduler` as a namespace-package plugin under `torchx_plugins/schedulers/kueue.py`, implementing the plugin architecture described in the issue. `KueueScheduler` subclasses `KubernetesScheduler` and overrides `_submit_dryrun` to inject the `kueue.x-k8s.io/queue-name` label into the job resource metadata before submission. The queue name is read from `cfg.get("queue")`, defaulting to `"default"` if unset. The factory function `kueue_scheduler` is registered via `@register.scheduler(name="kueue")`, making it auto-discoverable at runtime when the wheel containing `torchx_plugins/` is installed.

Test plan:
Two unit tests added to `torchx/schedulers/test/kubernetes_scheduler_test.py` under `KueueSchedulerTest`:
- `test_factory_returns_kueue_scheduler`: calls `kueue_scheduler(session_name="test")` and asserts the returned object is a `KueueScheduler` instance with `session_name == "test"`.
- `test_queue_label_added_to_metadata`: patches `KubernetesScheduler._submit_dryrun` with a `MagicMock`, invokes `KueueScheduler(session_name="test")._submit_dryrun` with `Opts(queue="my-kueue-queue")`, and asserts that `resource["metadata"]["labels"]["kueue.x-k8s.io/queue-name"] == "my-kueue-queue"` and that the original `dryrun_info` object is returned unmodified.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*