### PR TITLE
Record structured scheduler error_code on launch events (#1326)

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -313,7 +313,17 @@ class Runner:
         cfg = dryrun_info._cfg
         with log_event("schedule") as ctx:
             sched = self._scheduler(scheduler)
-            app_id = sched.schedule(dryrun_info)
+            try:
+                app_id = sched.schedule(dryrun_info)
+            except BaseException as e:
+                # Classify the failure for monitoring; a bad classifier must
+                # never mask the original launch exception.
+                try:
+                    code = sched.error_code(e)
+                except Exception:
+                    code = None
+                ctx.set_scheduler_error_code(code)
+                raise
             app_handle = make_app_handle(scheduler, self._name, app_id)
 
             app = none_throws(dryrun_info._app)

--- a/torchx/runner/events/__init__.py
+++ b/torchx/runner/events/__init__.py
@@ -25,6 +25,7 @@ import logging
 import sys
 import time
 import traceback
+from contextvars import ContextVar
 from types import TracebackType
 from typing import Type
 
@@ -36,6 +37,14 @@ from .api import SourceType, TorchxEvent  # noqa F401
 _events_logger: logging.Logger | None = None
 
 log: logging.Logger = logging.getLogger(__name__)
+
+
+# Carries a scheduler-classified error code from the inner schedule event out to
+# every enclosing log_event -- including the top-level event monitoring reads.
+# See log_event.set_scheduler_error_code and Scheduler.error_code().
+_scheduler_error_code: ContextVar[int | None] = ContextVar[int | None](
+    "torchx_scheduler_error_code", default=None
+)
 
 
 def _get_or_create_logger(destination: str = "null") -> logging.Logger:
@@ -115,11 +124,22 @@ class log_event:
         self._start_epoch_time_usec = 0
 
     def __enter__(self) -> "log_event":
+        # Reset per launch so a prior launch's code can't leak in. Not a token
+        # save/restore: the value must outlive __exit__ for enclosing events to read.
+        _scheduler_error_code.set(None)
         self._start_cpu_time_ns = time.process_time_ns()
         self._start_wall_time_ns = time.perf_counter_ns()
         self._torchx_event.start_epoch_time_usec = int(time.time() * 1_000_000)
 
         return self
+
+    def set_scheduler_error_code(self, error_code: int | None) -> None:
+        """Record a scheduler-classified error code (see ``Scheduler.error_code``)
+        on this launch event and, via a contextvar, on every enclosing
+        ``log_event`` -- including the top-level event monitoring reads.
+        """
+        self._torchx_event.error_code = error_code
+        _scheduler_error_code.set(error_code)
 
     def __exit__(
         self,
@@ -149,6 +169,9 @@ class log_event:
             self._torchx_event.exception_type = exec_type.__name__
         if exec_value:
             self._torchx_event.exception_message = str(exec_value)
+        error_code = _scheduler_error_code.get(None)
+        if error_code is not None:
+            self._torchx_event.error_code = error_code
         record(self._torchx_event)
 
     def _generate_torchx_event(

--- a/torchx/runner/events/api.py
+++ b/torchx/runner/events/api.py
@@ -56,6 +56,7 @@ class TorchxEvent:
     exception_type: str | None = None
     exception_message: str | None = None
     exception_source_location: str | None = None
+    error_code: int | None = None
 
     def __str__(self) -> str:
         return self.serialize()

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -519,6 +519,17 @@ class Scheduler(abc.ABC, Generic[T]):
             f"{self.__class__.__qualname__} does not support application log iteration"
         )
 
+    def error_code(self, exc: BaseException) -> int | None:
+        """Classify a scheduler-raised exception into a structured error code for
+        failure analytics (e.g. HTTP-style 4xx user vs 5xx infra). Returns ``None``
+        when there is no structured code for this exception. Schedulers whose
+        backend exposes an error code override this; the value is recorded on
+        torchx launch events so monitoring can separate user from infra failures
+        without parsing exception message text. Overrides must not raise --
+        classification must never mask the launch failure.
+        """
+        return None
+
     def _pre_build_validate(self, app: AppDef, scheduler: str, cfg: T) -> None:
         # Hook for pre-workspace-build validation. Override to add checks.
         pass


### PR DESCRIPTION
Summary:

This diff records a structured scheduler error code on torchx launch events so the conda launch-failure-rate detectors can distinguish user (4xx) from infrastructure (5xx) failures without parsing exception message text.

Today those detectors count every recorded exception as a failure, including user-config errors such as invalid job definitions, missing data-project ACLs, and quota-exceeded, which makes them noisy.

To keep the generic OSS events module scheduler-agnostic, the classification lives in the scheduler: a new `Scheduler.error_code(exc)` hook (default `None`) is overridden by the HPC bases (`BaseMastScheduler`, `BaseMslScheduler`) to surface the `HpcSchedulerServiceException` error code. The runner calls it at the launch site and records the result through a contextvar that `log_event` stamps onto the launch event(s) -- including the top-level event the detectors read. The `error_code` column on `TsmLoggerConfig` is added by a companion www diff.

Reviewed By: probli

Differential Revision: D108569715


