### PR TITLE
Support nested dataclasses in StructuredOpts (#1280)

### DIFF
--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import os
+from dataclasses import dataclass, field
 from datetime import datetime
 from io import StringIO
 from typing import Dict, Iterable, List, Mapping
@@ -24,7 +25,12 @@ from torchx.runner.config import (
     load_sections,
 )
 from torchx.schedulers import get_scheduler_factories, Scheduler
-from torchx.schedulers.api import DescribeAppResponse, ListAppResponse, Stream
+from torchx.schedulers.api import (
+    DescribeAppResponse,
+    ListAppResponse,
+    Stream,
+    StructuredOpts,
+)
 from torchx.specs import AppDef, AppDryRunInfo, CfgVal, runopts, Workspace
 from torchx.test.fixtures import TestWithTmpDir
 
@@ -540,3 +546,66 @@ workspace =
             },
             workspace.projects,
         )
+
+
+@dataclass
+class OptB(StructuredOpts):
+    x: str | None = None
+    """An optional string."""
+
+    y: str = "default_y"
+    """A string with default."""
+
+
+@dataclass
+class OptA(StructuredOpts):
+    name: str = "default_name"
+    """A top-level string."""
+
+    b: OptB = field(default_factory=OptB)
+    """Nested opts group."""
+
+
+class NestedTestScheduler(TestScheduler):
+    def __init__(self, session_name: str) -> None:
+        Scheduler.__init__(self, "nested_test", session_name)
+
+    def _run_opts(self) -> runopts:
+        return OptA.as_runopts()
+
+
+_NESTED_CONFIG = """#
+[nested_test]
+name = foo
+b.x = bar
+b.y = baz
+"""
+
+
+class NestedConfigTest(TestWithTmpDir):
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"nested_test": NestedTestScheduler},
+    )
+    def test_load_and_from_cfg(self, _) -> None:
+        cfg: dict[str, CfgVal] = {}
+        load(scheduler="nested_test", f=StringIO(_NESTED_CONFIG), cfg=cfg)
+        self.assertEqual("foo", cfg.get("name"))
+        self.assertEqual("bar", cfg.get("b.x"))
+        self.assertEqual("baz", cfg.get("b.y"))
+
+        opts = OptA.from_cfg(cfg)
+        self.assertEqual(opts.name, "foo")
+        self.assertEqual(opts.b.x, "bar")
+        self.assertEqual(opts.b.y, "baz")
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"nested_test": NestedTestScheduler},
+    )
+    def test_load_no_override_and_partial(self, _) -> None:
+        cfg: dict[str, CfgVal] = {"b.x": "cli-value"}
+        load(scheduler="nested_test", f=StringIO(_NESTED_CONFIG), cfg=cfg)
+        self.assertEqual("cli-value", cfg.get("b.x"))
+        self.assertEqual("baz", cfg.get("b.y"))

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -19,7 +19,6 @@ from enum import Enum
 from typing import (
     Generic,
     get_args,
-    get_origin,
     get_type_hints,
     Iterable,
     List,
@@ -53,6 +52,30 @@ DAYS_IN_2_WEEKS = 14
 # =============================================================================
 
 
+# pyre-fixme[24]: Generic type `type` expects 1 type parameter.
+def _unwrap_optional(tp: type) -> type:
+    """Strip ``None`` from union types (e.g. ``str | None`` -> ``str``)."""
+    args = [a for a in get_args(tp) if a is not types.NoneType]
+    if args and len(args) < len(get_args(tp)):
+        return args[0] if len(args) == 1 else Union[tuple(args)]
+    return tp
+
+
+# pyre-fixme[24]: Generic type `type` expects 1 type parameter.
+def _is_structured_opts(tp: type) -> bool:
+    """Return True if *tp* is a concrete ``StructuredOpts`` subclass."""
+    try:
+        return (
+            isinstance(tp, type)
+            and issubclass(tp, StructuredOpts)
+            and tp is not StructuredOpts
+        )
+    except TypeError:
+        # Generic aliases like list[str] or dict[str, str] can pass
+        # isinstance(tp, type) on some Python versions but fail issubclass().
+        return False
+
+
 class StructuredOpts(Mapping[str, CfgVal]):
     """Base class for typed scheduler configuration options.
 
@@ -65,6 +88,8 @@ class StructuredOpts(Mapping[str, CfgVal]):
         - Parses raw config dicts into typed instances via :py:meth:`from_cfg`
         - Supports snake_case field names with camelCase aliases
         - Extracts help text from field docstrings
+        - Supports nested ``StructuredOpts`` fields, flattened with dot-prefixed
+          keys (e.g., ``k8s.context``)
 
     Example:
         .. doctest::
@@ -96,11 +121,27 @@ class StructuredOpts(Mapping[str, CfgVal]):
 
         Fields are snake_case but also accept camelCase aliases (e.g.,
         ``hpc_identity`` can be set via ``hpcIdentity``).
+        Nested :py:class:`StructuredOpts` fields are reconstructed from
+        dot-prefixed keys (e.g., ``k8s.context``).
         """
+        type_hints = get_type_hints(cls)
         kwargs = {}
         for f in fields(cls):
             name = f.name
-            # Check for snake_case key first, then camelCase alias
+            field_type = _unwrap_optional(type_hints.get(name, str))
+
+            if _is_structured_opts(field_type):
+                prefix = f"{name}."
+                nested_cfg = {
+                    k[len(prefix) :]: v for k, v in cfg.items() if k.startswith(prefix)
+                }
+                if nested_cfg:
+                    kwargs[name] = field_type.from_cfg(nested_cfg)
+                elif f.default is MISSING and f.default_factory is MISSING:
+                    # Required nested group — construct so its own validation runs.
+                    kwargs[name] = field_type.from_cfg({})
+                continue
+
             if name in cfg:
                 kwargs[name] = cfg[name]
             else:
@@ -129,17 +170,32 @@ class StructuredOpts(Mapping[str, CfgVal]):
             return None
 
     def __getitem__(self, key: str) -> CfgVal:
+        if "." in key:
+            prefix, rest = key.split(".", 1)
+            prefix = cases.camel_to_snake(prefix)
+            nested = getattr(self, prefix, None)
+            if isinstance(nested, StructuredOpts):
+                return nested[rest]
+            raise KeyError(key) from None
         snake_key = cases.camel_to_snake(key)
         if hasattr(self, snake_key):
             return getattr(self, snake_key)
         raise KeyError(key) from None
 
     def __len__(self) -> int:
-        return len(fields(self))
+        return sum(1 for _ in self)
 
     def __iter__(self) -> Iterator[str]:
+        type_hints = get_type_hints(type(self))
         for f in fields(self):
-            yield f.name
+            field_type = _unwrap_optional(type_hints.get(f.name, str))
+            if _is_structured_opts(field_type):
+                nested = getattr(self, f.name)
+                if nested is not None:
+                    for nested_key in nested:
+                        yield f"{f.name}.{nested_key}"
+            else:
+                yield f.name
 
     # pyre-fixme[14]: Inconsistent override - Mapping uses PyreReadOnly[object]
     def __contains__(self, key: object) -> bool:
@@ -160,8 +216,7 @@ class StructuredOpts(Mapping[str, CfgVal]):
         except (OSError, TypeError):
             return docstrings
 
-        # Pattern to match: field_name: type = value (optional) followed by docstring
-        # Captures: field name, then the triple-quoted docstring on the next line
+        # Match: field_name: type...\n    """docstring"""
         pattern = re.compile(
             r'^\s+(\w+):\s*[^\n]+\n\s+"""([^"]+)"""',
             re.MULTILINE,
@@ -171,41 +226,47 @@ class StructuredOpts(Mapping[str, CfgVal]):
             docstring = match.group(2).strip()
             docstrings[field_name] = docstring
 
+        type_hints = get_type_hints(cls)
+        for f in fields(cls):
+            field_type = _unwrap_optional(type_hints.get(f.name, str))
+            if _is_structured_opts(field_type):
+                for key, doc in field_type.get_docstrings().items():
+                    docstrings[f"{f.name}.{key}"] = doc
+
         return docstrings
 
     @classmethod
     def as_runopts(cls) -> runopts:
-        """Build :py:class:`~torchx.specs.runopts` from dataclass fields."""
+        """Build :py:class:`~torchx.specs.runopts` from dataclass fields.
+
+        Nested :py:class:`StructuredOpts` fields are flattened with
+        dot-prefixed keys (e.g., field ``k8s: K8sOpts`` with sub-field
+        ``context`` becomes ``k8s.context``).
+        """
         opts = runopts()
 
-        # Get resolved type hints (handles string annotations from __future__.annotations)
         type_hints = get_type_hints(cls)
-        # Get field docstrings parsed from source code
         docstrings = cls.get_docstrings()
 
         for f in fields(cls):
             name = f.name
+            field_type = _unwrap_optional(type_hints.get(name, str))
 
-            # Get help text from field docstring
+            if _is_structured_opts(field_type):
+                nested_opts = field_type.as_runopts()
+                for nested_key, nested_runopt in nested_opts:
+                    opts.add(
+                        f"{name}.{nested_key}",
+                        type_=nested_runopt.opt_type,
+                        default=nested_runopt.default,
+                        required=nested_runopt.is_required,
+                        help=nested_runopt.help,
+                    )
+                continue
+
             help_text = docstrings.get(name, name)
-
-            # Get type: extract base type from Union (e.g., int | None -> int)
-            field_type = type_hints.get(name, str)
-            origin = get_origin(field_type)
-            # Handle Union types to extract the base type for runopts.
-            # This logic handles field declarations like:
-            #   * foo: str | None = None  (types.UnionType without __future__.annotations)
-            #   * foo: Union[str, None] = None
-            #   * foo: Optional[str] = None  (equivalent to Union[str, None])
-            # Note: With `from __future__ import annotations`, get_type_hints() returns
-            # typing.Union for all syntaxes. The UnionType check handles the case
-            # without __future__.annotations where `str | None` creates types.UnionType.
-            if origin is Union or isinstance(field_type, types.UnionType):
-                args = [a for a in get_args(field_type) if a is not type(None)]
-                field_type = args[0] if args else str
             type_ = field_type
 
-            # Get default value
             has_default = f.default is not MISSING
             has_default_factory = f.default_factory is not MISSING
             if has_default:
@@ -215,10 +276,8 @@ class StructuredOpts(Mapping[str, CfgVal]):
             else:
                 default = None
 
-            # Determine if required (no default value)
             required = not has_default and not has_default_factory
 
-            # Add the option
             opts.add(
                 name,
                 type_=type_,

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 
 import unittest
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Iterable, Mapping, TypeVar
 from unittest.mock import MagicMock, patch
@@ -516,3 +516,167 @@ class StructuredOptsTest(unittest.TestCase):
         # None values should be preserved
         self.assertIn("optional_tag", cfg)
         self.assertIsNone(cfg["optional_tag"])
+
+
+@dataclass
+class InnerOpts(StructuredOpts):
+    x: str | None = None
+    """An optional string."""
+
+    y: str | None = None
+    """Another optional string."""
+
+    z: str = "default_z"
+    """A string with default."""
+
+
+@dataclass
+class OuterOpts(StructuredOpts):
+    name: str = "default_name"
+    """A top-level string."""
+
+    inner: InnerOpts = field(default_factory=InnerOpts)
+    """Nested opts group."""
+
+
+@dataclass
+class DeepC(StructuredOpts):
+    flag: bool = False
+    """A boolean."""
+
+
+@dataclass
+class DeepB(StructuredOpts):
+    c: DeepC = field(default_factory=DeepC)
+    """Third level."""
+
+    val: int = 0
+    """An int."""
+
+
+@dataclass
+class DeepA(StructuredOpts):
+    b: DeepB = field(default_factory=DeepB)
+    """Second level."""
+
+    tag: str = "default_tag"
+    """A string."""
+
+
+class NestedStructuredOptsTest(unittest.TestCase):
+
+    def test_as_runopts(self) -> None:
+        opts = OuterOpts.as_runopts()
+        keys = [k for k, _ in opts]
+        self.assertEqual(
+            keys,
+            ["name", "inner.x", "inner.y", "inner.z"],
+        )
+        z_opt = opts.get("inner.z")
+        self.assertIsNotNone(z_opt)
+        self.assertEqual(z_opt.default, "default_z")
+        self.assertFalse(z_opt.is_required)
+
+    def test_from_cfg(self) -> None:
+        cfg = {
+            "name": "foo",
+            "inner.x": "bar",
+            "inner.z": "baz",
+        }
+        opts = OuterOpts.from_cfg(cfg)
+        self.assertEqual(opts.name, "foo")
+        self.assertEqual(opts.inner.x, "bar")
+        self.assertEqual(opts.inner.z, "baz")
+
+    def test_from_cfg_partial_uses_defaults(self) -> None:
+        opts = OuterOpts.from_cfg({"inner.x": "val"})
+        self.assertEqual(opts.inner.x, "val")
+        self.assertEqual(opts.inner.z, "default_z")
+        self.assertIsNone(opts.inner.y)
+        self.assertEqual(opts.name, "default_name")
+
+    def test_mapping_protocol(self) -> None:
+        opts = OuterOpts(inner=InnerOpts(x="a", z="b"))
+        self.assertEqual(
+            list(opts),
+            ["name", "inner.x", "inner.y", "inner.z"],
+        )
+        self.assertEqual(len(opts), 4)
+        self.assertEqual(opts["inner.x"], "a")
+        self.assertIn("inner.z", opts)
+        self.assertNotIn("inner.missing", opts)
+        with self.assertRaises(KeyError):
+            opts["inner.nonexistent"]
+
+    def test_get_docstrings(self) -> None:
+        docs = OuterOpts.get_docstrings()
+        self.assertEqual(docs.get("inner.x"), "An optional string.")
+        self.assertEqual(docs.get("inner.z"), "A string with default.")
+        self.assertEqual(docs.get("name"), "A top-level string.")
+
+    def test_or_merge(self) -> None:
+        merged = OuterOpts(name="a", inner=InnerOpts(x="b")) | SampleOpts(
+            cluster_name="c"
+        )
+        self.assertIsInstance(merged, dict)
+        self.assertEqual(merged["inner.x"], "b")
+        self.assertEqual(merged["name"], "a")
+        self.assertEqual(merged["cluster_name"], "c")
+
+    def test_three_levels_deep(self) -> None:
+        opts = DeepA.as_runopts()
+        keys = [k for k, _ in opts]
+        self.assertEqual(
+            keys,
+            ["b.c.flag", "b.val", "tag"],
+        )
+
+        cfg = {
+            "b.c.flag": True,
+            "b.val": 42,
+            "tag": "test",
+        }
+        deep = DeepA.from_cfg(cfg)
+        self.assertTrue(deep.b.c.flag)
+        self.assertEqual(deep.b.val, 42)
+        self.assertEqual(deep.tag, "test")
+        self.assertTrue(deep["b.c.flag"])
+
+    def test_optional_nested_none(self) -> None:
+        @dataclass
+        class OptsWithOptional(StructuredOpts):
+            name: str = "default_name"
+            inner: InnerOpts | None = None
+
+        opts = OptsWithOptional()
+        self.assertIsNone(opts.inner)
+        self.assertEqual(list(opts), ["name"])
+        self.assertEqual(len(opts), 1)
+        self.assertNotIn("inner.x", opts)
+        self.assertIsNone(opts.get("inner.x"))
+
+    def test_required_nested_from_cfg(self) -> None:
+        @dataclass
+        class OptsWithRequired(StructuredOpts):
+            inner: InnerOpts
+            name: str = "default_name"
+
+        opts = OptsWithRequired.from_cfg({"inner.x": "val"})
+        self.assertEqual(opts.inner.x, "val")
+        self.assertEqual(opts.inner.z, "default_z")
+
+        opts2 = OptsWithRequired.from_cfg({})
+        self.assertIsNone(opts2.inner.x)
+        self.assertEqual(opts2.inner.z, "default_z")
+
+    def test_camel_case_nested_prefix(self) -> None:
+        @dataclass
+        class ChildOpts(StructuredOpts):
+            val: str = "default_val"
+
+        @dataclass
+        class ParentOpts(StructuredOpts):
+            child_group: ChildOpts = field(default_factory=ChildOpts)
+
+        opts = ParentOpts(child_group=ChildOpts(val="custom"))
+        self.assertEqual(opts["childGroup.val"], "custom")


### PR DESCRIPTION
Summary:

StructuredOpts now supports nested StructuredOpts subclasses as fields.
Nested fields are flattened with dot-prefixed keys in runopts
(e.g. field `k8s: K8sOpts` with sub-field `context` becomes `k8s.context`).

Reviewed By: kiukchung

Differential Revision: D100175177


