### PR TITLE
[torchx][docs] Fix OSS docbuild under sphinx 8

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,6 +143,12 @@ exclude_patterns = []
 if not FBCODE:
     # fb/ contains Meta-internal docs only available in the fbcode build.
     exclude_patterns += ["fb/**"]
+    # The ``.. fbcode::`` directive (docs/source/ext/fbcode.py) hides the
+    # Meta-internal ``torchx.specs.fb`` / ``torchx.workspace.fb`` automodule
+    # blocks from the OSS build, but autosummary's pre-parse source scan still
+    # tries to import those modules, emitting fatal warnings under ``-W``. Mock
+    # them so the import succeeds without the fb sources being present.
+    autodoc_mock_imports += ["torchx.specs.fb", "torchx.workspace.fb"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,13 @@ if not FBCODE:
         "sphinxcontrib.katex",
     ]
 
-html_context = {"fbcode": FBCODE}
+html_context = {
+    "fbcode": FBCODE,
+    # Sphinx 7.2 removed the `style` template variable, but
+    # pytorch_sphinx_theme's layout.html still references it. Inject the
+    # value Sphinx < 7.2 derived from the theme's `stylesheet` setting.
+    "style": "css/theme.css",
+}
 
 # coverage options
 


### PR DESCRIPTION
## Why

**Docs Build** on main has been red since the `sphinx ~=5.0 → ~=8.1` bump (c26ea223, 2026-06-19). Two independent breakages, the second masked by the first:

1. `make doctest` (`-W`): 4 fatal warnings — `Failed to import torchx.specs.fb.overlay_mast` / `torchx.workspace.fb.{jetter,conda_env,sapling}_workspace`. The fb `automodule` blocks in `specs.rst`/`workspace.rst` are wrapped in the custom `.. fbcode::` directive (no-op outside fbcode), but `sphinx.ext.autosummary`'s pre-parse source scan text-matches the `.. automodule::` lines before any directive runs and tries to import them.
2. `make html`: `ThemeError: ... UndefinedError("'style' is undefined")` on every page — sphinx 7.2 removed the `style` template variable, but `pytorch_sphinx_theme`'s `layout.html` still references `{{ style }}`. CI never reached this step because doctest fails first.

## What

- Mock the fb parent packages via `autodoc_mock_imports` (gated `if not FBCODE:` so the internal build, where the real fb modules exist, is untouched).
- Inject `style` via `html_context` with the exact value sphinx <7.2 derived from the theme's `stylesheet` setting (`css/theme.css`). No-op on older sphinx.

## Test plan

Replicated the CI docbuild steps locally (`uv sync --frozen --extra dev` + `uv pip install -r docs/requirements.txt`, sphinx 8.2.3, python 3.12):

- `make doctest` → build succeeded, 102 doctests, 0 failures (was: 4 warnings treated as errors)
- `make linkcheck` → build succeeded
- `make html` → build succeeded (was: `ThemeError`)
- `make coverage` → build succeeded
- `lintrunner docs/source/conf.py` → clean