### PR TITLE
(bugfix)[torchx][runner/test] Fix `SchedulerFactory` lambda param name mismatches in `api_test`

### DIFF
--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -230,8 +230,9 @@ class RunnerTest(TestWithTmpDir):
         }
         with Runner(
             name=SESSION_NAME,
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: scheduler_mock},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: scheduler_mock
+            },
         ) as runner:
             role = Role(
                 name="touch",
@@ -258,8 +259,9 @@ class RunnerTest(TestWithTmpDir):
         scheduler_mock = MagicMock()
         with Runner(
             name=SESSION_NAME,
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: scheduler_mock},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: scheduler_mock
+            },
         ) as runner:
             role1 = Role(
                 name="echo1",
@@ -288,8 +290,9 @@ class RunnerTest(TestWithTmpDir):
         expected_parent_run_id = "123"
         with Runner(
             name=SESSION_NAME,
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: scheduler_mock},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: scheduler_mock
+            },
         ) as runner:
             role1 = Role(
                 name="echo1",
@@ -328,8 +331,9 @@ class RunnerTest(TestWithTmpDir):
 
         with Runner(
             name=SESSION_NAME,
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: scheduler_mock},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: scheduler_mock
+            },
         ) as runner:
             role1 = Role(
                 name="echo1",
@@ -377,8 +381,9 @@ class RunnerTest(TestWithTmpDir):
 
         with Runner(
             name=SESSION_NAME,
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: scheduler_mock},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: scheduler_mock
+            },
         ) as runner:
             role1 = Role(
                 name="echo1",
@@ -461,12 +466,13 @@ class RunnerTest(TestWithTmpDir):
 
         with Runner(
             name=SESSION_NAME,
-            # pyre-fixme[6]: scheduler factory type
             scheduler_factories={
-                "no-build-img": lambda name, **kwargs: TestScheduler(
+                "no-build-img": lambda session_name, **kwargs: TestScheduler(
                     build_new_img=False
                 ),
-                "builds-img": lambda name, **kwargs: TestScheduler(build_new_img=True),
+                "builds-img": lambda session_name, **kwargs: TestScheduler(
+                    build_new_img=True
+                ),
             },
         ) as runner:
             app = AppDef(
@@ -585,8 +591,9 @@ class RunnerTest(TestWithTmpDir):
 
         with Runner(
             name="test_ui_url_session",
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: mock_scheduler},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: mock_scheduler
+            },
         ) as runner:
             role = Role(
                 "ignored",
@@ -610,8 +617,9 @@ class RunnerTest(TestWithTmpDir):
 
         with Runner(
             name="test_structured_msg",
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: mock_scheduler},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: mock_scheduler
+            },
         ) as runner:
             role = Role(
                 "ignored",
@@ -662,8 +670,9 @@ class RunnerTest(TestWithTmpDir):
 
         with Runner(
             name=SESSION_NAME,
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: scheduler_mock},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: scheduler_mock
+            },
         ) as runner:
             role_name = "trainer"
             replica_id = 2
@@ -707,8 +716,9 @@ class RunnerTest(TestWithTmpDir):
         ]
         with Runner(
             name=SESSION_NAME,
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"kubernetes": lambda name, **kwargs: scheduler_mock},
+            scheduler_factories={
+                "kubernetes": lambda session_name, **kwargs: scheduler_mock
+            },
         ) as runner:
             apps = runner.list("kubernetes")
             self.assertEqual(apps, apps_expected)
@@ -720,13 +730,11 @@ class RunnerTest(TestWithTmpDir):
         json_dumps_mock.return_value = "{}"
         local_sched_mock = MagicMock()
         scheduler_factories = {
-            "local_dir": lambda name, **kwargs: local_dir_sched_mock,
-            "local": lambda name, **kwargs: local_sched_mock,
+            "local_dir": lambda session_name, **kwargs: local_dir_sched_mock,
+            "local": lambda session_name, **kwargs: local_sched_mock,
         }
         with Runner(
-            # pyrefly: ignore [bad-argument-type]
             name="test_session",
-            # pyrefly: ignore [bad-argument-type]
             scheduler_factories=scheduler_factories,
         ) as runner:
             role = Role(
@@ -761,10 +769,9 @@ class RunnerTest(TestWithTmpDir):
     def test_run_from_file_no_function_found(self, _) -> None:
         local_sched_mock = MagicMock()
         schedulers = {
-            "local_dir": lambda name, **kwargs: local_sched_mock,
-            "local": lambda name, **kwargs: local_sched_mock,
+            "local_dir": lambda session_name, **kwargs: local_sched_mock,
+            "local": lambda session_name, **kwargs: local_sched_mock,
         }
-        # pyrefly: ignore [bad-argument-type]
         with Runner(name="test_session", scheduler_factories=schedulers) as runner:
             component_path = get_full_path("distributed.py")
             with patch.object(runner, "run"):
@@ -857,8 +864,9 @@ class RunnerTest(TestWithTmpDir):
 
         with Runner(
             name=SESSION_NAME,
-            # pyrefly: ignore [bad-argument-type]
-            scheduler_factories={"local_dir": lambda name, **kwargs: scheduler_mock},
+            scheduler_factories={
+                "local_dir": lambda session_name, **kwargs: scheduler_mock
+            },
         ) as runner:
             self.assertDictEqual(
                 {


### PR DESCRIPTION
Summary:
Fixes `fbcode//torchx/runner/test:api_test-library-type-checking` red at trunk (issue 231923579, tasks T282791799 / T282764725 / T282763642).

The `SchedulerFactory` protocol declares `__call__(self, session_name: str, **kwargs: object) -> Scheduler` (`torchx/schedulers/__init__.py`), but 12 sites in `api_test.py` passed `lambda name, **kwargs: ...` as factories — a positional-parameter-name mismatch (`got name, want session_name`). Each site carried a `# pyrefly: ignore [bad-argument-type]` (added in D109083969); a pyrefly checker-version change on 07-29 (D113791492, which broke 500+ tests fleet-wide) re-surfaced the errors past the pinned ignore code, turning the target red.

This diff fixes the root cause instead of re-pinning suppressions:
* Renames the lambda parameter `name` -> `session_name` at every `scheduler_factories` lambda site, matching the protocol.
* Deletes the 13 now-stale `# pyrefly: ignore [bad-argument-type]` comments (they no longer suppressed anything and two were misplaced on the `name=` kwarg line).
* Same fix for `test_dryrun_with_workspace`, whose factories were masked by a `# pyre-fixme[6]` of the same class — renamed the lambdas and removed the suppression.

The three `lambda name` occurrences inside `patch(..., return_value={...})` mocks are untyped and don't hit the protocol; left as-is. The four remaining `pyrefly: ignore` comments on `TestScheduler` (`bad-return`/`bad-override`) suppress unrelated, still-active errors and are untouched.

Note: `torchx/runner/test` is OSS-synced (exports to meta-pytorch/torchx), so expect `github-export-checks`/`export-diff-to-pull-request` signals.

Differential Revision: D114263625
