### PR TITLE
Bump `aws-actions/configure-aws-credentials` from 1.6.1 to 6.2.0 (#1309)

### DIFF
--- a/.github/workflows/aws-batch-integration-tests.yaml
+++ b/.github/workflows/aws-batch-integration-tests.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout TorchX
         uses: actions/checkout@v6
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1.6.1
+        uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
           aws-region: us-west-1
           role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}

--- a/.github/workflows/components-integration-tests.yaml
+++ b/.github/workflows/components-integration-tests.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout TorchX
         uses: actions/checkout@v6
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1.6.1
+        uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
           aws-region: us-west-1
           role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}


### PR DESCRIPTION
Summary:

Bump `aws-actions/configure-aws-credentials` from `v1.6.1` to `v6.2.0` in
`aws-batch-integration-tests.yaml` and `components-integration-tests.yaml`.

Recreated from D108447066 (bot diff lacking Phab CI bundle).

Reviewed By: seemethere

Differential Revision: D108650482


