### PR TITLE
Set RESOURCE_NAME and IS_FRACTIONAL tags in @register.named_resource (#1314)

### DIFF
--- a/torchx/plugins/_registration.py
+++ b/torchx/plugins/_registration.py
@@ -60,20 +60,32 @@ class resource_tags:
     return so that downstream code can recover the registered name and
     whether the resource is a fractional slice.
 
+    Use :py:meth:`Resource.is_fractional() <torchx.specs.api.Resource.is_fractional>`
+    and :py:meth:`Resource.get_resource_name() <torchx.specs.api.Resource.get_resource_name>`
+    instead of querying these keys directly.
+
     Example::
 
         from torchx.plugins import resource_tags
 
         res = result["gpu_4"]()
         assert res.tags[resource_tags.RESOURCE_NAME] == "gpu_4"
-        assert res.tags[resource_tags.IS_FRACTIONAL] is True
+        assert res.is_fractional() is True
     """
 
     RESOURCE_NAME: str = "torchx/named_resources.name"
-    """Registered name that produced this :py:class:`Resource`."""
+    """Registered name that produced this :py:class:`Resource`.
+
+    Prefer :py:meth:`Resource.get_resource_name() <torchx.specs.api.Resource.get_resource_name>`
+    over reading this tag directly.
+    """
 
     IS_FRACTIONAL: str = "torchx/named_resources.is_fractional"
-    """``True`` when the resource is a fractional slice of a base resource."""
+    """``True`` when the resource is a fractional slice of a base resource.
+
+    Prefer :py:meth:`Resource.is_fractional() <torchx.specs.api.Resource.is_fractional>`
+    over reading this tag directly.
+    """
 
 
 def powers_of_two_gpus(resource: Any) -> dict[float, str]:
@@ -302,11 +314,20 @@ class _register_named_resource(register):
       produces ``my_gpu_8``, ``my_gpu_4``, ``my_gpu_2``, ``my_gpu_1`` —
       each calling ``my_gpu(fractional=<fraction>)``.
 
-    Subclasses override the two hook methods to inject platform-specific
-    metadata:
+    The decorator automatically populates :py:attr:`resource_tags.RESOURCE_NAME`
+    and :py:attr:`resource_tags.IS_FRACTIONAL` on every :py:class:`Resource`
+    returned by the registered factories:
 
-    * :py:meth:`_make_factory` — wrap the base factory (e.g. add tags).
-    * :py:meth:`_make_fractional` — wrap each fractional factory.
+    * **Base factory** — ``RESOURCE_NAME=name``, ``IS_FRACTIONAL=False``.
+    * **Alias** — delegates to the base factory, inheriting its tags.
+    * **Fractional (fraction == 1.0)** — ``RESOURCE_NAME=name_suffix``,
+      ``IS_FRACTIONAL=False``.
+    * **Fractional (fraction < 1.0)** — ``RESOURCE_NAME=name_suffix``,
+      ``IS_FRACTIONAL=True``.
+
+    Use :py:meth:`Resource.is_fractional() <torchx.specs.api.Resource.is_fractional>`
+    to check whether a resource is fractional rather than reading the tag
+    directly.
     """
 
     def __init__(
@@ -330,37 +351,6 @@ class _register_named_resource(register):
             self._fractionals = fractionals
         else:
             self._fractionals = lambda _: {}
-
-    # -- hooks for subclasses ------------------------------------------------
-
-    def _make_factory(self, fn: Callable[..., Any], name: str) -> Callable[..., Any]:
-        """Wrap the base factory before registration.
-
-        The default implementation returns *fn* unchanged.  Subclasses
-        override to inject metadata (e.g. whole-host flags, resource tags).
-        """
-        return fn
-
-    def _make_fractional(
-        self,
-        fn: Callable[..., Any],
-        fraction: float,
-        frac_name: str,
-    ) -> Callable[..., Any]:
-        """Create a zero-arg factory for a fractional resource variant.
-
-        The default implementation returns ``lambda: fn(fraction)``.
-        Subclasses override to inject fractional-specific metadata.
-        """
-
-        def fractional_factory() -> Any:
-            return fn(fraction)
-
-        fractional_factory.__module__ = fn.__module__
-        fractional_factory.__qualname__ = frac_name
-        return fractional_factory
-
-    # -- registration orchestration ------------------------------------------
 
     def __call__(self, fn: Callable[..., Resource]) -> Callable[..., Resource]:
         mod: ModuleType = sys.modules[fn.__module__]
@@ -389,8 +379,15 @@ class _register_named_resource(register):
                 )
             setattr(mod, attr_name, factory)
 
-        # [1] Base factory
-        factory = self._make_factory(fn, name)
+        # [1] Base factory — sets RESOURCE_NAME and IS_FRACTIONAL=False.
+        def factory(*args: Any, **kwargs: Any) -> Any:
+            resource = fn(*args, **kwargs)
+            resource.tags[resource_tags.RESOURCE_NAME] = name
+            resource.tags[resource_tags.IS_FRACTIONAL] = False
+            return resource
+
+        factory.__module__ = fn.__module__
+        factory.__qualname__ = fn.__qualname__
         _tag_and_register(name, factory)
 
         if name != fn.__name__:
@@ -419,9 +416,19 @@ class _register_named_resource(register):
             base_resource = fn()
             for fraction, suffix in self._fractionals(base_resource).items():
                 frac_name = f"{name}_{suffix}"
-                frac_factory = self._make_fractional(fn, fraction, frac_name)
+
+                def frac_factory(
+                    _frac: float = fraction, _fname: str = frac_name
+                ) -> Any:
+                    resource = fn(_frac)
+                    resource.tags[resource_tags.RESOURCE_NAME] = _fname
+                    resource.tags[resource_tags.IS_FRACTIONAL] = _frac != WHOLE
+                    return resource
+
+                frac_factory.__module__ = fn.__module__
+                frac_factory.__qualname__ = frac_name
                 frac_factory._plugin_base_name = name  # type: ignore[attr-defined]
                 _tag_and_register(frac_name, frac_factory)
                 _set_module_attr(frac_name, frac_factory)
 
-        return factory  # NB: returns _make_factory(fn), not fn
+        return factory

--- a/torchx/plugins/test/register_test.py
+++ b/torchx/plugins/test/register_test.py
@@ -20,10 +20,10 @@ import unittest
 from typing import Any
 
 from torchx.plugins._registration import (
-    _register_named_resource,
     halve_mem_down_to,
     powers_of_two_gpus,
     register,
+    resource_tags,
 )
 from torchx.plugins._registry import NAMED_RESOURCES_ATTR, PluginType, registry
 from torchx.specs.api import Resource
@@ -378,56 +378,164 @@ class NamedResourceRegisterTest(unittest.TestCase):
             ):
                 register.named_resource(name="same")(res_b)
 
-    def test_make_factory_hook(self) -> None:
-        """Subclass override of ``_make_factory`` is called."""
-        with _ModuleContextManager("test_nr_hook_factory"):
-            make_factory_calls: list[str] = []
+    def test_base_factory_sets_resource_name_tag(self) -> None:
+        """Base factory sets ``resource_tags.RESOURCE_NAME`` on the returned Resource."""
+        with _ModuleContextManager("test_nr_tag_base"):
 
-            class custom_nr(_register_named_resource):
-                def _make_factory(self, fn: Any, name: str) -> Any:
-                    make_factory_calls.append(name)
-                    return fn
+            def gpu8(fractional: float = 1.0) -> Resource:
+                return Resource(
+                    cpu=int(8 * fractional), gpu=int(8 * fractional), memMB=1024
+                )
 
-            def my_res() -> Resource:
-                return Resource(cpu=1, gpu=0, memMB=128)
-
-            my_res.__module__ = "test_nr_hook_factory"
-            custom_nr()(my_res)
-
+            gpu8.__module__ = "test_nr_tag_base"
+            factory = register.named_resource()(gpu8)
+            res = factory()
             self.assertEqual(
-                make_factory_calls,
-                ["my_res"],
-                "_make_factory hook should be called with the resource name",
+                res.tags[resource_tags.RESOURCE_NAME],
+                "gpu8",
+                "base factory should set RESOURCE_NAME to the registered name",
+            )
+            self.assertFalse(
+                res.tags[resource_tags.IS_FRACTIONAL],
+                "base factory should set IS_FRACTIONAL=False",
             )
 
-    def test_make_fractional_hook(self) -> None:
-        """Subclass override of ``_make_fractional`` is called for each fraction."""
-        with _ModuleContextManager("test_nr_hook_frac"):
-            frac_calls: list[tuple[float, str]] = []
+    def test_fractional_factory_sets_tags(self) -> None:
+        """Fractional factories set ``RESOURCE_NAME`` and ``IS_FRACTIONAL``."""
+        with _ModuleContextManager("test_nr_tag_frac") as mod:
 
-            class custom_nr(_register_named_resource):
-                def _make_fractional(
-                    self, fn: Any, fraction: float, frac_name: str
-                ) -> Any:
-                    frac_calls.append((fraction, frac_name))
-                    return super()._make_fractional(fn, fraction, frac_name)
+            def gpu8(fractional: float = 1.0) -> Resource:
+                return Resource(
+                    cpu=int(8 * fractional), gpu=int(8 * fractional), memMB=1024
+                )
 
-            def host(fractional: float = 1.0) -> Resource:
-                return Resource(cpu=int(8 * fractional), gpu=0, memMB=512)
+            gpu8.__module__ = "test_nr_tag_frac"
+            register.named_resource(fractionals={1.0: "8", 0.5: "4", 0.25: "2"})(gpu8)
 
-            host.__module__ = "test_nr_hook_frac"
-            custom_nr(fractionals={1.0: "8", 0.5: "4"})(host)
-
+            whole = mod.gpu8_8()
             self.assertEqual(
-                len(frac_calls),
-                2,
-                "_make_fractional should be called once per fractional entry",
+                whole.tags[resource_tags.RESOURCE_NAME],
+                "gpu8_8",
+                "whole fractional should set RESOURCE_NAME to fractional name",
             )
-            frac_names = {name for _, name in frac_calls}
+            self.assertFalse(
+                whole.tags[resource_tags.IS_FRACTIONAL],
+                "whole fractional (1.0) should set IS_FRACTIONAL=False",
+            )
+
+            half = mod.gpu8_4()
             self.assertEqual(
-                frac_names,
-                {"host_8", "host_4"},
-                "_make_fractional should receive correct fractional names",
+                half.tags[resource_tags.RESOURCE_NAME],
+                "gpu8_4",
+                "half fractional should set RESOURCE_NAME to fractional name",
+            )
+            self.assertTrue(
+                half.tags[resource_tags.IS_FRACTIONAL],
+                "half fractional (0.5) should set IS_FRACTIONAL=True",
+            )
+
+            quarter = mod.gpu8_2()
+            self.assertTrue(
+                quarter.tags[resource_tags.IS_FRACTIONAL],
+                "quarter fractional (0.25) should set IS_FRACTIONAL=True",
+            )
+
+    def test_alias_inherits_canonical_resource_name(self) -> None:
+        """Alias factory returns the canonical RESOURCE_NAME, not the alias."""
+        with _ModuleContextManager("test_nr_tag_alias") as mod:
+
+            def gpu8(fractional: float = 1.0) -> Resource:
+                return Resource(
+                    cpu=int(8 * fractional), gpu=int(8 * fractional), memMB=1024
+                )
+
+            gpu8.__module__ = "test_nr_tag_alias"
+            factory = register.named_resource(aliases=["my_alias"])(gpu8)
+
+            canonical = factory()
+            alias = mod.my_alias()
+            self.assertEqual(
+                canonical.tags[resource_tags.RESOURCE_NAME],
+                "gpu8",
+                "canonical factory should set RESOURCE_NAME to its own name",
+            )
+            self.assertEqual(
+                alias.tags[resource_tags.RESOURCE_NAME],
+                "gpu8",
+                "alias should set RESOURCE_NAME to canonical name, not alias",
+            )
+            self.assertFalse(
+                alias.tags[resource_tags.IS_FRACTIONAL],
+                "alias should inherit IS_FRACTIONAL=False from base factory",
+            )
+
+    def test_tags_match_fbcode_named_resource_behavior(self) -> None:
+        """Verify tag behavior across all factory types.
+
+        - base factory: RESOURCE_NAME=name, IS_FRACTIONAL=False
+        - alias: RESOURCE_NAME=canonical_name, IS_FRACTIONAL=False
+        - fractional(1.0): RESOURCE_NAME=frac_name, IS_FRACTIONAL=False
+        - fractional(<1.0): RESOURCE_NAME=frac_name, IS_FRACTIONAL=True
+        """
+        with _ModuleContextManager("test_nr_tag_parity") as mod:
+
+            def my_gpu(fractional: float = 1.0) -> Resource:
+                return Resource(
+                    cpu=int(8 * fractional), gpu=int(8 * fractional), memMB=1024
+                )
+
+            my_gpu.__module__ = "test_nr_tag_parity"
+            factory = register.named_resource(
+                aliases=["gpu_alias"],
+                fractionals={1.0: "8", 0.5: "4"},
+            )(my_gpu)
+
+            # base factory: RESOURCE_NAME=name, IS_FRACTIONAL=False
+            base = factory()
+            self.assertEqual(
+                base.tags[resource_tags.RESOURCE_NAME],
+                "my_gpu",
+                "base: RESOURCE_NAME should be function name",
+            )
+            self.assertFalse(
+                base.tags[resource_tags.IS_FRACTIONAL],
+                "base: IS_FRACTIONAL should be False",
+            )
+
+            # alias: RESOURCE_NAME=canonical name, IS_FRACTIONAL=False
+            alias = mod.gpu_alias()
+            self.assertEqual(
+                alias.tags[resource_tags.RESOURCE_NAME],
+                "my_gpu",
+                "alias: RESOURCE_NAME should be canonical name",
+            )
+            self.assertFalse(
+                alias.tags[resource_tags.IS_FRACTIONAL],
+                "alias: IS_FRACTIONAL should be False",
+            )
+
+            # fractional(1.0): IS_FRACTIONAL=False
+            whole = mod.my_gpu_8()
+            self.assertEqual(
+                whole.tags[resource_tags.RESOURCE_NAME],
+                "my_gpu_8",
+                "whole fractional: RESOURCE_NAME should be fractional name",
+            )
+            self.assertFalse(
+                whole.tags[resource_tags.IS_FRACTIONAL],
+                "whole fractional: IS_FRACTIONAL should be False",
+            )
+
+            # fractional(0.5): IS_FRACTIONAL=True
+            half = mod.my_gpu_4()
+            self.assertEqual(
+                half.tags[resource_tags.RESOURCE_NAME],
+                "my_gpu_4",
+                "half fractional: RESOURCE_NAME should be fractional name",
+            )
+            self.assertTrue(
+                half.tags[resource_tags.IS_FRACTIONAL],
+                "half fractional: IS_FRACTIONAL should be True",
             )
 
 


### PR DESCRIPTION
Summary:


Populate `resource_tags.RESOURCE_NAME` and `resource_tags.IS_FRACTIONAL` on `Resource` objects returned by `register.named_resource` factories.

**Before** — tags empty despite `resource_tags` keys and `Resource` accessors existing:

```python
register.named_resource(fractionals=powers_of_two_gpus)
def my_gpu(fractional: float = WHOLE) -> Resource: ...

my_gpu().tags          # {}
my_gpu_4().tags        # {}
my_gpu().is_fractional()  # False (default)
```

**After** — tags set automatically:

```python
my_gpu().tags
# {"torchx/named_resources.name": "my_gpu",
#  "torchx/named_resources.is_fractional": False}

my_gpu_8().tags
# {"torchx/named_resources.name": "my_gpu_8",
#  "torchx/named_resources.is_fractional": False}

my_gpu_4().tags
# {"torchx/named_resources.name": "my_gpu_4",
#  "torchx/named_resources.is_fractional": True}

my_gpu_4().is_fractional()  # True
```

**Tag values by factory type:**

| Factory type       | `RESOURCE_NAME` | `IS_FRACTIONAL` |
|--------------------|-----------------|-----------------|
| Base               | registered name | `False`         |
| Alias              | canonical name  | `False`         |
| Fractional (1.0)   | `name_suffix`   | `False`         |
| Fractional (< 1.0) | `name_suffix`   | `True`          |

**Other changes:**
- Removed `_make_factory`/`_make_fractional` hook methods — no public API to subclass `_register_named_resource`, so the indirection was dead abstraction
- Added docstrings pointing users to `Resource.is_fractional()` and `Resource.get_resource_name()` accessors instead of reading tags directly

Reviewed By: d4l3k

Differential Revision: D108944836


