### PR TITLE
[torchx][tracker/mlflow] Use sqlite:// tracking backend for mlflow 3.13 compat

### DIFF
--- a/torchx/tracker/mlflow.py
+++ b/torchx/tracker/mlflow.py
@@ -12,6 +12,7 @@ from logging import getLogger, Logger
 from pathlib import Path
 from tempfile import gettempdir
 from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import urlparse
 
 import mlflow
 from mlflow import MlflowClient
@@ -64,11 +65,15 @@ class MLflowTracker(TrackerBase):
     def __init__(
         self,
         experiment_name: str | None = None,
-        tracking_uri: str = f"file://{Path(gettempdir()) / 'torchx' / 'mlruns'}",
+        tracking_uri: str = f"sqlite:///{Path(gettempdir()) / 'torchx' / 'mlruns.db'}",
         artifact_location: str | None = None,
     ) -> None:
         if experiment_name is None:
             experiment_name = self.default_experiment_name()
+
+        parsed = urlparse(tracking_uri)
+        if parsed.scheme.startswith("sqlite"):
+            Path(parsed.path).parent.mkdir(parents=True, exist_ok=True)
 
         self.tracking_uri = tracking_uri
         mlflow.set_tracking_uri(tracking_uri)

--- a/torchx/tracker/test/mlflow_test.py
+++ b/torchx/tracker/test/mlflow_test.py
@@ -57,7 +57,7 @@ class MLflowTrackerTest(TestWithTmpDir):
         super().setUp()
         self.tracker = MLflowTracker(
             experiment_name=_generate_random_name(),
-            tracking_uri=str(self.tmpdir / "experiments"),
+            tracking_uri=f"sqlite:///{self.tmpdir / 'experiments.db'}",
             artifact_location=str(self.tmpdir / "artifacts"),
         )
 
@@ -202,7 +202,7 @@ class MLflowTrackerTest(TestWithTmpDir):
 [tracker:mlflow]
 config = {confdir}
 
-tracking_uri = {str(self.tmpdir / 'experiments')}
+tracking_uri = sqlite:///{self.tmpdir / 'experiments.db'}
 artifact_location = {str(self.tmpdir / 'artifacts')}
 experiment_name = foobar
         """
@@ -210,7 +210,9 @@ experiment_name = foobar
         )
 
         tracker = create_tracker(config=confdir)
-        self.assertEqual(str(self.tmpdir / "experiments"), tracker.tracking_uri)
+        self.assertEqual(
+            f"sqlite:///{self.tmpdir / 'experiments.db'}", tracker.tracking_uri
+        )
         self.assertEqual(str(self.tmpdir / "artifacts"), tracker.artifact_location)
         self.assertEqual("foobar", tracker.experiment.name)
 
@@ -269,7 +271,7 @@ class MlflowTrackerMultiRankTest(DistributedTestCase):
             "mlflow_test.conf",
             content=[
                 "[tracker:mlflow]",
-                f"tracking_uri = {self.tmpdir / 'mlruns'}",
+                f"tracking_uri = sqlite:///{self.tmpdir / 'mlruns.db'}",
             ],
         )
         run_name = "test-run"


### PR DESCRIPTION
## Why

mlflow 3.13 put the filesystem tracking backend (FileStore) into maintenance mode: any `file://`/bare-path `tracking_uri` now raises `MlflowException`. Main bumped mlflow to 3.13 (b2b93187) but the accompanying code migration to sqlite never made it to GitHub (it landed internally as D108650910), so `MLflowTracker`'s `file://` default and the tests still hit the gated FileStore.

This is why **Python Unittests** on main is red: 12 failures, all in `torchx/tracker/test/mlflow_test.py`, e.g. [run 28965848439](https://github.com/meta-pytorch/torchx/actions/runs/28965848439).

## What

Migrate the default `tracking_uri` and the tests to `sqlite:///` (with a `mkdir` guard), matching the internal change.

## Test plan

- `uv sync --frozen --extra dev && uv run pytest torchx/tracker/test/mlflow_test.py -v` → **12 passed** (the exact 12 tests failing on main's CI)
- Full `uv run pytest` locally: no failures beyond 2 known local-env flakes (`process_monitor_test`, `streams_test`) that also fail/flake on clean main locally and pass in CI