### PR TITLE
Fix CUSTOM_NAMED_RESOURCES priority in _load_named_resources

### DIFF
--- a/torchx/plugins/test/registry_test.py
+++ b/torchx/plugins/test/registry_test.py
@@ -219,6 +219,40 @@ class RegistryTest(_RegistryTestBase):
         )
 
     @mock_install_torchx_plugins()
+    def test_specs_resource_custom_beats_namespace_plugin(self) -> None:
+        """``specs.resource(h=name)`` must resolve to ``CUSTOM_NAMED_RESOURCES``
+        when a downstream ``torchx_plugins.named_resources.*`` registers the
+        same name. Exercises the full scanner → ``_load_named_resources`` →
+        ``specs.resource`` path (the user-visible API).
+        """
+        import torchx.specs
+        from torchx.specs.api import Resource
+
+        # Fixture already registers `gpu` with alias `t4g` under
+        # torchx_plugins.named_resources.generic via @register.named_resource.
+        # Install a colliding custom-layer factory with a distinguishing capability.
+        def custom_gpu() -> Resource:
+            return Resource(
+                cpu=999, gpu=999, memMB=999, capabilities={"layer": "custom"}
+            )
+
+        with patch(
+            "torchx.specs.CUSTOM_NAMED_RESOURCES",
+            {"gpu": custom_gpu, "t4g": custom_gpu},
+        ):
+            factories = torchx.specs._load_named_resources()
+            with patch.object(torchx.specs, "_named_resource_factories", factories):
+                by_name = torchx.specs.resource(h="gpu")
+                by_alias = torchx.specs.resource(h="t4g")
+
+        for r, how in ((by_name, "base name"), (by_alias, "alias")):
+            self.assertEqual(
+                r.capabilities.get("layer"),
+                "custom",
+                f"CUSTOM_NAMED_RESOURCES did not win over namespace plugin via {how!r}",
+            )
+
+    @mock_install_torchx_plugins()
     def test_load_entrypoints_false(self) -> None:
         """load_entrypoints=False skips entry-point loading."""
         ep_result = {"ep_only": "ep_value"}

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -88,11 +88,12 @@ CUSTOM_NAMED_RESOURCES: Mapping[str, ResourceFactory] = import_attr(
 def _load_named_resources() -> dict[str, Callable[[], Resource]]:
     materialized_resources: dict[str, Callable[[], Resource]] = {}
 
+    # Priority low → high (later wins on name collision).
     for name, resource in {
+        **plugins.registry().get(plugins.PluginType.NAMED_RESOURCE),
         **GENERIC_NAMED_RESOURCES,
         **AWS_NAMED_RESOURCES,
         **CUSTOM_NAMED_RESOURCES,
-        **plugins.registry().get(plugins.PluginType.NAMED_RESOURCE),
     }.items():
         materialized_resources[name] = resource
 


### PR DESCRIPTION
Summary: Swap the unpack order so namespace-scanned plugins form the base layer and the in-tree registries (GENERIC/AWS/CUSTOM) override them on name collision. Previously namespace plugins were unpacked last, so a downstream ``torchx_plugins.named_resources.*`` registration silently shadowed ``CUSTOM_NAMED_RESOURCES`` — including any capability injection the custom layer adds on top of the base factory. After: ``CUSTOM_NAMED_RESOURCES`` wins, matching the docstring contract downstream plugin authors rely on.

Differential Revision: D101888085


