### PR TITLE
Handle flat reply-file schema when formatting replica status (#1331)

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -649,7 +649,12 @@ class AppStatus:
         app_status_dict = asdict(self)
         structured_error_msg = app_status_dict.pop("structured_error_msg")
         if structured_error_msg != NONE:
-            structured_error_msg_parsed = json.loads(structured_error_msg)
+            try:
+                structured_error_msg_parsed = json.loads(structured_error_msg)
+            except JSONDecodeError:
+                # reply-file content is job-authored and not always JSON;
+                # embed it verbatim rather than failing repr()
+                structured_error_msg_parsed = structured_error_msg
         else:
             structured_error_msg_parsed = NONE
         app_status_dict["structured_error_msg"] = structured_error_msg_parsed
@@ -692,15 +697,44 @@ class AppStatus:
                 error_data = json.loads(replica_status.structured_error_msg)
             except JSONDecodeError:
                 return replica_status.structured_error_msg
+            # Reply files carry one of two known schemas: the torchelastic
+            # error file nests the error under "message"
+            # ({"message": {"message": ..., "errorCode": ...,
+            #   "extraInfo": {"timestamp": ...}}}) while scheduler-written
+            # reply files are flat
+            # ({"message": "...", "errorCode": ..., "timestamp": ...}).
+            # The content is authored by the job or the scheduler, not by
+            # torchx, so render anything unrecognized verbatim instead of
+            # raising while formatting the status.
+            error = error_data.get("message") if isinstance(error_data, dict) else None
+            if isinstance(error, dict) and isinstance(error.get("message"), str):
+                msg = error["message"]
+                extra_info = error.get("extraInfo")
+                timestamp = (
+                    extra_info.get("timestamp")
+                    if isinstance(extra_info, dict)
+                    else None
+                )
+                exitcode = error.get("errorCode")
+            elif isinstance(error, str):
+                msg = error
+                timestamp = error_data.get("timestamp")
+                exitcode = error_data.get("errorCode")
+            else:
+                return replica_status.structured_error_msg
             error_message = self._format_error_message(
-                msg=error_data["message"]["message"], header="    error_msg: "
+                msg=msg, header="    error_msg: "
             )
-            timestamp = int(error_data["message"]["extraInfo"]["timestamp"])
-            exitcode = error_data["message"]["errorCode"]
+            timestamp_str = "<N/A>"
+            if timestamp is not None:
+                try:
+                    timestamp_str = str(datetime.fromtimestamp(int(timestamp)))
+                except (TypeError, ValueError, OverflowError, OSError):
+                    pass
             if not exitcode:
                 exitcode = "<N/A>"
             data = f"""{str(replica_status.state)} (exitcode: {exitcode})
-        timestamp: {datetime.fromtimestamp(timestamp)}
+        timestamp: {timestamp_str}
         hostname: {replica_status.hostname}
     {error_message}"""
         else:

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -307,6 +307,89 @@ Traceback (most recent call last):
         # Split and compare to aviod AssertionError.
         self.assertEqual(expected_message.split(), actual_message.split())
 
+    def _get_test_app_status_with_error_msg(self, error_msg: str) -> AppStatus:
+        replica = ReplicaStatus(
+            id=0,
+            state=AppState.FAILED,
+            role="worker",
+            hostname="localhost",
+            structured_error_msg=error_msg,
+        )
+        role_status = RoleStatus(role="worker", replicas=[replica])
+        return AppStatus(state=AppState.RUNNING, roles=[role_status])
+
+    def test_format_app_status_flat_error_schema(self) -> None:
+        # Flat reply-file schema (e.g. MAST's MastReplyFileMessage): "message"
+        # is a string and timestamp/errorCode live at the top level.
+        os.environ["TZ"] = "Europe/London"
+        time.tzset()
+
+        app_status = self._get_test_app_status_with_error_msg(
+            '{"message": "InjectedFailure: Injected failure exception",'
+            ' "timestamp": 1293182, "timestamp_us": 1293182000000,'
+            ' "errorService": "Mast", "errorCode": 1,'
+            ' "pyCallStack": "Traceback (most recent call last): ..."}'
+        )
+        actual_message = app_status.format()
+        expected_message = """AppStatus:
+    State: RUNNING
+    Num Restarts: 0
+    Roles:
+ *worker[0]:FAILED (exitcode: 1)
+        timestamp: 1970-01-16 00:13:02
+        hostname: localhost
+        error_msg: InjectedFailure: Injected failure exception
+    Msg:
+    Structured Error Msg: <NONE>
+    UI URL: None
+    """
+        self.assertEqual(expected_message.split(), actual_message.split())
+
+    def test_format_app_status_flat_error_schema_missing_fields(self) -> None:
+        app_status = self._get_test_app_status_with_error_msg(
+            '{"message": "InjectedFailure: Injected failure exception"}'
+        )
+        actual_message = app_status.format()
+        self.assertIn("FAILED (exitcode: <N/A>)", actual_message)
+        self.assertIn("timestamp: <N/A>", actual_message)
+        self.assertIn(
+            "error_msg: InjectedFailure: Injected failure exception", actual_message
+        )
+
+    def test_format_app_status_nested_error_schema_missing_fields(self) -> None:
+        app_status = self._get_test_app_status_with_error_msg(
+            '{"message":{"message":"test error"}}'
+        )
+        actual_message = app_status.format()
+        self.assertIn("FAILED (exitcode: <N/A>)", actual_message)
+        self.assertIn("timestamp: <N/A>", actual_message)
+        self.assertIn("error_msg: test error", actual_message)
+
+    def test_format_app_status_unrecognized_error_schema(self) -> None:
+        # Valid JSON that matches neither known reply-file schema renders
+        # verbatim instead of raising.
+        for error_msg in (
+            '["not", "a", "dict"]',
+            '{"error": "no message key"}',
+            '{"message": {"message": 5}}',
+            '{"message": null}',
+            '"just a quoted string"',
+        ):
+            with self.subTest(error_msg=error_msg):
+                app_status = self._get_test_app_status_with_error_msg(error_msg)
+                self.assertIn(error_msg, app_status.format())
+
+    def test_serialize_non_json_error(self) -> None:
+        status = AppStatus(
+            AppState.FAILED, structured_error_msg="worker terminated by SIGKILL"
+        )
+        self.assertIn("worker terminated by SIGKILL", repr(status))
+
+        with self.assertRaisesRegex(
+            AppStatusError, r"(?s)job did not succeed:.*FAILED.*"
+        ):
+            status.raise_for_status()
+
     def test_app_status_in_json(self) -> None:
         app_status = self._get_test_app_status()
         result = app_status.to_json()


### PR DESCRIPTION
Summary:

This diff makes `AppStatus._format_replica_status` tolerate the flat reply-file schema when rendering `torchx status` output. The formatter assumed every JSON `structured_error_msg` used the nested torchelastic error-file schema (`{"message": {"message": ..., "extraInfo": {"timestamp": ...}, "errorCode": ...}}`) and crashed with `TypeError: string indices must be integers` on flat scheduler-written reply messages (`{"message": "<str>", "timestamp": ..., "errorCode": ...}`); the fix in #889 (D56338530) covered only the non-JSON case. Scheduler-written reply files now commonly carry the flat schema, so `torchx status` crashes on any job that surfaces one for a failed replica attempt.

The formatter now recognizes both schemas, renders a missing timestamp/errorCode as `<N/A>`, and renders anything unrecognized verbatim (matching the existing non-JSON fallback) instead of raising. Rendering stays defensive in core rather than normalizing in each scheduler because reply-file content is job-authored bytes — the renderer must not crash on it regardless of what any scheduler forwards. `AppStatus.__repr__` gets the same guard for non-JSON app-level messages so `raise_for_status` raises `AppStatusError` rather than `JSONDecodeError`.

Reviewed By: suo

Differential Revision: D111764155


