### PR TITLE
Fix Docs Build failing when a commit changes no docs (#1333)

### DIFF
--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -102,6 +102,13 @@ redirect_url: "/torchx/main"
 REDIRECT
 
 git add .
+# A docs-neutral commit (e.g. a CI/dependency bump) produces no change to the
+# generated HTML, so there is nothing to commit. Exit cleanly instead of letting
+# `git commit` fail under `set -e` and turn the Docs Build workflow red.
+if git diff --cached --quiet; then
+    echo "No documentation changes to publish; nothing to commit."
+    exit 0
+fi
 git commit --quiet -m "[doc_push][$release_tag] built from $commit_id ($branch). Redirects: ${redirects[*]} -> $torchx_ver."
 
 if [ $dry_run -eq 1 ]; then


### PR DESCRIPTION
Summary:
## What

`docs/doc_push.sh` (run as `--dry-run` by the `docpush` job on every push to `main`) fails with a non-zero exit when a commit doesn't change the generated docs:

```
nothing to commit, working tree clean
##[error]Process completed with exit code 1.
```

After copying the freshly-built HTML into the gh-pages checkout, `git commit` finds nothing staged and exits 1; under `set -e` that fails the script and turns the **Docs Build** workflow red — even though the docs built fine.

This reproduces on any docs-neutral commit to `main` (e.g. the recent CI/dependency bumps: aws-actions, pyarrow, starlette).

## Fix

Guard the commit — if nothing is staged, log and `exit 0` instead of failing. No behavior change when there *are* doc updates.

## Test

- The build steps (`make html`, gh-pages checkout, copy) are unchanged; only the no-op commit case now exits cleanly.
- Verified the failing run: latest `main` Docs Build (`docpush`) reached `nothing to commit, working tree clean` then `exit code 1` immediately after a successful Sphinx build.


Differential Revision: D112885804

Pulled By: kiukchung


