### PR TITLE
Runner auto-discovers scheduler plugins when scheduler_factories is not provided

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -101,7 +101,9 @@ class Runner:
     ) -> None:
         self._name: str = name
         self._scheduler_factories: dict[str, SchedulerFactory] = (
-            scheduler_factories or {}
+            scheduler_factories
+            if scheduler_factories is not None
+            else get_scheduler_factories()
         )
         self._scheduler_params: dict[str, Any] = {
             **(self._get_scheduler_params_from_env()),

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -762,6 +762,36 @@ class RunnerTest(TestWithTmpDir):
         runner = get_runner()
         self.assertEqual("torchx", runner._name)
 
+    def test_runner_autodiscovers_schedulers(self, _) -> None:
+        """Runner() auto-discovers plugins; explicit factories skip discovery."""
+        mock_factory = MagicMock()
+        with patch(
+            GET_SCHEDULER_FACTORIES,
+            return_value={"kubernetes": mock_factory},
+        ) as mock_get:
+            # No scheduler_factories → auto-discover
+            with Runner(name="my_session") as runner:
+                self.assertIn(
+                    "kubernetes",
+                    runner.scheduler_backends(),
+                    "Runner should auto-discover schedulers when none are provided",
+                )
+            mock_get.assert_called()
+            mock_get.reset_mock()
+
+            # Explicit scheduler_factories → skip discovery
+            with Runner(
+                name="my_session",
+                scheduler_factories={"local_cwd": mock_factory},
+            ) as runner:
+                self.assertIn("local_cwd", runner.scheduler_backends())
+                self.assertNotIn(
+                    "kubernetes",
+                    runner.scheduler_backends(),
+                    "explicit factories should skip auto-discovery",
+                )
+            mock_get.assert_not_called()
+
     def test_cfg_from_str(self, _) -> None:
         scheduler_mock = MagicMock()
         opts = runopts()


### PR DESCRIPTION
Summary:
Make `Runner()` auto-discover installed scheduler plugins via
`get_scheduler_factories()` when `scheduler_factories` is not provided.

Previously, `Runner(scheduler_factories=None)` defaulted to an empty dict,
requiring callers to always pass explicit factories. Only `get_runner()`
called `get_scheduler_factories()`, but most code constructs `Runner()`
directly.

Now `Runner(name="my_session")` is sufficient — it discovers all registered
schedulers (e.g. `register.scheduler("kubernetes")` from torchx_plugins).
Passing explicit `scheduler_factories={...}` still works and skips discovery.

Differential Revision: D100054882


