### PR TITLE
Fail fast in `torchx log` when the app does not exist (#1291)

### DIFF
--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -72,6 +72,32 @@ def print_log_lines(
         raise
 
 
+def _wait_for_app_started(runner: Runner, app_handle: str) -> bool:
+    """Block until ``app_handle`` has started.
+
+    Returns ``True`` once the app has started. Returns ``False`` (after logging
+    a warning) if the app does not exist: ``status()`` returns ``None`` only for
+    a missing / mistyped app id; a submitted-but-pending app returns a
+    non-``None`` status. Without this, ``torchx log`` polled ``status()`` forever
+    and RPC-spammed the scheduler until the process was killed.
+    """
+    display_waiting = True
+    while True:
+        status = runner.status(app_handle)
+        if status is None:
+            logger.warning(
+                "app `%s` not found; it does not exist or the app id is incorrect",
+                app_handle,
+            )
+            return False
+        elif is_started(status.state):
+            return True
+        elif display_waiting:
+            logger.info("Waiting for app state response before fetching logs...")
+            display_waiting = False
+        time.sleep(1)
+
+
 def get_logs(
     file: TextIO,
     identifier: str,
@@ -96,16 +122,8 @@ def get_logs(
     if len(path) == 4:
         replica_ids = [(role_name, int(id)) for id in path[3].split(",") if id]
     else:
-        display_waiting = True
-        while True:
-            status = runner.status(app_handle)
-            if status and is_started(status.state):
-                break
-            elif display_waiting:
-                logger.info("Waiting for app state response before fetching logs...")
-                display_waiting = False
-            time.sleep(1)
-
+        if not _wait_for_app_started(runner, app_handle):
+            return
         app = none_throws(runner.describe(app_handle))
         # print all replicas for the role
         replica_ids = find_role_replicas(app, role_name)

--- a/torchx/cli/test/cmd_log_test.py
+++ b/torchx/cli/test/cmd_log_test.py
@@ -188,6 +188,20 @@ class CmdLogTest(unittest.TestCase):
         self.assertIn("Waiting", "\n".join(cm.output))
 
     @patch(RUNNER, new_callable=MockRunner)
+    def test_cmd_log_app_not_found(self, mock_runner: MagicMock) -> None:
+        # A non-existent app id makes status() return None; cmd_log must log a
+        # warning and return gracefully instead of polling the scheduler forever.
+        out = io.StringIO()
+        with patch.object(mock_runner, "status", return_value=None):
+            with self.assertLogs(level="WARNING") as cm:
+                get_logs(
+                    out,
+                    "local_docker://test-session/NonExistentApp/trainer",
+                    regex=None,
+                )
+        self.assertIn("not found", "\n".join(cm.output))
+
+    @patch(RUNNER, new_callable=MockRunner)
     def test_print_log_lines_throws(self, mock_runner: MagicMock) -> None:
         # makes sure that when the function executed in the threadpool
         # errors out; we raise the exception all the way through


### PR DESCRIPTION
Summary:

`torchx log <scheduler>://.../<app_id>/<role>` wraps `Runner.log_iter()` in a `while True` loop (`cmd_log.get_logs`) that polls `runner.status()` until the app is started. The loop only broke once the app was started; otherwise it slept and retried forever — including when `status()` returns `None`, which is exactly what happens when the app does not exist (a mistyped or corrupted app id, or a job that was never submitted).

On a non-existent app id this polled `describe()`/`status()` indefinitely. After the MAST→MSL routing migration (D105069640), every poll resolves through `ResourceLocatorResolver`, so the infinite loop RPC-spammed MSL `locateHpcJob` with `JOB_NOT_FOUND` (407) until the process was killed. This is a pre-existing bug: the same forever-poll has spammed MAST `getHpcJobStatus` with 407 at ~50K errors/hr for as long as we have data (~3.45M errors over 2.5 days; see S671419). The routing flip did not introduce it — it only relocated the spam onto the monitored MSL tier and made it visible.

A submitted-but-pending app returns a non-`None` status (e.g. `PENDING`), so `status is None` uniquely identifies a non-existent app. This diff breaks out of the wait loop and exits with a clear error in that case instead of polling forever. The legitimate "wait for a pending job to start" path is preserved (it returns a non-`None` status).

Note: this intentionally drops the niche "`torchx log` an app id before submitting it, then submit from another process" (watch-style) pattern, which relied on the infinite poll. Dropping that was discussed and agreed as acceptable.

Reviewed By: kiukchung

Differential Revision: D108083142


