### PR TITLE
Bump jinja2 from >=3.1.4 to >=3.1.6

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx~=8.1
 sphinxcontrib-katex
 pytorch-sphinx-theme @ git+https://github.com/pytorch/pytorch_sphinx_theme.git
-jinja2>=3.1.4
+jinja2>=3.1.6


### PR DESCRIPTION
Summary:
Bump `jinja2` minimum from `>=3.1.4` to `>=3.1.6` in `docs/requirements.txt`.
Includes security fix GHSA-cpwx-vrp4-4pq7 (`|attr` filter sandbox bypass).

Recreated from D108447349 (bot-authored, could not submit as non-author).

bypass-github-export-checks

___

Differential Revision: D109102183


