### PR TITLE
Replace boolean plugin-source flags with TORCHX_PLUGINS_SOURCE + PluginSource IntFlag (#1286)

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -20,11 +20,11 @@ sufficient.
    ``setup.py`` / ``pyproject.toml``) is deprecated. Use the ``@register``
    decorator with ``torchx_plugins.*`` namespace packages instead.
 
-   Namespace plugins are **always** loaded. By default
-   (``TORCHX_NO_ENTRYPOINTS=0`` or unset), entry points are also loaded
-   for backward compatibility. Set ``TORCHX_NO_ENTRYPOINTS=1`` to load
-   only namespace plugins. Entry-point loading will be removed in a
-   future release. See :doc:`plugins` for the full API reference.
+   By default both namespace plugins and entry points are loaded for
+   backward compatibility. Set ``TORCHX_PLUGINS_SOURCE=1`` (namespace
+   package only) to opt out of entry-point discovery early; entry-point
+   loading will be removed in a future release. See
+   :doc:`plugins` for the full API reference.
 
 .. code-block:: text
 

--- a/torchx/plugins/__init__.py
+++ b/torchx/plugins/__init__.py
@@ -28,7 +28,8 @@ Discover plugins and print a diagnostic report::
 
 .. deprecated::
     Entry-point based registration (``[torchx.*]`` in ``pyproject.toml``)
-    is deprecated.  Set ``TORCHX_NO_ENTRYPOINTS=1`` to opt out early.
+    is deprecated.  Set ``TORCHX_PLUGINS_SOURCE=1`` (namespace package
+    only) to opt out of entry-point discovery early.
 """
 
 from torchx.plugins._registration import (

--- a/torchx/plugins/_registry.py
+++ b/torchx/plugins/_registry.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pathlib
 import pkgutil
+from enum import auto
 from types import ModuleType
 from typing import Any, Callable, overload
 
@@ -46,6 +47,19 @@ class PluginType(str, enum.Enum):
     SCHEDULER = "torchx.schedulers"
     NAMED_RESOURCE = "torchx.named_resources"
     TRACKER = "torchx.tracker"
+
+
+class PluginSource(enum.IntFlag):
+    """Bitmask of plugin discovery channels.
+
+    Combine with ``|`` and test with ``in``.  The value of the
+    ``TORCHX_PLUGINS_SOURCE`` env var is parsed as the integer
+    representation of this flag.
+    """
+
+    NONE = 0
+    NAMESPACE_PKG = auto()
+    ENTRYPOINT = auto()
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
@@ -80,19 +94,24 @@ class PluginRegistry:
         scheds = reg.get(plugins.PluginType.SCHEDULER)
         print(reg)
 
-    Namespace plugins (``torchx_plugins.*``) are **always** loaded.
-    The *load_entrypoints* flag only controls whether ``importlib.metadata``
-    entry points are additionally merged in.
+    Discovery channels are selected via *plugin_sources*, a :py:class:`PluginSource`
+    bitmask.  Defaults to all channels enabled; pass :py:attr:`PluginSource.NONE`
+    for an empty registry or any combination of ``NAMESPACE_PKG`` / ``ENTRYPOINT``
+    to enable a subset.
 
     Args:
-        load_entrypoints: Whether to **also** load plugins from
-            ``importlib.metadata`` entry points.  Set to ``False`` to
-            disable entry-point loading (namespace plugins are still
-            discovered).  Defaults to ``True`` for backward compatibility.
+        plugin_sources: Bitmask of discovery channels to enable.
+            Defaults to ``NAMESPACE_PKG | ENTRYPOINT``.
     """
 
-    def __init__(self, *, load_entrypoints: bool = True) -> None:
-        self._load_entrypoints: bool = load_entrypoints
+    def __init__(
+        self,
+        *,
+        plugin_sources: PluginSource = (
+            PluginSource.NAMESPACE_PKG | PluginSource.ENTRYPOINT
+        ),
+    ) -> None:
+        self._plugin_sources: PluginSource = plugin_sources
         # pyre-ignore[4]: plugin factories are heterogeneously typed
         self._cache: dict[PluginType, dict[str, Callable[..., Any]]] = {}
         self._errors: list[RegistrationError] = []
@@ -476,28 +495,20 @@ class PluginRegistry:
 
         Merge priority (highest → lowest):
 
-        1. ``importlib.metadata`` entry points (when *load_entrypoints* is True)
-        2. ``torchx_plugins.<suffix>`` namespace submodules
+        1. ``importlib.metadata`` entry points (when ``ENTRYPOINT`` is set)
+        2. ``torchx_plugins.<suffix>`` namespace submodules (when
+           ``NAMESPACE_PKG`` is set)
         """
         group: str = plugin_type.value
         namespace = self._namespace_for_type(plugin_type)
-        ns_plugins = self._find_namespace_plugins(namespace, plugin_type)
-        merged = dict(ns_plugins)
-
-        if self._load_entrypoints:
-            ep_plugins = entrypoints.load_group(group) or {}
-            # Entry points override namespace plugins (higher priority).
-            merged.update(ep_plugins)
-            if ns_plugins and ep_plugins:
-                new_keys = set(ns_plugins) - set(ep_plugins)
-                if new_keys:
-                    logger.debug(
-                        "namespace plugins added keys %s for group `%s`",
-                        new_keys,
-                        group,
-                    )
-
-        return merged
+        plugins = (
+            self._find_namespace_plugins(namespace, plugin_type)
+            if PluginSource.NAMESPACE_PKG in self._plugin_sources
+            else {}
+        )
+        if PluginSource.ENTRYPOINT in self._plugin_sources:
+            plugins |= entrypoints.load_group(group) or {}
+        return plugins
 
 
 @functools.lru_cache(maxsize=1)
@@ -507,9 +518,11 @@ def registry() -> PluginRegistry:
     The registry lazily discovers plugins per-group on first
     :py:meth:`~PluginRegistry.get` access and caches the results.
 
-    Namespace plugins (``torchx_plugins.*``) are **always** loaded.
-    Entry points from ``importlib.metadata`` are additionally merged in
-    unless ``TORCHX_NO_ENTRYPOINTS=1`` is set.
+    The ``TORCHX_PLUGINS_SOURCE`` environment variable selects which
+    discovery channels are enabled.  Its value is parsed as the integer
+    representation of a :py:class:`PluginSource` bitmask: ``0`` for
+    none, ``1`` for namespace package only, ``2`` for entry points only,
+    ``3`` for both.  Defaults to all channels enabled when unset.
 
     Returns:
         The cached :py:class:`PluginRegistry` instance.
@@ -523,5 +536,17 @@ def registry() -> PluginRegistry:
         named = reg.get(plugins.PluginType.NAMED_RESOURCE)
         print(reg)
     """
-    load_entrypoints = os.environ.get("TORCHX_NO_ENTRYPOINTS") != "1"
-    return PluginRegistry(load_entrypoints=load_entrypoints)
+    all_sources = PluginSource.NAMESPACE_PKG | PluginSource.ENTRYPOINT
+    raw = os.environ.get("TORCHX_PLUGINS_SOURCE", str(int(all_sources)))
+    try:
+        value = int(raw)
+        if not 0 <= value <= int(all_sources):
+            raise ValueError
+        plugin_sources = PluginSource(value)
+    except ValueError as e:
+        raise ValueError(
+            f"TORCHX_PLUGINS_SOURCE={raw!r} is invalid; expected one of"
+            " 0 (none), 1 (namespace only), 2 (entry points only),"
+            " 3 (both)."
+        ) from e
+    return PluginRegistry(plugin_sources=plugin_sources)

--- a/torchx/plugins/test/registry_test.py
+++ b/torchx/plugins/test/registry_test.py
@@ -14,6 +14,7 @@ priority, named resource discovery, and fault-tolerance of discovery against
 broken plugin modules.
 """
 
+import os
 import sys
 import types
 import unittest
@@ -24,6 +25,7 @@ from unittest.mock import patch
 from torchx.plugins._registration import register
 from torchx.plugins._registry import (
     PluginRegistry,
+    PluginSource,
     PluginType,
     RegistrationError,
     registry,
@@ -83,7 +85,7 @@ class RegistryTest(_RegistryTestBase):
     """Tests ``registry()`` and ``PluginRegistry`` caching, discovery, and merge priority."""
 
     def test_returns_empty_when_not_installed(self) -> None:
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         result = reg.get(PluginType.SCHEDULER)
         self.assertEqual(
             result,
@@ -111,7 +113,7 @@ class RegistryTest(_RegistryTestBase):
 
     @mock_install_torchx_plugins()
     def test_discovers_decorated_plugins(self) -> None:
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         result = reg.get(PluginType.SCHEDULER)
 
         self.assertIn(
@@ -137,7 +139,7 @@ class RegistryTest(_RegistryTestBase):
 
     @mock_install_torchx_plugins()
     def test_skips_private_modules(self) -> None:
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         result = reg.get(PluginType.SCHEDULER)
 
         # _private.py should have been skipped.
@@ -163,9 +165,55 @@ class RegistryTest(_RegistryTestBase):
         )
 
     @mock_install_torchx_plugins()
+    def test_registry_env_var_gates_discovery(self) -> None:
+        """``registry()`` honours TORCHX_PLUGINS_SOURCE via reg.get()."""
+        ep_result = {"ep_only": "ep_value"}
+        # env var value → (namespace plugin expected?, entry-point plugin expected?)
+        cases = [
+            (None, (True, True)),  # unset → ALL
+            ("3", (True, True)),  # NAMESPACE_PKG | ENTRYPOINT
+            ("1", (True, False)),  # NAMESPACE_PKG
+            ("2", (False, True)),  # ENTRYPOINT
+            ("0", (False, False)),  # NONE
+        ]
+        for value, (want_ns, want_ep) in cases:
+            with self.subTest(TORCHX_PLUGINS_SOURCE=value):
+                registry.cache_clear()
+                with patch.dict("os.environ", {}, clear=False):
+                    os.environ.pop("TORCHX_PLUGINS_SOURCE", None)
+                    if value is not None:
+                        os.environ["TORCHX_PLUGINS_SOURCE"] = value
+                    with patch.object(
+                        entrypoints, "load_group", return_value=ep_result
+                    ):
+                        result = registry().get(PluginType.SCHEDULER)
+                self.assertEqual(
+                    "local_cwd" in result,
+                    want_ns,
+                    f"namespace plugin presence for {value}",
+                )
+                self.assertEqual(
+                    "ep_only" in result,
+                    want_ep,
+                    f"entry-point plugin presence for {value}",
+                )
+        registry.cache_clear()
+
+    def test_registry_env_var_invalid_raises(self) -> None:
+        """``registry()`` raises a clear ValueError on invalid TORCHX_PLUGINS_SOURCE."""
+        for bad in ("namespace", "1a", "-1", "4"):
+            with self.subTest(TORCHX_PLUGINS_SOURCE=bad):
+                registry.cache_clear()
+                with patch.dict("os.environ", {"TORCHX_PLUGINS_SOURCE": bad}):
+                    with self.assertRaises(ValueError) as ctx:
+                        registry()
+                    self.assertIn("TORCHX_PLUGINS_SOURCE", str(ctx.exception))
+        registry.cache_clear()
+
+    @mock_install_torchx_plugins()
     def test_get_returns_cached_dict(self) -> None:
         """Second .get() call returns the same dict object (lazy cache)."""
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         first = reg.get(PluginType.SCHEDULER)
         second = reg.get(PluginType.SCHEDULER)
 
@@ -219,29 +267,36 @@ class RegistryTest(_RegistryTestBase):
         )
 
     @mock_install_torchx_plugins()
-    def test_load_entrypoints_false(self) -> None:
-        """load_entrypoints=False skips entry-point loading."""
+    def test_plugin_sources_gate_discovery(self) -> None:
+        """``plugin_sources`` bitmask selects which discovery channels run."""
         ep_result = {"ep_only": "ep_value"}
-
-        with patch.object(entrypoints, "load_group", return_value=ep_result):
-            reg = PluginRegistry(load_entrypoints=False)
-            result = reg.get(PluginType.SCHEDULER)
-
-        self.assertNotIn(
-            "ep_only",
-            result,
-            "should not include entry-point-only plugins when load_entrypoints=False",
-        )
-        self.assertIn(
-            "local_cwd",
-            result,
-            "namespace plugins should still be discovered",
-        )
+        # plugin_sources → (namespace plugin expected?, entry-point plugin expected?)
+        cases = [
+            (PluginSource.NAMESPACE_PKG | PluginSource.ENTRYPOINT, (True, True)),
+            (PluginSource.NAMESPACE_PKG, (True, False)),
+            (PluginSource.ENTRYPOINT, (False, True)),
+            (PluginSource.NONE, (False, False)),
+        ]
+        for plugin_sources, (want_ns, want_ep) in cases:
+            with self.subTest(plugin_sources=plugin_sources):
+                with patch.object(entrypoints, "load_group", return_value=ep_result):
+                    reg = PluginRegistry(plugin_sources=plugin_sources)
+                    result = reg.get(PluginType.SCHEDULER)
+                self.assertEqual(
+                    "local_cwd" in result,
+                    want_ns,
+                    f"namespace plugin presence for plugin_sources={plugin_sources!r}",
+                )
+                self.assertEqual(
+                    "ep_only" in result,
+                    want_ep,
+                    f"entry-point plugin presence for plugin_sources={plugin_sources!r}",
+                )
 
     @mock_install_torchx_plugins()
     def test_info_returns_all_groups(self) -> None:
         """info() returns dict[PluginType, dict[str, Callable]]."""
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         all_plugins = reg.info()
 
         self.assertIsInstance(all_plugins, dict, "info() should return a dict")
@@ -270,7 +325,7 @@ class RegistryTest(_RegistryTestBase):
     @mock_install_torchx_plugins()
     def test_info_single_type(self) -> None:
         """info(PluginType) returns dict[str, Callable] for that group."""
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         scheds = reg.info(PluginType.SCHEDULER)
 
         self.assertIsInstance(scheds, dict, "info(type) should return a dict")
@@ -287,7 +342,7 @@ class RegistryTest(_RegistryTestBase):
     @mock_install_torchx_plugins()
     def test_str(self) -> None:
         """Snapshot of str(registry) YAML output with test fixtures."""
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         output = str(reg)
 
         expected = """\
@@ -335,7 +390,7 @@ errors:
         """str(registry) is valid YAML that round-trips through to_dict()."""
         import yaml
 
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         output = str(reg)
         expected = reg.to_dict()
 
@@ -349,7 +404,7 @@ errors:
     @mock_install_torchx_plugins()
     def test_to_dict(self) -> None:
         """to_dict() returns the expected structure."""
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         data = reg.to_dict()
 
         # Schedulers.
@@ -408,7 +463,7 @@ class NamedResourceDiscoveryTest(_RegistryTestBase):
     """Tests named resource discovery via ``registry().get(PluginType.NAMED_RESOURCE)``."""
 
     def test_returns_empty_when_not_installed(self) -> None:
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         result = reg.get(PluginType.NAMED_RESOURCE)
         self.assertEqual(
             result,
@@ -423,7 +478,7 @@ class NamedResourceDiscoveryTest(_RegistryTestBase):
         Covers: base resources, fractionals, cross-package namespace merging,
         and fractional resource value correctness.
         """
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         result = reg.get(PluginType.NAMED_RESOURCE)
 
         # --- generic.py: gpu resource (powers_of_two_gpus fractionals) ---
@@ -495,7 +550,7 @@ class DiscoveryFaultToleranceTest(_RegistryTestBase):
     @mock_install_torchx_plugins()
     def test_bad_plugins_do_not_prevent_good_plugins(self) -> None:
         """Broken plugins in torchx-plugins-bad don't crash healthy discovery."""
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         scheds = reg.get(PluginType.SCHEDULER)
 
         # Good plugins from torchx-plugins-default still work.
@@ -513,7 +568,7 @@ class DiscoveryFaultToleranceTest(_RegistryTestBase):
     @mock_install_torchx_plugins()
     def test_errors_captured_from_bad_package(self) -> None:
         """All error types from torchx-plugins-bad are captured in errors list."""
-        reg = PluginRegistry(load_entrypoints=False)
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
         reg.info()  # trigger full discovery
 
         error_modules = {e.module for e in reg.errors}
@@ -574,7 +629,7 @@ class DiscoveryFaultToleranceTest(_RegistryTestBase):
         dummy_mod.fake_local_cwd = fake_local_cwd  # type: ignore[attr-defined]
 
         try:
-            reg = PluginRegistry(load_entrypoints=False)
+            reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
             result = reg._find_namespace_plugins(
                 "torchx_plugins.schedulers",
                 expected_type=PluginType.SCHEDULER,
@@ -603,7 +658,7 @@ class DiscoveryFaultToleranceTest(_RegistryTestBase):
                 "torchx.plugins._registry.pkgutil.iter_modules",
                 side_effect=OSError("broken __path__"),
             ):
-                reg = PluginRegistry(load_entrypoints=False)
+                reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
                 result = reg._find_namespace_plugins("torchx_plugins.broken_ns")
 
             self.assertEqual(


### PR DESCRIPTION
Summary:

Extend plugin discovery with a gate for the `torchx_plugins.*` namespace scan, and unify it with the existing entry-point gate under a single `PluginSource` bitmask + `TORCHX_PLUGINS_SOURCE` env var.

`PluginSource` is an `enum.IntFlag` with `NAMESPACE_PKG=1`, `ENTRYPOINT=2`, and `ALL=NAMESPACE_PKG | ENTRYPOINT`. `PluginRegistry.__init__` takes `plugin_sources: PluginSource = PluginSource.ALL`; `registry()` parses `TORCHX_PLUGINS_SOURCE` as the integer value of the flag (`0` for none, `1` for namespace only, `2` for entry points only, `3` for both), with a clear `ValueError` for unparsable or out-of-range input. Default discovery behavior is unchanged — the previous `TORCHX_NO_ENTRYPOINTS=1` spelling becomes `TORCHX_PLUGINS_SOURCE=1`.

Differential Revision: D101807646


