### PR TITLE
(bugfix)[torchx][docs] Exclude nested fb/ doc dirs from OSS sphinx build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,8 +147,11 @@ language = "en"
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = []
 if not FBCODE:
-    # fb/ contains Meta-internal docs only available in the fbcode build.
-    exclude_patterns += ["fb/**"]
+    # fb/ dirs contain Meta-internal docs only available in the fbcode build.
+    # These reference `torchx.*.fb.*` modules that are stripped from the OSS
+    # export, so autodoc'ing them fails. Exclude both the top-level `fb/` tree
+    # and nested `<section>/fb/` trees (e.g. `schedulers/fb/`, `workspaces/fb/`).
+    exclude_patterns += ["fb/**", "**/fb/**"]
     # The ``.. fbcode::`` directive (docs/source/ext/fbcode.py) hides the
     # Meta-internal ``torchx.specs.fb`` / ``torchx.workspace.fb`` automodule
     # blocks from the OSS build, but autosummary's pre-parse source scan still


### PR DESCRIPTION
Summary:
Fix the OSS `Docs Build` CI failure where `make doctest`/`make html` fail
under `-W` (SPHINXOPTS) because sphinx autodoc tries to import
Meta-internal `torchx.*.fb.*` modules that are stripped from the OSS export.

**Root cause:** `conf.py` excluded only the top-level `fb/` doc tree
(`exclude_patterns += ["fb/**"]`), but the fb API-reference pages also live
in nested `<section>/fb/` dirs (`schedulers/fb/`, `workspaces/fb/`,
`components/fb/`, `pipelines/fb/`). Those standalone `.rst` files carry bare
`.. automodule:: torchx.<x>.fb.<y>` directives; on the OSS runner (cwd has no
`fbcode`) they are read and autodoc'd, and the fb modules don't exist there:

  WARNING: Failed to import torchx.workspace.fb.jetter_workspace  (etc.)

Under `-W` these warnings are promoted to errors and the build exits non-zero.

**Fix:** extend the OSS-only exclusion to nested fb dirs
(`exclude_patterns += ["fb/**", "**/fb/**"]`). This drops every fb `.rst`
before it is read, so no fb import is attempted. The previous stop-gap of
mocking `torchx.workspace.fb`/`torchx.specs.fb` via `autodoc_mock_imports`
is now redundant (and itself produced `A mocked object is detected` /
`duplicate object description` warnings), so it is removed.

The change is inside `if not FBCODE:`, so the internal staticdocs build
(`TORCHX_DOCS_FBCODE=1`) is unaffected and still renders the fb docs.

Differential Revision: D110915534
