### PR TITLE
ci: free runner disk before docker live tests to fix "no space left on device" flake

### DIFF
--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Free disk space (docker tests load multi-GB images)
         if: runner.os == 'Linux'
         run: |
+          df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
           sudo docker image prune --all --force || true
           df -h /

--- a/.github/workflows/python-unittests.yaml
+++ b/.github/workflows/python-unittests.yaml
@@ -23,6 +23,12 @@ jobs:
     steps:
       - name: Checkout TorchX
         uses: actions/checkout@v7
+      - name: Free disk space (docker tests load multi-GB images)
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force || true
+          df -h /
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
The `unittest (3.X, linux.24_04.4x)` legs intermittently fail in `DockerSchedulerLiveTest::test_docker_submit_dist` with:

```
docker.errors.BuildError: ... write .../libtorch_cuda.so: no space left on device
```

while docker-loading the multi-GB pytorch base image. 4 occurrences this week alone (e.g. run 30042471479 / job 89325491832). The macOS leg is unaffected since docker live tests skip there.

Fix: add a Linux-only "Free disk space" step before any docker usage that removes preinstalled runner bloat (dotnet, android SDK, ghc, CodeQL) and prunes stale docker images, then prints `df -h /` so freed space is visible in the CI log.
