### PR TITLE
Add dryrun parameter to Runner.run() (#1282)

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -13,7 +13,16 @@ import time
 import warnings
 from datetime import datetime
 from types import TracebackType
-from typing import Any, Iterable, Mapping, Type, TYPE_CHECKING, TypeVar
+from typing import (
+    Any,
+    Iterable,
+    Literal,
+    Mapping,
+    overload,
+    Type,
+    TYPE_CHECKING,
+    TypeVar,
+)
 
 from torchx.runner.events import log_event
 from torchx.schedulers import get_scheduler_factories, SchedulerFactory
@@ -211,6 +220,30 @@ class Runner:
             parent_run_id=parent_run_id,
         )
 
+    @overload
+    def run(
+        self,
+        app: AppDef,
+        scheduler: str,
+        cfg: Mapping[str, CfgVal] | None = ...,
+        workspace: Workspace | str | None = ...,
+        parent_run_id: str | None = ...,
+        *,
+        dryrun: Literal[True],
+    ) -> AppDryRunInfo: ...
+
+    @overload
+    def run(
+        self,
+        app: AppDef,
+        scheduler: str,
+        cfg: Mapping[str, CfgVal] | None = ...,
+        workspace: Workspace | str | None = ...,
+        parent_run_id: str | None = ...,
+        *,
+        dryrun: Literal[False] = ...,
+    ) -> AppHandle: ...
+
     def run(
         self,
         app: AppDef,
@@ -218,8 +251,26 @@ class Runner:
         cfg: Mapping[str, CfgVal] | None = None,
         workspace: Workspace | str | None = None,
         parent_run_id: str | None = None,
-    ) -> AppHandle:
-        """Submits an :py:class:`~torchx.specs.AppDef` and returns its :py:data:`~torchx.specs.AppHandle`."""
+        *,
+        dryrun: bool = False,
+    ) -> AppHandle | AppDryRunInfo:
+        """Submits an :py:class:`~torchx.specs.AppDef` or returns its dry-run info.
+
+        .. code-block:: python
+
+            # Submit
+            handle = runner.run(app, "mkube", cfg=cfg)
+
+            # Dryrun — inspect without submitting
+            info = runner.run(app, "mkube", cfg=cfg, dryrun=True)
+            print(info)
+
+        Args:
+            dryrun: If ``True``, only validate and render the request
+                without submitting.  Returns :py:class:`~torchx.specs.AppDryRunInfo`.
+                If ``False`` (default), submit and return the
+                :py:data:`~torchx.specs.AppHandle`.
+        """
 
         with log_event(api="run") as ctx:
             dryrun_info = self.dryrun(
@@ -229,6 +280,10 @@ class Runner:
                 workspace=workspace,
                 parent_run_id=parent_run_id,
             )
+
+            if dryrun:
+                return dryrun_info
+
             handle = self.schedule(dryrun_info)
 
             event = ctx._torchx_event

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -188,6 +188,40 @@ class RunnerTest(TestWithTmpDir):
                 event = record_mock.call_args_list[i].args[0]
                 self.assertEqual(event.session, CURRENT_SESSION_ID)
 
+    def test_run_dryrun_true(self, record_mock: MagicMock) -> None:
+        with self.get_runner() as runner:
+            role = Role(
+                name="echo",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello"],
+            )
+            app = AppDef("name", roles=[role])
+
+            result = runner.run(app, scheduler="local_dir", cfg=self.cfg, dryrun=True)
+            self.assertIsInstance(
+                result, AppDryRunInfo, "run(dryrun=True) returns AppDryRunInfo"
+            )
+
+    def test_run_dryrun_false(self, record_mock: MagicMock) -> None:
+        test_file = self.tmpdir / "test_run_dryrun_false"
+
+        with self.get_runner() as runner:
+            role = Role(
+                name="touch",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="touch.sh",
+                args=[str(test_file)],
+            )
+            app = AppDef("name", roles=[role])
+
+            result = runner.run(app, scheduler="local_dir", cfg=self.cfg, dryrun=False)
+            self.assertIsInstance(
+                result, str, "run(dryrun=False) returns AppHandle (str)"
+            )
+
     def test_dryrun(self, record_mock: MagicMock) -> None:
         scheduler_mock = MagicMock()
         scheduler_mock.run_opts.return_value.resolve.return_value = {


### PR DESCRIPTION
Summary:

Make `Runner.run()` polymorphic with `overload` + `Literal[bool]`:
- `run(..., dryrun=True)` returns `AppDryRunInfo`
- `run(..., dryrun=False)` (default) returns `AppHandle`

When callers pass a literal, Pyre/mypy narrows the return type exactly. When callers pass a runtime `bool`, the inferred type is `AppHandle | AppDryRunInfo`.

This replaces the awkward pattern repeated in every launch script:
```python
dryrun_info = runner.dryrun(app, scheduler, cfg=cfg)
if dryrun:
    print(dryrun_info)
else:
    handle = runner.schedule(dryrun_info)
    print(f"Submitted: {handle}")
```

With:
```python
result = runner.run(app, scheduler, cfg=cfg, dryrun=args.dryrun)
print(result)
```

Backwards compatible — existing `run()` callers without `dryrun` are unaffected.

Differential Revision: D100704877


